### PR TITLE
feat: omit 'undefined' when generating SSDK and @required trait is used

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -68,7 +68,7 @@ final class StructuredMemberWriter {
         this.members = new LinkedHashSet<>(members);
     }
 
-    void writeMembers(TypeScriptWriter writer, Shape shape) {
+    void writeMembers(TypeScriptWriter writer, Shape shape, Boolean generateServerSdk) {
         int position = -1;
         for (MemberShape member : members) {
             if (skipMembers.contains(member.getMemberName())) {
@@ -79,7 +79,7 @@ final class StructuredMemberWriter {
             boolean wroteDocs = !noDocs && writer.writeMemberDocs(model, member);
             String memberName = getSanitizedMemberName(member);
             String optionalSuffix = shape.isUnionShape() || !isRequiredMember(member) ? "?" : "";
-            String typeSuffix = isRequiredMember(member) ? " | undefined" : "";
+            String typeSuffix = isRequiredMember(member) && !generateServerSdk ? " | undefined" : "";
             writer.write("${L}${L}${L}: ${T}${L};", memberPrefix, memberName, optionalSuffix,
                          symbolProvider.toSymbol(member), typeSuffix);
 


### PR DESCRIPTION
*Issue #, if available:*

Addresses issues raised in #503 for SSDK code

*Description of changes:*

Currently when the client SDK is generated, @required shapes have their
types rendered with ' | undefined'. This allows removing @required as
a non-breaking change for client SDK users.

However, the server SDK (SSDK) has no need for backwards compatibility,
it can be updated as the service evolves. When generating SSDK types
the project does not need to include ' | undefined' for required types.

This update changes the structure member writer when the SSDK is 
generated to not include ' | undefined" when it is a required member.
Client SDK remains unaffected.

Server SDK does not appear to have any tests. Test frameworks do
not seem to support SSDK generation at this moment. only implementation
code is included.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
