### PR TITLE
feat(experimentalIdentityAndAuth): add generic identity and auth integration tests

### DIFF
--- a/.changeset/empty-kings-ring.md
+++ b/.changeset/empty-kings-ring.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add identity and auth generic coverage integration tests.

--- a/.changeset/olive-cobras-look.md
+++ b/.changeset/olive-cobras-look.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add utilities for integration tests.

--- a/.changeset/pink-cherries-ring.md
+++ b/.changeset/pink-cherries-ring.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Update `@httpBearerAuth` integration tests to use integration test utilities.

--- a/.changeset/silver-bottles-fry.md
+++ b/.changeset/silver-bottles-fry.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Update `@httpApiKeyAuth` integration tests to use integration test utilities.

--- a/.changeset/weak-pots-know.md
+++ b/.changeset/weak-pots-know.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Fix typo in `HttpAuthScheme` not enabled message in `httpAuthSchemeMiddleware`.

--- a/.changeset/wild-swans-hang.md
+++ b/.changeset/wild-swans-hang.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Allow extracting config properties for identity and auth.

--- a/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
@@ -37,6 +37,12 @@ export interface HttpAuthOption {
   schemeId: HttpAuthSchemeId;
   identityProperties?: Record<string, unknown>;
   signingProperties?: Record<string, unknown>;
+  configPropertiesExtractor?: (
+    config: Record<string, unknown>
+  ) => {
+    identityProperties?: Record<string, unknown>;
+    signingProperties?: Record<string, unknown>;
+  };
 }
 
 /**

--- a/packages/experimental-identity-and-auth/src/integration/genericIdentityAndAuth.integ.spec.ts
+++ b/packages/experimental-identity-and-auth/src/integration/genericIdentityAndAuth.integ.spec.ts
@@ -1,0 +1,1974 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  HttpApiKeyAuthLocation,
+  HttpApiKeyAuthSigner,
+  HttpBearerAuthSigner,
+  NoAuthSigner,
+  SigV4Signer,
+} from "@smithy/experimental-identity-and-auth";
+import { DefaultAuthServiceClient } from "@smithy/identity-and-auth-service-default-multi-auth-service";
+import * as DAS from "@smithy/identity-and-auth-service-default-multi-auth-service";
+import { EmptyAuthServiceClient } from "@smithy/identity-and-auth-service-empty-auth-service";
+import * as EAS from "@smithy/identity-and-auth-service-empty-auth-service";
+import { SpecifiedAuthServiceClient } from "@smithy/identity-and-auth-service-specified-multi-auth-service";
+import * as SAS from "@smithy/identity-and-auth-service-specified-multi-auth-service";
+import { AwsCredentialIdentity } from "@smithy/types";
+
+import { expectClientCommand, getSelectedHttpAuthScheme } from "../util-test";
+
+describe("Generic Identity and Auth", () => {
+  // Arbitrary region
+  const MOCK_REGION = "us-east-1";
+
+  // TODO(experimentalIdentityAndAuth): should match `DefaultAuthService` / `EmptyAuthService` / `SpecificAuthService` `@httpApiKeyAuth` trait
+  const MOCK_API_KEY_NAME = "X-Api-Key";
+  const MOCK_API_KEY = "APIKEY_123";
+
+  // Arbitrary mock token
+  const MOCK_TOKEN = "TOKEN_123";
+
+  // Arbitrary mock credentials
+  const MOCK_CREDENTIALS: AwsCredentialIdentity = {
+    accessKeyId: "MOCK_ACCESS_KEY_ID",
+    secretAccessKey: "SECRET_ACCESS_KEY",
+    sessionToken: "SESSION_TOKEN",
+  };
+
+  describe("Default Service Auth Resolution (no `@auth` trait)", () => {
+    describe("Operation that uses the default service auth order", () => {
+      test("should throw request with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          clientRejects:
+            `HttpAuthScheme \`aws.auth#sigv4\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`common#fakeAuth\` was not enabled for this service.\n` +
+            `HttpAuthScheme \`smithy.api#httpApiKeyAuth\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`smithy.api#httpBearerAuth\` did not have an IdentityProvider configured.`,
+        });
+      });
+
+      test("should resolve the first auth trait in default model order (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@httpApiKeyAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@aws.auth#sigv4`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses the default service auth order and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve the first auth trait in default model order (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@httpApiKeyAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@aws.auth#sigv4`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that specifies the `@auth` trait", () => {
+      test("should throw request with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          clientRejects:
+            `HttpAuthScheme \`smithy.api#httpBearerAuth\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`smithy.api#httpApiKeyAuth\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`common#fakeAuth\` was not enabled for this service.\n` +
+            `HttpAuthScheme \`aws.auth#sigv4\` did not have an IdentityProvider configured.`,
+        });
+      });
+
+      test("should resolve the first auth trait in the specified `@auth` trait order (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@httpBearerAuth`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that specifies the `@auth` trait and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve the first auth trait in the specified `@auth` trait order (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@httpBearerAuth`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses an empty `@auth` trait", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses an empty `@auth` trait and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationEmptyAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: DefaultAuthServiceClient,
+          commandConstructor: DAS.OperationEmptyAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+  });
+
+  describe("Empty Service Auth Resolution (empty `@auth` trait)", () => {
+    describe("Operation that uses the service empty `@auth` trait", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses the service empty `@auth` trait and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that specifies the `@auth` trait", () => {
+      test("should throw request with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          clientRejects:
+            `HttpAuthScheme \`aws.auth#sigv4\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`common#fakeAuth\` was not enabled for this service.\n` +
+            `HttpAuthScheme \`smithy.api#httpApiKeyAuth\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`smithy.api#httpBearerAuth\` did not have an IdentityProvider configured.`,
+        });
+      });
+
+      test("should resolve the first auth trait in specified `@auth` trait order (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@httpApiKeyAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@aws.auth#sigv4`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that specifies the `@auth` trait and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve the first auth trait in specified `@auth` trait order (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@httpApiKeyAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@aws.auth#sigv4`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses an empty `@auth` trait", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses an empty `@auth` trait and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationEmptyAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: EmptyAuthServiceClient,
+          commandConstructor: EAS.OperationEmptyAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+  });
+
+  describe("Specified Service Auth Resolution (`@auth` trait)", () => {
+    describe("Operation that uses the specified service `@auth` trait order", () => {
+      test("should throw request with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          clientRejects:
+            `HttpAuthScheme \`smithy.api#httpBearerAuth\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`smithy.api#httpApiKeyAuth\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`common#fakeAuth\` was not enabled for this service.\n` +
+            `HttpAuthScheme \`aws.auth#sigv4\` did not have an IdentityProvider configured.`,
+        });
+      });
+
+      test("should resolve the first auth trait in specified `@auth` trait order (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@httpBearerAuth`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses the specified service `@auth` trait order and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve the first auth trait in specified `@auth` trait order (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@httpBearerAuth`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.SameAsServiceOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that specifies the `@auth` trait", () => {
+      test("should throw request with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          clientRejects:
+            `HttpAuthScheme \`aws.auth#sigv4\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`common#fakeAuth\` was not enabled for this service.\n` +
+            `HttpAuthScheme \`smithy.api#httpApiKeyAuth\` did not have an IdentityProvider configured.\n` +
+            `HttpAuthScheme \`smithy.api#httpBearerAuth\` did not have an IdentityProvider configured.`,
+        });
+      });
+
+      test("should resolve the first auth trait in specified `@auth` trait order (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@httpApiKeyAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@aws.auth#sigv4`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that specifies the `@auth` trait and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve the first auth trait in specified `@auth` trait order (`@aws.auth#sigv4`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+        });
+      });
+
+      test("should skip the unsupported codegen `@common#fakeAuth` (before `@httpApiKeyAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => {
+              throw new Error("after `common#fakeAuth`");
+            },
+          },
+          clientRejects: "after `common#fakeAuth`",
+        });
+      });
+
+      test("should resolve earlier auth trait given configs (`@httpApiKeyAuth`, `@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              [MOCK_API_KEY_NAME]: MOCK_API_KEY,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpApiKeyAuth",
+                signingProperties: {
+                  name: MOCK_API_KEY_NAME,
+                  in: HttpApiKeyAuthLocation.HEADER,
+                  scheme: undefined,
+                },
+              },
+              identity: {
+                apiKey: MOCK_API_KEY,
+              },
+              signer: expect.any(HttpApiKeyAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve last auth trait (`@httpBearerAuth`)", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              Authorization: `Bearer ${MOCK_TOKEN}`,
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#httpBearerAuth",
+              },
+              identity: {
+                token: MOCK_TOKEN,
+              },
+              signer: expect.any(HttpBearerAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve first auth trait (`@aws.auth#sigv4`) given all auth have configs", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationAuthTraitOptionalCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            credentials: async () => MOCK_CREDENTIALS,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+          },
+          requestMatchers: {
+            headers: {
+              authorization: (val: any) => expect(val).toBeDefined(),
+            },
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "aws.auth#sigv4",
+                signingProperties: {
+                  name: "weather",
+                  region: MOCK_REGION,
+                },
+                configPropertiesExtractor: expect.anything(),
+              },
+              identity: MOCK_CREDENTIALS,
+              signer: expect.any(SigV4Signer),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses an empty `@auth` trait", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+
+    describe("Operation that uses an empty `@auth` trait and `@optionalAuth`", () => {
+      test("should resolve to `smithy.api#noAuth` with no config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+
+      test("should resolve to `smithy.api#noAuth` with config", async () => {
+        await expectClientCommand({
+          clientConstructor: SpecifiedAuthServiceClient,
+          commandConstructor: SAS.OperationEmptyAuthTraitCommand,
+          clientConfig: {
+            region: MOCK_REGION,
+            apiKey: async () => ({
+              apiKey: MOCK_API_KEY,
+            }),
+            token: async () => ({
+              token: MOCK_TOKEN,
+            }),
+            credentials: async () => MOCK_CREDENTIALS,
+          },
+          contextExpectFn: (context) => {
+            expect(getSelectedHttpAuthScheme(context)).toMatchObject({
+              httpAuthOption: {
+                schemeId: "smithy.api#noAuth",
+              },
+              identity: {},
+              signer: expect.any(NoAuthSigner),
+            });
+          },
+        });
+      });
+    });
+  });
+});

--- a/packages/experimental-identity-and-auth/src/integration/httpBearerAuth.integ.spec.ts
+++ b/packages/experimental-identity-and-auth/src/integration/httpBearerAuth.integ.spec.ts
@@ -1,213 +1,217 @@
+import { describe, it } from "@jest/globals";
 import {
   HttpBearerAuthServiceClient,
   OnlyHttpBearerAuthCommand,
   OnlyHttpBearerAuthOptionalCommand,
   SameAsServiceCommand,
 } from "@smithy/identity-and-auth-http-bearer-auth-service";
-import { requireRequestsFrom } from "@smithy/util-test";
+
+import { expectClientCommand } from "../util-test";
 
 describe("@httpBearerAuth integration tests", () => {
   // Arbitrary mock token
   const MOCK_TOKEN = "TOKEN_123";
 
-  // Arbitrary mock endpoint (`requireRequestsFrom()` intercepts network requests)
-  const MOCK_ENDPOINT = "https://foo.bar";
-
   describe("Operation requires `@httpBearerAuth`", () => {
     it("Request is thrown when `token` is not configured", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientRejects: "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured.",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthCommand({}))).rejects.toThrow(
-        "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured."
-      );
     });
 
     it("Request is thrown when `token` is configured incorrectly", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {} as any,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: {},
+        },
+        clientRejects: "request could not be signed with `token` since the `token` is not defined",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthCommand({}))).rejects.toThrow(
-        "request could not be signed with `token` since the `token` is not defined"
-      );
     });
 
     it("Request is thrown given configured `token` identity provider throws", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => {
-          throw new Error("IdentityProvider throws this error");
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: async () => {
+            throw new Error("IdentityProvider throws this error");
+          },
         },
+        clientRejects: "IdentityProvider throws this error",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthCommand({}))).rejects.toThrow(
-        "IdentityProvider throws this error"
-      );
     });
 
     it("Request is signed given configured `token` identity provider", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => ({
-          token: MOCK_TOKEN,
-        }),
-      });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: async () => ({
+            token: MOCK_TOKEN,
+          }),
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      await client.send(new OnlyHttpBearerAuthCommand({}));
     });
 
     it("Request is signed given configured `token` identity", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {
-          token: MOCK_TOKEN,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: {
+            token: MOCK_TOKEN,
+          },
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
-        },
-      });
-      await client.send(new OnlyHttpBearerAuthCommand({}));
     });
   });
 
   describe("Operation has `@httpBearerAuth` and `@optionalAuth`", () => {
     it("Request is NOT thrown and NOT signed when `token` is not configured", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: (value) => expect(value).toBeUndefined(),
-        },
-      });
-      await client.send(new OnlyHttpBearerAuthOptionalCommand({}));
     });
 
     it("Request is thrown when `token` is configured incorrectly", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {} as any,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: {},
+        },
+        clientRejects: "request could not be signed with `token` since the `token` is not defined",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthOptionalCommand({}))).rejects.toThrow(
-        "request could not be signed with `token` since the `token` is not defined"
-      );
     });
 
     it("Request is thrown given configured `token` identity provider throws", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => {
-          throw new Error("IdentityProvider throws this error");
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: async () => {
+            throw new Error("IdentityProvider throws this error");
+          },
         },
+        clientRejects: "IdentityProvider throws this error",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthOptionalCommand({}))).rejects.toThrow(
-        "IdentityProvider throws this error"
-      );
     });
 
     it("Request is signed given configured `token` identity provider", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => ({
-          token: MOCK_TOKEN,
-        }),
-      });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: async () => ({
+            token: MOCK_TOKEN,
+          }),
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      await client.send(new OnlyHttpBearerAuthOptionalCommand({}));
     });
 
     it("Request is signed given configured `token` identity", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {
-          token: MOCK_TOKEN,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: {
+            token: MOCK_TOKEN,
+          },
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
-        },
-      });
-      await client.send(new OnlyHttpBearerAuthOptionalCommand({}));
     });
   });
 
   describe("Service has `@httpBearerAuth`", () => {
     it("Request is thrown when `token` is not configured", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientRejects: "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured.",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow(
-        "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured."
-      );
     });
 
     it("Request is thrown when `token` is configured incorrectly", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {} as any,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: {},
+        },
+        clientRejects: "request could not be signed with `token` since the `token` is not defined",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow(
-        "request could not be signed with `token` since the `token` is not defined"
-      );
     });
 
     it("Request is thrown given configured `token` identity provider throws", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => {
-          throw new Error("IdentityProvider throws this error");
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: async () => {
+            throw new Error("IdentityProvider throws this error");
+          },
         },
+        clientRejects: "IdentityProvider throws this error",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow("IdentityProvider throws this error");
     });
 
     it("Request is signed given configured `token` identity provider", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => ({
-          token: MOCK_TOKEN,
-        }),
-      });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: async () => ({
+            token: MOCK_TOKEN,
+          }),
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      await client.send(new SameAsServiceCommand({}));
     });
 
     it("Request is signed given configured `token` identity", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {
-          token: MOCK_TOKEN,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: {
+            token: MOCK_TOKEN,
+          },
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
-        },
-      });
-      await client.send(new SameAsServiceCommand({}));
     });
   });
 });

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
@@ -84,7 +84,7 @@ export const httpAuthSchemeMiddleware = <
   for (const option of options) {
     const scheme = authSchemes.get(option.schemeId);
     if (!scheme) {
-      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` was not enable for this service.`);
+      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` was not enabled for this service.`);
       continue;
     }
     const identityProvider = scheme.identityProvider(config.identityProviderConfig);

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
@@ -1,6 +1,5 @@
 import {
   HandlerExecutionContext,
-  MetadataBearer,
   SerializeHandler,
   SerializeHandlerArguments,
   SerializeHandlerOutput,
@@ -92,10 +91,13 @@ export const httpAuthSchemeMiddleware = <
       failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` did not have an IdentityProvider configured.`);
       continue;
     }
-    const identity = await identityProvider(option.identityProperties || {});
+    const { identityProperties = {}, signingProperties = {} } =
+      option.configPropertiesExtractor?.(config as Record<string, unknown>) || {};
+    option.identityProperties = Object.assign(option.identityProperties || {}, identityProperties);
+    option.signingProperties = Object.assign(option.signingProperties || {}, signingProperties);
     smithyContext.selectedHttpAuthScheme = {
       httpAuthOption: option,
-      identity,
+      identity: await identityProvider(option.identityProperties),
       signer: scheme.signer,
     };
     break;

--- a/packages/experimental-identity-and-auth/src/util-test/index.ts
+++ b/packages/experimental-identity-and-auth/src/util-test/index.ts
@@ -1,0 +1,59 @@
+import { expect } from "@jest/globals";
+import { FinalizeRequestMiddleware, HandlerExecutionContext } from "@smithy/types";
+import { getSmithyContext } from "@smithy/util-middleware";
+import { requireRequestsFrom } from "@smithy/util-test";
+
+import { SelectedHttpAuthScheme } from "../HttpAuthScheme";
+
+/**
+ * @internal
+ */
+export const expectClientCommand = async (input: any) => {
+  const {
+    // Constructors
+    clientConstructor,
+    commandConstructor,
+    // Config
+    defaultClientConfig = {
+      // Arbitrary mock endpoint (`requireRequestsFrom()` intercepts network requests)
+      endpoint: "https://foo.bar",
+    },
+    clientConfig = {},
+    // Request Matching
+    requestMatchers = {
+      headers: {
+        Authorization: (val: any) => expect(val).toBeUndefined(),
+        authorization: (val: any) => expect(val).toBeUndefined(),
+      },
+    },
+    // Expectations
+    contextExpectFn = undefined,
+    clientRejects = undefined,
+  } = input;
+  const client = new clientConstructor(Object.assign({}, defaultClientConfig, clientConfig));
+  if (contextExpectFn) {
+    client.middlewareStack.add(
+      ((next, context) => async (args) => {
+        (contextExpectFn as Function)(context);
+        return next(args);
+      }) as FinalizeRequestMiddleware<any, any>,
+      {
+        step: "finalizeRequest",
+        priority: "low",
+      }
+    );
+  }
+  requireRequestsFrom(client).toMatch(requestMatchers);
+  const command = new commandConstructor({});
+  if (clientRejects) {
+    await expect(client.send(command)).rejects.toThrow(clientRejects);
+  } else {
+    await client.send(command);
+  }
+};
+
+/**
+ * @internal
+ */
+export const getSelectedHttpAuthScheme = (context: HandlerExecutionContext): SelectedHttpAuthScheme =>
+  getSmithyContext(context).selectedHttpAuthScheme as SelectedHttpAuthScheme;

--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -50,6 +50,27 @@ const httpBearerAuthClientDir = path.join(
     "typescript-codegen"
 );
 
+// TODO(experimentalIdentityAndAuth): add default multi-auth client for integration tests
+const defaultMultiAuthClientDir = path.join(
+    codegenTestDir,
+    "identity-and-auth-service-default-multi-auth",
+    "typescript-codegen"
+);
+
+// TODO(experimentalIdentityAndAuth): add empty auth client for integration tests
+const emptyAuthClientDir = path.join(
+    codegenTestDir,
+    "identity-and-auth-service-empty-auth",
+    "typescript-codegen"
+);
+
+// TODO(experimentalIdentityAndAuth): add specified multi-auth client for integration tests
+const specifiedMultiAuthClientDir = path.join(
+    codegenTestDir,
+    "identity-and-auth-service-specified-multi-auth",
+    "typescript-codegen"
+);
+
 const nodeModulesDir = path.join(root, "node_modules");
 
 const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir) => {
@@ -79,6 +100,12 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
     await buildAndCopyToNodeModules("@smithy/identity-and-auth-http-api-key-auth-service", httpApiKeyAuthClientDir, nodeModulesDir);
     // TODO(experimentalIdentityAndAuth): add `@httpBearerAuth` client for integration tests
     await buildAndCopyToNodeModules("@smithy/identity-and-auth-http-bearer-auth-service", httpBearerAuthClientDir, nodeModulesDir);
+    // TODO(experimentalIdentityAndAuth): add default multi-auth client for integration tests
+    await buildAndCopyToNodeModules("@smithy/identity-and-auth-service-default-multi-auth-service", defaultMultiAuthClientDir, nodeModulesDir);
+    // TODO(experimentalIdentityAndAuth): add empty auth client for integration tests
+    await buildAndCopyToNodeModules("@smithy/identity-and-auth-service-empty-auth-service", emptyAuthClientDir, nodeModulesDir);
+    // TODO(experimentalIdentityAndAuth): add specified multi-auth client for integration tests
+    await buildAndCopyToNodeModules("@smithy/identity-and-auth-service-specified-multi-auth-service", specifiedMultiAuthClientDir, nodeModulesDir);
  } catch (e) {
     console.log(e);
     process.exit(1);

--- a/smithy-typescript-codegen-test/model/identity-and-auth/service-default-multi-auth/DefaultAuthService.smithy
+++ b/smithy-typescript-codegen-test/model/identity-and-auth/service-default-multi-auth/DefaultAuthService.smithy
@@ -1,0 +1,49 @@
+$version: "2.0"
+
+namespace identity.auth.defaultAuth
+
+use aws.auth#sigv4
+use common#fakeProtocol
+use common#fakeAuth
+
+@fakeProtocol
+@sigv4(name: "weather")
+@fakeAuth
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
+@httpBearerAuth
+// No @auth trait applied, uses default auth order (sorted by ShapeId)
+service DefaultAuthService {
+    operations: [
+        SameAsService
+        SameAsServiceOptional
+        OperationAuthTrait
+        OperationAuthTraitOptional
+        OperationEmptyAuthTrait
+        OperationEmptyAuthTraitOptional
+    ]
+}
+
+@http(method: "GET", uri: "/SameAsService")
+operation SameAsService {}
+
+@optionalAuth
+@http(method: "GET", uri: "/SameAsServiceOptional")
+operation SameAsServiceOptional {}
+
+@auth([httpBearerAuth, httpApiKeyAuth, fakeAuth, sigv4])
+@http(method: "GET", uri: "/OperationAuthTrait")
+operation OperationAuthTrait {}
+
+@auth([httpBearerAuth, httpApiKeyAuth, fakeAuth, sigv4])
+@optionalAuth
+@http(method: "GET", uri: "/OperationAuthTraitOptional")
+operation OperationAuthTraitOptional {}
+
+@auth([])
+@http(method: "GET", uri: "/OperationEmptyAuthTrait")
+operation OperationEmptyAuthTrait {}
+
+@auth([])
+@optionalAuth
+@http(method: "GET", uri: "/OperationEmptyAuthTraitOptional")
+operation OperationEmptyAuthTraitOptional {}

--- a/smithy-typescript-codegen-test/model/identity-and-auth/service-empty-auth/EmptyAuthService.smithy
+++ b/smithy-typescript-codegen-test/model/identity-and-auth/service-empty-auth/EmptyAuthService.smithy
@@ -1,0 +1,50 @@
+$version: "2.0"
+
+namespace identity.auth.emptyAuth
+
+use aws.auth#sigv4
+use common#fakeProtocol
+use common#fakeAuth
+
+@fakeProtocol
+@sigv4(name: "weather")
+@fakeAuth
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
+@httpBearerAuth
+// Empty @auth trait applied
+@auth([])
+service EmptyAuthService {
+    operations: [
+        SameAsService
+        SameAsServiceOptional
+        OperationAuthTrait
+        OperationAuthTraitOptional
+        OperationEmptyAuthTrait
+        OperationEmptyAuthTraitOptional
+    ]
+}
+
+@http(method: "GET", uri: "/SameAsService")
+operation SameAsService {}
+
+@http(method: "GET", uri: "/SameAsServiceOptional")
+@optionalAuth
+operation SameAsServiceOptional {}
+
+@auth([sigv4, fakeAuth, httpApiKeyAuth, httpBearerAuth])
+@http(method: "GET", uri: "/OperationAuthTrait")
+operation OperationAuthTrait {}
+
+@auth([sigv4, fakeAuth, httpApiKeyAuth, httpBearerAuth])
+@optionalAuth
+@http(method: "GET", uri: "/OperationAuthTraitOptional")
+operation OperationAuthTraitOptional {}
+
+@auth([])
+@http(method: "GET", uri: "/OperationEmptyAuthTrait")
+operation OperationEmptyAuthTrait {} 
+
+@auth([])
+@optionalAuth
+@http(method: "GET", uri: "/OperationEmptyAuthTraitOptional")
+operation OperationEmptyAuthTraitOptional {} 

--- a/smithy-typescript-codegen-test/model/identity-and-auth/service-specified-multi-auth/SpecifiedAuthService.smithy
+++ b/smithy-typescript-codegen-test/model/identity-and-auth/service-specified-multi-auth/SpecifiedAuthService.smithy
@@ -1,0 +1,50 @@
+$version: "2.0"
+
+namespace identity.auth.specifiedAuth
+
+use aws.auth#sigv4
+use common#fakeProtocol
+use common#fakeAuth
+
+@fakeProtocol
+@sigv4(name: "weather")
+@fakeAuth
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
+@httpBearerAuth
+// Specific @auth trait specified; in this cases, uses the reverse of default auth order (reverse sorted by ShapeId)
+@auth([httpBearerAuth, httpApiKeyAuth, fakeAuth, sigv4])
+service SpecifiedAuthService {
+    operations: [
+        SameAsService
+        SameAsServiceOptional
+        OperationAuthTrait
+        OperationAuthTraitOptional
+        OperationEmptyAuthTrait
+        OperationEmptyAuthTraitOptional
+    ]
+}
+
+@http(method: "GET", uri: "/SameAsService")
+operation SameAsService {}
+
+@optionalAuth
+@http(method: "GET", uri: "/SameAsServiceOptional")
+operation SameAsServiceOptional {}
+
+@auth([sigv4, fakeAuth, httpApiKeyAuth, httpBearerAuth])
+@http(method: "GET", uri: "/OperationAuthTrait")
+operation OperationAuthTrait {}
+
+@auth([sigv4, fakeAuth, httpApiKeyAuth, httpBearerAuth])
+@optionalAuth
+@http(method: "GET", uri: "/OperationAuthTraitOptional")
+operation OperationAuthTraitOptional {} 
+
+@auth([])
+@http(method: "GET", uri: "/OperationEmptyAuthTrait")
+operation OperationEmptyAuthTrait {} 
+
+@auth([])
+@optionalAuth
+@http(method: "GET", uri: "/OperationEmptyAuthTraitOptional")
+operation OperationEmptyAuthTraitOptional {} 

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -120,6 +120,75 @@
                     "experimentalIdentityAndAuth": true
                 }
             }
+        },
+        "identity-and-auth-service-default-multi-auth": {
+            "transforms": [
+                {
+                    "name": "includeServices",
+                    "args": {
+                        "services": ["identity.auth.defaultAuth#DefaultAuthService"]
+                    }
+                }
+            ],
+            "plugins": {
+                "typescript-codegen": {
+                    "service": "identity.auth.defaultAuth#DefaultAuthService",
+                    "targetNamespace": "DefaultAuthService",
+                    "package": "@smithy/identity-and-auth-service-default-multi-auth-service",
+                    "packageVersion": "0.0.1",
+                    "packageJson": {
+                        "license": "Apache-2.0",
+                        "private": true
+                    },
+                    "experimentalIdentityAndAuth": true
+                }
+            }
+        },
+        "identity-and-auth-service-empty-auth": {
+            "transforms": [
+                {
+                    "name": "includeServices",
+                    "args": {
+                        "services": ["identity.auth.emptyAuth#EmptyAuthService"]
+                    }
+                }
+            ],
+            "plugins": {
+                "typescript-codegen": {
+                    "service": "identity.auth.emptyAuth#EmptyAuthService",
+                    "targetNamespace": "EmptyAuthService",
+                    "package": "@smithy/identity-and-auth-service-empty-auth-service",
+                    "packageVersion": "0.0.1",
+                    "packageJson": {
+                        "license": "Apache-2.0",
+                        "private": true
+                    },
+                    "experimentalIdentityAndAuth": true
+                }
+            }
+        },
+        "identity-and-auth-service-specified-multi-auth": {
+            "transforms": [
+                {
+                    "name": "includeServices",
+                    "args": {
+                        "services": ["identity.auth.specifiedAuth#SpecifiedAuthService"]
+                    }
+                }
+            ],
+            "plugins": {
+                "typescript-codegen": {
+                    "service": "identity.auth.specifiedAuth#SpecifiedAuthService",
+                    "targetNamespace": "SpecifiedAuthService",
+                    "package": "@smithy/identity-and-auth-service-specified-multi-auth-service",
+                    "packageVersion": "0.0.1",
+                    "packageJson": {
+                        "license": "Apache-2.0",
+                        "private": true
+                    },
+                    "experimentalIdentityAndAuth": true
+                }
+            }
         }
     },
     "plugins": {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
@@ -18,6 +18,7 @@ import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.ServiceIndex.AuthSchemeMode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.ConfigField;
 import software.amazon.smithy.typescript.codegen.Dependency;
@@ -148,5 +149,24 @@ public final class AuthUtils {
             }
         }
         return httpAuthSchemeParameters;
+    }
+
+    public static boolean areHttpAuthSchemesEqual(
+        Map<ShapeId, Trait> httpAuthSchemes1,
+        Map<ShapeId, Trait> httpAuthSchemes2
+    ) {
+        if (httpAuthSchemes1.size() != httpAuthSchemes2.size()) {
+            return false;
+        }
+        var iter1 = httpAuthSchemes1.entrySet().iterator();
+        var iter2 = httpAuthSchemes2.entrySet().iterator();
+        while (iter1.hasNext() && iter2.hasNext()) {
+            var entry1 = iter1.next();
+            var entry2 = iter2.next();
+            if (!entry1.equals(entry2)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.typescript.codegen.auth.http;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
@@ -35,6 +36,7 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
     private final List<ConfigField> configFields;
     private final List<HttpAuthSchemeParameter> httpAuthSchemeParameters;
     private final List<HttpAuthOptionProperty> httpAuthOptionProperties;
+    private final Consumer<TypeScriptWriter> httpAuthOptionConfigPropertiesExtractor;
 
     private HttpAuthScheme(Builder builder) {
         this.schemeId = SmithyBuilder.requiredState(
@@ -52,6 +54,8 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             "httpAuthSchemeParameters", builder.httpAuthSchemeParameters.copy());
         this.httpAuthOptionProperties = SmithyBuilder.requiredState(
             "httpAuthOptionProperties", builder.httpAuthOptionProperties.copy());
+        this.httpAuthOptionConfigPropertiesExtractor =
+            builder.httpAuthOptionConfigPropertiesExtractor;
     }
 
     /**
@@ -128,6 +132,14 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
     }
 
     /**
+     * Gets the writer for the config properties extractor.
+     * @return optional of config properties extractor
+     */
+    public Optional<Consumer<TypeScriptWriter>> getHttpAuthOptionConfigPropertiesExtractor() {
+        return Optional.ofNullable(httpAuthOptionConfigPropertiesExtractor);
+    }
+
+    /**
      * Creates a {@link Builder}.
      * @return a builder
      */
@@ -149,7 +161,8 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             .defaultSigners(defaultSigners)
             .configFields(configFields)
             .httpAuthSchemeParameters(httpAuthSchemeParameters)
-            .httpAuthOptionProperties(httpAuthOptionProperties);
+            .httpAuthOptionProperties(httpAuthOptionProperties)
+            .httpAuthOptionConfigPropertiesExtractor(httpAuthOptionConfigPropertiesExtractor);
     }
 
     /**
@@ -169,6 +182,7 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             BuilderRef.forList();
         private BuilderRef<List<HttpAuthOptionProperty>> httpAuthOptionProperties =
             BuilderRef.forList();
+        private Consumer<TypeScriptWriter> httpAuthOptionConfigPropertiesExtractor;
 
         private Builder() {}
 
@@ -341,6 +355,17 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
          */
         public Builder addHttpAuthOptionProperty(HttpAuthOptionProperty httpAuthOptionProperty) {
             this.httpAuthOptionProperties.get().add(httpAuthOptionProperty);
+            return this;
+        }
+
+        /**
+         * Sets the httpAuthOptionConfigPropertiesExtractor.
+         * @param httpAuthOptionConfigPropertiesExtractor writer for properties extractor
+         * @return the builder
+         */
+        public Builder httpAuthOptionConfigPropertiesExtractor(
+            Consumer<TypeScriptWriter> httpAuthOptionConfigPropertiesExtractor) {
+            this.httpAuthOptionConfigPropertiesExtractor = httpAuthOptionConfigPropertiesExtractor;
             return this;
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
@@ -123,7 +123,7 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
      * @param type type of auth option property
      * @return httpAuthOptionProperties filtered by type
      */
-    public List<HttpAuthOptionProperty> getAuthSchemeOptionParametersByType(Type type) {
+    public List<HttpAuthOptionProperty> getHttpAuthSchemeOptionParametersByType(Type type) {
         return httpAuthOptionProperties.stream().filter(p -> p.type().equals(type)).toList();
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -246,6 +246,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                             }
                         });
                     }
+                    authScheme.getHttpAuthOptionConfigPropertiesExtractor()
+                        .ifPresent(extractor -> w.write("configPropertiesExtractor: $C", extractor));
                 });
             });
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -308,7 +308,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                             serviceShape, operationShapeId, AuthSchemeMode.NO_AUTH_AWARE);
                         // Skip operation generation if operation auth schemes are equivalent to the default service
                         // auth schemes.
-                        if (serviceAuthSchemes.equals(operationAuthSchemes)) {
+                        if (AuthUtils.areHttpAuthSchemesEqual(serviceAuthSchemes, operationAuthSchemes)) {
                             continue;
                         }
                         w.openBlock("case $S: {", "};", operationShapeId.getName(), () -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -229,7 +229,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                     }
                     Trait trait = serviceShape.findTrait(authScheme.getTraitId()).orElse(null);
                     List<HttpAuthOptionProperty> identityProperties =
-                        authScheme.getAuthSchemeOptionParametersByType(Type.IDENTITY);
+                        authScheme.getHttpAuthSchemeOptionParametersByType(Type.IDENTITY);
                     if (!identityProperties.isEmpty()) {
                         w.openBlock("identityProperties: {", "},", () -> {
                             for (HttpAuthOptionProperty parameter : identityProperties) {
@@ -238,7 +238,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                         });
                     }
                     List<HttpAuthOptionProperty> signingProperties =
-                        authScheme.getAuthSchemeOptionParametersByType(Type.SIGNING);
+                        authScheme.getHttpAuthSchemeOptionParametersByType(Type.SIGNING);
                     if (!signingProperties.isEmpty()) {
                         w.openBlock("signingProperties: {", "},", () -> {
                             for (HttpAuthOptionProperty parameter : signingProperties) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
@@ -102,6 +102,12 @@ public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
                         w.write("authParameters.region");
                     })
                     .build())
+                .httpAuthOptionConfigPropertiesExtractor(w -> w.write("""
+                    (config: Record<string, unknown>) => ({
+                      signingProperties: {
+                        sha256: config.sha256,
+                      },
+                    }),"""))
                 .build());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

*Dependent on: https://github.com/awslabs/smithy-typescript/pull/1031, https://github.com/awslabs/smithy-typescript/pull/1032, https://github.com/awslabs/smithy-typescript/pull/1033, https://github.com/awslabs/smithy-typescript/pull/1034, https://github.com/awslabs/smithy-typescript/pull/1035*

Add generic identity and auth integration tests.

- [x] Build generic identity and auth clients
- [x] Write integration tests for identity and auth clients
  - [x] `@TRAIT`
  - [x] `@TRAIT` with an `@optionalAuth` operation
  - [x] `@TRAIT` with `@auth` operation
  - [x] `@TRAIT` with `@auth` operation and `@optionalAuth`
  - [x] `@TRAIT` with empty `@auth` operation
  - [x] `@TRAIT` with empty `@auth` operation and `@optionalAuth`
  - [x] `@TRAIT` with `@auth` on the service level
  - [x] `@TRAIT` with `@auth` on the service level and `@optionalAuth`
  - [x] `@TRAIT` with `@auth` on the service level and `@auth` operation
  - [x] `@TRAIT` with `@auth` on the service level and `@optionalAuth` operation
  - [x] `@TRAIT` with `@auth` on the service level and an empty `@auth` operation
  - [x] `@TRAIT` with `@auth` on the service level and an empty `@auth` operation and `@optionalAuth`
  - [x] `@TRAIT` with an empty `@auth` on the service level
  - [x] `@TRAIT` with an empty `@auth` on the service level and `@optionalAuth` operation
  - [x] `@TRAIT` with an empty `@auth` on the service level and `@auth` on the operation level
  - [x] `@TRAIT` with an empty `@auth` on the service level and `@auth` on the operation level and `@optionalAuth`
  - [x] `@TRAIT` with an empty `@auth` on the service level and an empty `@auth` on the operation level
  - [x] `@TRAIT` with an empty `@auth` on the service level and an empty `@auth` on the operation level and `@optionalAuth`

*Testing:*

1. Run `yarn test:integration`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
