### PR TITLE
Publish on merge

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -1,7 +1,11 @@
 name: release-npm-packages
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch: # on button click
+
 
 jobs:
   release:


### PR DESCRIPTION
This PR updates the NPM release workflow to be run on each merge to main.

When changes to the `/packages` directory are merged, this will result in changesets being applied for the `@smithy` packages, version bumps committed and new package versions published to NPM.

If changes are merged which do not update any of the packages in the `/packages` directory, the workflow will still run, but it will not apply any version updates and will not attempt to publish any packages to NPM.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
