### PR TITLE
feat(experimentalIdentityAndAuth): add utilities for integration tests

### DIFF
--- a/.changeset/olive-cobras-look.md
+++ b/.changeset/olive-cobras-look.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add utilities for integration tests.

--- a/.changeset/pink-cherries-ring.md
+++ b/.changeset/pink-cherries-ring.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Update `@httpBearerAuth` integration tests to use integration test utilities.

--- a/.changeset/silver-bottles-fry.md
+++ b/.changeset/silver-bottles-fry.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Update `@httpApiKeyAuth` integration tests to use integration test utilities.

--- a/packages/experimental-identity-and-auth/src/integration/httpBearerAuth.integ.spec.ts
+++ b/packages/experimental-identity-and-auth/src/integration/httpBearerAuth.integ.spec.ts
@@ -1,213 +1,217 @@
+import { describe, it } from "@jest/globals";
 import {
   HttpBearerAuthServiceClient,
   OnlyHttpBearerAuthCommand,
   OnlyHttpBearerAuthOptionalCommand,
   SameAsServiceCommand,
 } from "@smithy/identity-and-auth-http-bearer-auth-service";
-import { requireRequestsFrom } from "@smithy/util-test";
+
+import { expectClientCommand } from "../util-test";
 
 describe("@httpBearerAuth integration tests", () => {
   // Arbitrary mock token
   const MOCK_TOKEN = "TOKEN_123";
 
-  // Arbitrary mock endpoint (`requireRequestsFrom()` intercepts network requests)
-  const MOCK_ENDPOINT = "https://foo.bar";
-
   describe("Operation requires `@httpBearerAuth`", () => {
     it("Request is thrown when `token` is not configured", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientRejects: "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured.",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthCommand({}))).rejects.toThrow(
-        "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured."
-      );
     });
 
     it("Request is thrown when `token` is configured incorrectly", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {} as any,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: {},
+        },
+        clientRejects: "request could not be signed with `token` since the `token` is not defined",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthCommand({}))).rejects.toThrow(
-        "request could not be signed with `token` since the `token` is not defined"
-      );
     });
 
     it("Request is thrown given configured `token` identity provider throws", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => {
-          throw new Error("IdentityProvider throws this error");
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: async () => {
+            throw new Error("IdentityProvider throws this error");
+          },
         },
+        clientRejects: "IdentityProvider throws this error",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthCommand({}))).rejects.toThrow(
-        "IdentityProvider throws this error"
-      );
     });
 
     it("Request is signed given configured `token` identity provider", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => ({
-          token: MOCK_TOKEN,
-        }),
-      });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: async () => ({
+            token: MOCK_TOKEN,
+          }),
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      await client.send(new OnlyHttpBearerAuthCommand({}));
     });
 
     it("Request is signed given configured `token` identity", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {
-          token: MOCK_TOKEN,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthCommand,
+        clientConfig: {
+          token: {
+            token: MOCK_TOKEN,
+          },
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
-        },
-      });
-      await client.send(new OnlyHttpBearerAuthCommand({}));
     });
   });
 
   describe("Operation has `@httpBearerAuth` and `@optionalAuth`", () => {
     it("Request is NOT thrown and NOT signed when `token` is not configured", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: (value) => expect(value).toBeUndefined(),
-        },
-      });
-      await client.send(new OnlyHttpBearerAuthOptionalCommand({}));
     });
 
     it("Request is thrown when `token` is configured incorrectly", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {} as any,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: {},
+        },
+        clientRejects: "request could not be signed with `token` since the `token` is not defined",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthOptionalCommand({}))).rejects.toThrow(
-        "request could not be signed with `token` since the `token` is not defined"
-      );
     });
 
     it("Request is thrown given configured `token` identity provider throws", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => {
-          throw new Error("IdentityProvider throws this error");
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: async () => {
+            throw new Error("IdentityProvider throws this error");
+          },
         },
+        clientRejects: "IdentityProvider throws this error",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new OnlyHttpBearerAuthOptionalCommand({}))).rejects.toThrow(
-        "IdentityProvider throws this error"
-      );
     });
 
     it("Request is signed given configured `token` identity provider", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => ({
-          token: MOCK_TOKEN,
-        }),
-      });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: async () => ({
+            token: MOCK_TOKEN,
+          }),
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      await client.send(new OnlyHttpBearerAuthOptionalCommand({}));
     });
 
     it("Request is signed given configured `token` identity", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {
-          token: MOCK_TOKEN,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: OnlyHttpBearerAuthOptionalCommand,
+        clientConfig: {
+          token: {
+            token: MOCK_TOKEN,
+          },
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
-        },
-      });
-      await client.send(new OnlyHttpBearerAuthOptionalCommand({}));
     });
   });
 
   describe("Service has `@httpBearerAuth`", () => {
     it("Request is thrown when `token` is not configured", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientRejects: "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured.",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow(
-        "HttpAuthScheme `smithy.api#httpBearerAuth` did not have an IdentityProvider configured."
-      );
     });
 
     it("Request is thrown when `token` is configured incorrectly", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {} as any,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: {},
+        },
+        clientRejects: "request could not be signed with `token` since the `token` is not defined",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow(
-        "request could not be signed with `token` since the `token` is not defined"
-      );
     });
 
     it("Request is thrown given configured `token` identity provider throws", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => {
-          throw new Error("IdentityProvider throws this error");
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: async () => {
+            throw new Error("IdentityProvider throws this error");
+          },
         },
+        clientRejects: "IdentityProvider throws this error",
       });
-      requireRequestsFrom(client).toMatch({});
-      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow("IdentityProvider throws this error");
     });
 
     it("Request is signed given configured `token` identity provider", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: async () => ({
-          token: MOCK_TOKEN,
-        }),
-      });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: async () => ({
+            token: MOCK_TOKEN,
+          }),
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      await client.send(new SameAsServiceCommand({}));
     });
 
     it("Request is signed given configured `token` identity", async () => {
-      const client = new HttpBearerAuthServiceClient({
-        endpoint: MOCK_ENDPOINT,
-        token: {
-          token: MOCK_TOKEN,
+      await expectClientCommand({
+        clientConstructor: HttpBearerAuthServiceClient,
+        commandConstructor: SameAsServiceCommand,
+        clientConfig: {
+          token: {
+            token: MOCK_TOKEN,
+          },
+        },
+        requestMatchers: {
+          headers: {
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          },
         },
       });
-      requireRequestsFrom(client).toMatch({
-        headers: {
-          Authorization: `Bearer ${MOCK_TOKEN}`,
-        },
-      });
-      await client.send(new SameAsServiceCommand({}));
     });
   });
 });

--- a/packages/experimental-identity-and-auth/src/util-test/index.ts
+++ b/packages/experimental-identity-and-auth/src/util-test/index.ts
@@ -1,0 +1,59 @@
+import { expect } from "@jest/globals";
+import { FinalizeRequestMiddleware, HandlerExecutionContext } from "@smithy/types";
+import { getSmithyContext } from "@smithy/util-middleware";
+import { requireRequestsFrom } from "@smithy/util-test";
+
+import { SelectedHttpAuthScheme } from "../HttpAuthScheme";
+
+/**
+ * @internal
+ */
+export const expectClientCommand = async (input: any) => {
+  const {
+    // Constructors
+    clientConstructor,
+    commandConstructor,
+    // Config
+    defaultClientConfig = {
+      // Arbitrary mock endpoint (`requireRequestsFrom()` intercepts network requests)
+      endpoint: "https://foo.bar",
+    },
+    clientConfig = {},
+    // Request Matching
+    requestMatchers = {
+      headers: {
+        Authorization: (val: any) => expect(val).toBeUndefined(),
+        authorization: (val: any) => expect(val).toBeUndefined(),
+      },
+    },
+    // Expectations
+    contextExpectFn = undefined,
+    clientRejects = undefined,
+  } = input;
+  const client = new clientConstructor(Object.assign({}, defaultClientConfig, clientConfig));
+  if (contextExpectFn) {
+    client.middlewareStack.add(
+      ((next, context) => async (args) => {
+        (contextExpectFn as Function)(context);
+        return next(args);
+      }) as FinalizeRequestMiddleware<any, any>,
+      {
+        step: "finalizeRequest",
+        priority: "low",
+      }
+    );
+  }
+  requireRequestsFrom(client).toMatch(requestMatchers);
+  const command = new commandConstructor({});
+  if (clientRejects) {
+    await expect(client.send(command)).rejects.toThrow(clientRejects);
+  } else {
+    await client.send(command);
+  }
+};
+
+/**
+ * @internal
+ */
+export const getSelectedHttpAuthScheme = (context: HandlerExecutionContext): SelectedHttpAuthScheme =>
+  getSmithyContext(context).selectedHttpAuthScheme as SelectedHttpAuthScheme;


### PR DESCRIPTION

*Issue #, if available:*

N/A.

*Description of changes:*

Add utilities for integration tests:

- update `@httpApiKeyAuth` integration tests to use integration test utilities
- update `@httpBearerAuth` integration tests to use integration test utilities

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
