### PR TITLE
chore: pin aws crypto helpers dependency to 2.0.0

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -52,8 +52,8 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", true),
     MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", true),
 
-    AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^1.1.0", true),
-    AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "^1.1.0", true),
+    AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "2.0.0", true),
+    AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "2.0.0", true),
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", true),
 
     AWS_SDK_URL_PARSER("dependencies", "@aws-sdk/url-parser", true),


### PR DESCRIPTION
*Issue #, if available:*
Associated with https://github.com/aws/aws-sdk-js-v3/pull/2940

*Description of changes:*
Bump the aws crypto packages version. See associated issue for more information.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
