### PR TITLE
feat(experimentalIdentityAndAuth): make `experimentalIdentityAndAuth` default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ under development:
 
 Experimental Feature | Flag                          | Description
 ---------------------|-------------------------------|------------
-Identity & Auth      | `experimentalIdentityAndAuth` | Standardize identity and auth integrations to match the Smithy specification (see [Authentication Traits](https://smithy.io/2.0/spec/authentication-traits.html)). Newer capabilities include support for multiple auth schemes, `@optionalAuth`, and standardized identity interfaces for authentication schemes both in code generation and TypeScript packages. In `smithy-typescript`, `@httpApiKeyAuth` will be updated to use the new standardized interfaces. In `aws-sdk-js-v3` (`smithy-typescript`'s largest customer), this will affect `@aws.auth#sigv4` and `@httpBearerAuth` implementations, but is planned to be completely backwards-compatible.
+Currently None | N/A | N/A
 
 ## Reporting Bugs/Feature Requests
 

--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -26,7 +26,7 @@ service Weather {
         GetCurrentTime
         // util-stream.integ.spec.ts
         Invoke
-        // experimentalIdentityAndAuth
+        // Identity and Auth
         OnlyHttpApiKeyAuth
         OnlyHttpApiKeyAuthOptional
         OnlyHttpBearerAuth

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -24,21 +24,6 @@
                 }
             }
         },
-        "client-experimental-identity-and-auth": {
-            "plugins": {
-                "typescript-codegen": {
-                    "service": "example.weather#Weather",
-                    "targetNamespace": "Weather",
-                    "package": "weather",
-                    "packageVersion": "0.0.1",
-                    "packageJson": {
-                        "license": "Apache-2.0",
-                        "private": true
-                    },
-                    "experimentalIdentityAndAuth": true
-                }
-            }
-        },
         "control-experimental-identity-and-auth": {
             "plugins": {
                 "typescript-codegen": {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
@@ -13,8 +13,6 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 /**
  * Definition of a Config field.
  *
- * Currently used to populate the ClientDefaults interface in `experimentalIdentityAndAuth`.
- *
  * @param name name of the config field
  * @param type whether the config field is main or auxiliary
  * @param inputType writer for the input type of the config field

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -236,9 +236,7 @@ final class DirectedTypeScriptCodegen
         delegator.useShapeWriter(service, writer -> new ServiceBareBonesClientGenerator(
                 settings, model, symbolProvider, writer, integrations, runtimePlugins, applicationProtocol).run());
 
-        if (directive.settings().getExperimentalIdentityAndAuth()) {
-            // feat(experimentalIdentityAndAuth): allow configuring custom HttpAuthSchemeProviderGenerator
-            LOGGER.fine("experimentalIdentityAndAuth: Generating auth scheme resolver");
+        if (applicationProtocol.isHttpProtocol()) {
             new HttpAuthSchemeProviderGenerator(
                 delegator,
                 settings,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -182,10 +182,10 @@ final class RuntimeConfigGenerator {
                 for (TypeScriptIntegration integration : integrations) {
                     configs.putAll(integration.getRuntimeConfigWriters(settings, model, symbolProvider, target));
                 }
-                // feat(experimentalIdentityAndAuth): add config writers for httpAuthScheme and httpAuthSchemes
+                // TODO(experimentalIdentityAndAuth): add config writers for httpAuthScheme and httpAuthSchemes
                 // Needs a separate integration point since not all the information is accessible in
                 // {@link TypeScriptIntegration#getRuntimeConfigWriters()}
-                if (applicationProtocol.isHttpProtocol() && settings.getExperimentalIdentityAndAuth()) {
+                if (applicationProtocol.isHttpProtocol()) {
                     generateHttpAuthSchemeConfig(configs, writer, target);
                 }
                 int indentation = target.equals(LanguageTarget.SHARED) ? 1 : 2;
@@ -209,7 +209,6 @@ final class RuntimeConfigGenerator {
     ) {
         SupportedHttpAuthSchemesIndex authIndex = new SupportedHttpAuthSchemesIndex(integrations);
 
-        // feat(experimentalIdentityAndAuth): write the default imported HttpAuthSchemeProvider
         if (target.equals(LanguageTarget.SHARED)) {
             configs.put("httpAuthSchemeProvider", w -> {
                 w.write("$T", authIndex.getDefaultHttpAuthSchemeProvider()
@@ -220,7 +219,6 @@ final class RuntimeConfigGenerator {
             });
         }
 
-        // feat(experimentalIdentityAndAuth): gather HttpAuthSchemes to generate
         ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, HttpAuthScheme> allEffectiveHttpAuthSchemes =
             AuthUtils.getAllEffectiveNoAuthAwareAuthSchemes(service, serviceIndex, authIndex);
@@ -246,7 +244,6 @@ final class RuntimeConfigGenerator {
             return;
         }
 
-        // feat(experimentalIdentityAndAuth): write the default httpAuthSchemes
         configs.put("httpAuthSchemes", w -> {
             w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
             w.addImport("IdentityProviderConfig", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -119,7 +119,7 @@ public enum TypeScriptDependency implements Dependency {
     // Conditionally added when @aws.auth#sigv4 is used
     SIGNATURE_V4("dependencies", "@smithy/signature-v4", false),
 
-    // feat(experimentalIdentityAndAuth): Conditionally added dependencies for `experimentalIdentityAndAuth`.
+    // TODO(experimentalIdentityAndAuth): Conditionally added dependencies for `experimentalIdentityAndAuth`.
     // This package should never have a major version, and should only use minor and patch versions in development.
     EXPERIMENTAL_IDENTITY_AND_AUTH("dependencies", "@smithy/experimental-identity-and-auth", false),
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -58,7 +58,6 @@ public final class TypeScriptSettings {
     private static final String PRIVATE = "private";
     private static final String PACKAGE_MANAGER = "packageManager";
     private static final String CREATE_DEFAULT_README = "createDefaultReadme";
-    private static final String EXPERIMENTAL_IDENTITY_AND_AUTH = "experimentalIdentityAndAuth";
 
     private String packageName;
     private String packageDescription = "";
@@ -75,7 +74,6 @@ public final class TypeScriptSettings {
         RequiredMemberMode.NULLABLE;
     private PackageManager packageManager = PackageManager.YARN;
     private boolean createDefaultReadme = false;
-    private boolean experimentalIdentityAndAuth = false;
 
     @Deprecated
     public static TypeScriptSettings from(Model model, ObjectNode config) {
@@ -109,8 +107,6 @@ public final class TypeScriptSettings {
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
         settings.setCreateDefaultReadme(
                 config.getBooleanMember(CREATE_DEFAULT_README).map(BooleanNode::getValue).orElse(false));
-        settings.setExperimentalIdentityAndAuth(
-                config.getBooleanMemberOrDefault(EXPERIMENTAL_IDENTITY_AND_AUTH, false));
         settings.setPackageManager(
                 config.getStringMember(PACKAGE_MANAGER)
                     .map(s -> PackageManager.fromString(s.getValue()))
@@ -357,31 +353,6 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * Returns whether to use experimental identity and auth.
-     *
-     * @return if experimental identity and auth should used. Default: false
-     */
-    public boolean getExperimentalIdentityAndAuth() {
-        return experimentalIdentityAndAuth;
-    }
-
-    /**
-     * Sets whether experimental identity and auth should be used.
-     *
-     * @param experimentalIdentityAndAuth whether experimental identity and auth should be used.
-     */
-    public void setExperimentalIdentityAndAuth(boolean experimentalIdentityAndAuth) {
-        if (experimentalIdentityAndAuth) {
-            LOGGER.warning("""
-                Experimental identity and auth is in development, and is subject to \
-                breaking changes. Behavior may NOT have the same feature parity as \
-                non-experimental behavior. This setting is also subject to removal \
-                when the feature is completed.""");
-        }
-        this.experimentalIdentityAndAuth = experimentalIdentityAndAuth;
-    }
-
-    /**
      * Gets the corresponding {@link ServiceShape} from a model.
      *
      * @param model Model to search for the service shape by ID.
@@ -469,7 +440,7 @@ public final class TypeScriptSettings {
         CLIENT(SymbolVisitor::new,
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
                               SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, REQUIRED_MEMBER_MODE,
-                              CREATE_DEFAULT_README, EXPERIMENTAL_IDENTITY_AND_AUTH)),
+                              CREATE_DEFAULT_README)),
         SSDK((m, s) -> new ServerSymbolVisitor(m, new SymbolVisitor(m, s)),
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
                               SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, REQUIRED_MEMBER_MODE,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
- * feat(experimentalIdentityAndAuth): Defines an HttpAuthScheme used in code generation.
+ * Defines an HttpAuthScheme used in code generation.
  *
  * HttpAuthScheme defines everything needed to generate an HttpAuthSchemeProvider,
  * HttpAuthOptions, and registered HttpAuthSchemes in the IdentityProviderConfiguration.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeParameter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeParameter.java
@@ -14,8 +14,6 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 /**
  * Definition of an HttpAuthSchemeParameter.
  *
- * Currently this is used to generate the the HttpAuthSchemeParameters interface in `experimentalIdentityAndAuth`.
- *
  * @param name name of the auth scheme parameter
  * @param type writer for the type of the auth scheme parameter
  * @param source writer for the value of the auth scheme parameter, typically from {@code context} or {@code config}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -29,7 +29,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
- * feat(experimentalIdentityAndAuth): Generator for {@code HttpAuthSchemeProvider} and corresponding interfaces.
+ * Generator for {@code HttpAuthSchemeProvider} and corresponding interfaces.
  *
  * Code generated includes:
  *

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
@@ -14,7 +14,6 @@ import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.ConfigField;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
@@ -22,8 +21,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Support for @httpApiKeyAuth.
- *
- * This is the experimental behavior for `experimentalIdentityAndAuth`.
  */
 @SmithyInternalApi
 public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
@@ -32,14 +29,6 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
         w.addImport("HttpApiKeyAuthSigner", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
         w.write("new HttpApiKeyAuthSigner()");
     };
-
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return settings.getExperimentalIdentityAndAuth();
-    }
 
     @Override
     public Optional<HttpAuthScheme> getHttpAuthScheme() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
@@ -34,14 +34,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptIntegration {
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return settings.getExperimentalIdentityAndAuth();
-    }
-
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return List.of(
@@ -78,7 +70,7 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
         writer.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
         writer.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
         writer.writeDocs("""
-            experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides \
+            Configuration of HttpAuthSchemes for a client which provides \
             default identity providers and signers per auth scheme.
             @internal""");
         writer.write("httpAuthSchemes?: HttpAuthScheme[];\n");
@@ -87,7 +79,7 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
             + "HttpAuthSchemeProvider";
         writer.addImport(httpAuthSchemeProviderName, null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
         writer.writeDocs("""
-            experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which \
+            Configuration of an HttpAuthSchemeProvider for a client which \
             resolves which HttpAuthScheme to use.
             @internal""");
         writer.write("httpAuthSchemeProvider?: $L;\n", httpAuthSchemeProviderName);
@@ -172,7 +164,7 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
                     w.write("readonly $L?: $C;", configField.name(), configField.resolvedType());
                 }
                 w.writeDocs("""
-                    experimentalIdentityAndAuth: provides parameters for HttpAuthSchemeProvider.
+                    provides parameters for HttpAuthSchemeProvider.
                     @internal""");
                 w.write("readonly httpAuthSchemeParametersProvider: $LHttpAuthSchemeParametersProvider;",
                     service);
@@ -180,7 +172,7 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
                 w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
                 w.addImport("IdentityProviderConfig", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
                 w.writeDocs("""
-                    experimentalIdentityAndAuth: abstraction around identity configuration fields
+                    abstraction around identity configuration fields
                     @internal""");
                 w.write("readonly identityProviderConfig: IdentityProviderConfig;");
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
@@ -13,15 +13,12 @@ import software.amazon.smithy.typescript.codegen.ConfigField;
 import software.amazon.smithy.typescript.codegen.ConfigField.Type;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Support for @httpBearerAuth.
- *
- * This is the experimental behavior for `experimentalIdentityAndAuth`.
  */
 @SmithyInternalApi
 public final class AddHttpBearerAuthPlugin implements HttpAuthTypeScriptIntegration {
@@ -30,14 +27,6 @@ public final class AddHttpBearerAuthPlugin implements HttpAuthTypeScriptIntegrat
         w.addImport("HttpBearerAuthSigner", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
         w.write("new HttpBearerAuthSigner()");
     };
-
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return settings.getExperimentalIdentityAndAuth();
-    }
 
     @Override
     public Optional<HttpAuthScheme> getHttpAuthScheme() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpSigningMiddleware.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpSigningMiddleware.java
@@ -9,26 +9,15 @@ import static software.amazon.smithy.typescript.codegen.integration.RuntimeClien
 
 import java.util.List;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Add middleware for {@code httpSigningMiddleware}.
- *
- * This is the experimental behavior for `experimentalIdentityAndAuth`.
  */
 @SmithyInternalApi
 public class AddHttpSigningMiddleware implements TypeScriptIntegration {
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return settings.getExperimentalIdentityAndAuth();
-    }
-
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return List.of(RuntimeClientPlugin.builder()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddNoAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddNoAuthPlugin.java
@@ -11,7 +11,6 @@ import software.amazon.smithy.model.traits.synthetic.NoAuthTrait;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -28,14 +27,6 @@ public final class AddNoAuthPlugin implements HttpAuthTypeScriptIntegration {
         w.addImport("NoAuthSigner", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
         w.write("new NoAuthSigner()");
     };
-
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return settings.getExperimentalIdentityAndAuth();
-    }
 
     @Override
     public Optional<HttpAuthScheme> getHttpAuthScheme() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
@@ -12,7 +12,6 @@ import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.ConfigField;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
@@ -21,8 +20,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Support for generic @aws.auth#sigv4.
- *
- * This is the experimental behavior for `experimentalIdentityAndAuth`.
  */
 @SmithyInternalApi
 public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
@@ -31,14 +28,6 @@ public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
         w.addImport("SigV4Signer", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
         w.write("new SigV4Signer()");
     };
-
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return settings.getExperimentalIdentityAndAuth();
-    }
 
     @Override
     public Optional<HttpAuthScheme> getHttpAuthScheme() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthExtensionConfigurationInterface.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthExtensionConfigurationInterface.java
@@ -13,8 +13,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Adds the corresponding interface and functions for {@code HttpAuthExtensionConfiguration}.
- *
- * This is experimental for `experimentalIdentityAndAuth`.
  */
 @SmithyInternalApi
 public class HttpAuthExtensionConfigurationInterface implements ExtensionConfigurationInterface {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
@@ -15,7 +15,6 @@ import software.amazon.smithy.typescript.codegen.ConfigField;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
 import software.amazon.smithy.typescript.codegen.TypeScriptDelegator;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
@@ -26,20 +25,9 @@ import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Adds {@link HttpAuthExtensionConfigurationInterface} to a client.
- *
- * This is the experimental behavior for `experimentalIdentityAndAuth`.
  */
 @SmithyInternalApi
 public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegration {
-
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return settings.getExperimentalIdentityAndAuth();
-    }
-
     @Override
     public List<ExtensionConfigurationInterface> getExtensionConfigurationInterfaces() {
         return List.of(new HttpAuthExtensionConfigurationInterface());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
@@ -29,21 +29,12 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Add config and middleware to support a service with the @httpApiKeyAuth trait.
- *
- * This is the existing control behavior for `experimentalIdentityAndAuth`.
  */
+@Deprecated
 @SmithyInternalApi
 public final class AddHttpApiKeyAuthPlugin implements TypeScriptIntegration {
 
     public static final String INTEGRATION_NAME = "HttpApiKeyAuth";
-
-    /**
-     * Integration should only be used if `experimentalIdentityAndAuth` flag is false.
-     */
-    @Override
-    public boolean matchesSettings(TypeScriptSettings settings) {
-        return !settings.getExperimentalIdentityAndAuth();
-    }
 
     /**
      * Plug into code generation for the client.

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -9,7 +9,6 @@ software.amazon.smithy.typescript.codegen.auth.http.integration.AddNoAuthPlugin
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpBearerAuthPlugin
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddSigV4AuthPlugin
-software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddBaseServiceExceptionClass
 software.amazon.smithy.typescript.codegen.integration.AddSdkStreamMixinDependency
 software.amazon.smithy.typescript.codegen.integration.DefaultReadmeGenerator

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPluginTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
@@ -28,12 +29,15 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
+@Deprecated
 public class AddHttpApiKeyAuthPluginTest {
+    @Disabled("software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin is considered deprecated")
     @Test
     public void httpApiKeyAuthClientOnService() {
         testInjects("http-api-key-auth-trait.smithy", ", { scheme: 'ApiKey', in: 'header', name: 'Authorization'}");
     }
 
+    @Disabled("software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin is considered deprecated")
     @Test
     public void httpApiKeyAuthClientOnOperation() {
         testInjects("http-api-key-auth-trait-on-operation.smithy",
@@ -42,6 +46,7 @@ public class AddHttpApiKeyAuthPluginTest {
 
     // This should be identical to the httpApiKeyAuthClient test except for the parameters provided
     // to the middleware.
+    @Disabled("software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin is considered deprecated")
     @Test
     public void httpApiKeyAuthClientNoScheme() {
         testInjects("http-api-key-auth-trait-no-scheme.smithy", ", { in: 'header', name: 'Authorization'}");


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Make `experimentalIdentityAndAuth` default, including deprecating the original `AddHttpApiKeyAuthPlugin`.

TODO:

- [ ] HttpAuthTypeScriptIntegration
- [ ] Remove hack for Sigv4a support in AuthUtils
- [ ] Better RuntimeConfigGenerator TypeScriptIntegration method
- [ ] EXPERIMENTAL_IDENTITY_AND_AUTH split

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
