### PR TITLE
Add ability to ts-ignore a default import

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -166,6 +166,19 @@ public final class TypeScriptWriter extends CodeWriter {
     }
 
     /**
+     * default import from a module, annotated with @ts-ignore.
+     *
+     * @param name Name of default import.
+     * @param from Module to default import from.
+     * @param reason The reason for ignoring the import
+     * @return Returns the writer.
+     */
+    public TypeScriptWriter addIgnoredDefaultImport(String name, String from, String reason) {
+        imports.addIgnoredDefaultImport(name, from, reason);
+        return this;
+    }
+
+    /**
      * Imports a type using an alias from a module only if necessary.
      *
      * @param name Type to import.

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ImportDeclarationsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ImportDeclarationsTest.java
@@ -109,6 +109,16 @@ public class ImportDeclarationsTest {
     }
 
     @Test
+    public void canImportDefaultImportWithIgnore() {
+        ImportDeclarations declarations = new ImportDeclarations("/foo/bar");
+        declarations.addIgnoredDefaultImport("foo", "@types/foo", "I want to");
+        String result = declarations.toString();
+
+        assertThat(result, containsString("// @ts-ignore: I want to\nimport foo from \"@types/foo\"; // eslint-disable-line"));
+    }
+
+
+    @Test
     public void canImportDefaultImportWithNamedImport() {
         ImportDeclarations declarations = new ImportDeclarations("/foo/bar");
         declarations.addDefaultImport("foo", "@types/foo");


### PR DESCRIPTION
*Description of changes:*
When importing package.json outside srcDir, TypeScript will fail checks even
though compiled JS will work fine. Annotating the import with @ts-ignore,
and using eslint-disable-line to prevent import reordering from separating
the ts-ignore comment from the line being ignored, allows us to suppress these
errors without reorganizing the generated module and without postprocessing
the generator output.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
