### PR TITLE
Use 8-core runner for TypeScript Test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn lint --concurrency=3
 
   test-typescript:
-    runs-on: ubuntu-latest
+    runs-on: smithy-typescript_ubuntu-latest_8-core
     name: TypeScript Test
     steps:
       - uses: actions/checkout@v3
@@ -60,9 +60,9 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Build packages
-        run: yarn build --concurrency=2
+        run: yarn build
       - name: Run unit tests
-        run: yarn workspaces foreach --exclude smithy-typescript  -v run test
+        run: yarn test
       - name: Run integration tests
         run: |
           yarn config set enableImmutableInstalls false


### PR DESCRIPTION
Use 8-core runner for TypeScript Test CI.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
