### PR TITLE
fix: emitDeclarationOnly in tsconfig.types.json

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2893

*Description of changes:*
Adds emitDeclarationOnly in tsconfig.types.json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
