### PR TITLE
Cast client constructor optional configuration type

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -348,8 +348,8 @@ final class ServiceBareBonesClientGenerator implements Runnable {
             writer.pushState(CLIENT_CONSTRUCTOR_SECTION);
 
             int configVariable = 0;
-            writer.write("let $L = __getRuntimeConfig(configuration || {});",
-                    generateConfigVariable(configVariable));
+            writer.write("let $L = __getRuntimeConfig(configuration || {} as $L);",
+                    generateConfigVariable(configVariable), configType);
 
             if (service.hasTrait(EndpointRuleSetTrait.class)) {
                 configVariable++;


### PR DESCRIPTION
*Issue #, if available:*

VS Code complains about this in the generic clients, draft PR in case this is actually needed.

```log
Argument of type 'HttpApiKeyAuthServiceClientConfig | {}' is not assignable to parameter of type 'HttpApiKeyAuthServiceClientConfig'.
  Type '{}' is not assignable to type 'HttpApiKeyAuthServiceClientConfigType'.
    Property 'endpoint' is missing in type '{}' but required in type 'CustomEndpointsInputConfig'.
```

*Description of changes:*

Cast client constructor optional configuration type.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
