### PR TITLE
Remove inlineSourceMap and inlineSources from SSDK libs

### DIFF
--- a/smithy-typescript-ssdk-libs/tsconfig.json
+++ b/smithy-typescript-ssdk-libs/tsconfig.json
@@ -21,8 +21,6 @@
     "declaration": true,
     "importHelpers": true,
     "noEmitHelpers": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
     "paths": {
       "@aws-smithy/server-common": ["server-common/src"],
       "@aws-smithy/server-apigateway": ["server-apigateway/src"]


### PR DESCRIPTION
*Description of changes:*
Following the JS SDK's lead, removing these to slim library size a bit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
