### PR TITLE
fix: only write default input body if operation has payload bindings

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -935,7 +935,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
     /**
      * Given a context and operation, should a default input body be written. By default no body will be written
-     * if there are no members bound to the input.
+     * if there are no members bound to the input in the payload.
      *
      * @param context The generation context.
      * @param operation The operation whose input is being serialized.
@@ -943,7 +943,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * @return True if a default body should be generated.
      */
     protected boolean shouldWriteDefaultInputBody(GenerationContext context, OperationShape operation) {
-        return HttpBindingIndex.of(context.getModel()).getRequestBindings(operation).isEmpty();
+        return HttpBindingIndex.of(context.getModel()).getRequestBindings(operation, Location.PAYLOAD).size() > 0;
     }
 
     /**


### PR DESCRIPTION
fixes #552

Before this change, when an operation has no input defined, a GET
operation would include a 'content-type' header and an empty body. This
will cause servers to respond with a 415 error, as the server is not
expected content in the body of the request.

The code to determine if a default input body should be written had
faulty logic. It returned true to write an empty body if there are
no request bindings. Instead, a default body should be written if there
are request bindings in the payload.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
