### PR TITLE
feat: rename client-documentation-generator package

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -40,7 +40,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
-    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", true),
+    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/service-client-documentation-generator", true),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", true),
     AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", true),
     INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", true),

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -32,7 +32,7 @@
     "mode": "file",
     "out": "docs",
     "theme": "minimal",
-    "plugin": ["@aws-sdk/client-documentation-generator"]
+    "plugin": ["@aws-sdk/service-client-documentation-generator"]
   },
   "exclude": ["test/**/*"]
 }


### PR DESCRIPTION
Related to: https://github.com/aws/aws-sdk-js-v3/pull/2916

*Description of changes:*
This change complies the conventions that only client packages starts with client-*. This makes
it easer to run certain commands to only clients or only dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
