### PR TITLE
feat: publish files in dist-* only

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -36,5 +36,6 @@
     "<4.0": {
       "dist-types/*": ["dist-types/ts3.4/*"]
     }
-  }
+  },
+  "files": ["dist-*"]
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2873

*Description of changes:*
Publishes files only from `dist-*` folders which reduces npm publish size

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
