### PR TITLE
feat(experimentalIdentityAndAuth): add internal error and success handlers to `HttpSigner` and QOL changes

### DIFF
--- a/.changeset/old-trees-wink.md
+++ b/.changeset/old-trees-wink.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Copy `getSmithyContext()` and `normalizeProvider()` to `@smithy/core`.

--- a/.changeset/rotten-islands-brake.md
+++ b/.changeset/rotten-islands-brake.md
@@ -1,0 +1,6 @@
+---
+"@smithy/types": patch
+"@smithy/core": patch
+---
+
+Add internal error and success handlers to `HttpSigner`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
-    "test": "yarn g:jest --passWithNoTests"
+    "test": "yarn g:jest"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/core/src/getSmithyContext.ts
+++ b/packages/core/src/getSmithyContext.ts
@@ -1,0 +1,7 @@
+import { HandlerExecutionContext, SMITHY_CONTEXT_KEY } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export const getSmithyContext = (context: HandlerExecutionContext): Record<string, unknown> =>
+  context[SMITHY_CONTEXT_KEY] || (context[SMITHY_CONTEXT_KEY] = {});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./middleware-http-auth-scheme";
 export * from "./middleware-http-signing";
 export * from "./util-identity-and-auth";
+export * from "./getSmithyContext";
+export * from "./normalizeProvider";

--- a/packages/core/src/normalizeProvider.spec.ts
+++ b/packages/core/src/normalizeProvider.spec.ts
@@ -1,0 +1,22 @@
+import { normalizeProvider } from "./normalizeProvider";
+
+describe(normalizeProvider.name, () => {
+  const testCases = [
+    true, // boolean
+    null, // null
+    undefined, // undefined
+    1, // number
+    "", // string
+    {}, // object
+  ];
+
+  it.each(testCases)("returns Provider if value is not a function: %s", async (value) => {
+    const output = normalizeProvider(value);
+    expect(await output()).toEqual(value);
+  });
+
+  it.each(testCases)("returns Provider if value if a function which returns %s", (value) => {
+    const mockValueProvider = () => Promise.resolve(value);
+    expect(normalizeProvider(mockValueProvider)).toBe(mockValueProvider);
+  });
+});

--- a/packages/core/src/normalizeProvider.ts
+++ b/packages/core/src/normalizeProvider.ts
@@ -1,0 +1,12 @@
+import { Provider } from "@smithy/types";
+
+/**
+ * @internal
+ *
+ * @returns a provider function for the input value if it isn't already one.
+ */
+export const normalizeProvider = <T>(input: T | Provider<T>): Provider<T> => {
+  if (typeof input === "function") return input as Provider<T>;
+  const promisified = Promise.resolve(input);
+  return () => promisified;
+};

--- a/packages/types/src/auth/HttpSigner.ts
+++ b/packages/types/src/auth/HttpSigner.ts
@@ -1,5 +1,19 @@
-import { HttpRequest } from "../http";
+import { HttpRequest, HttpResponse } from "../http";
 import { Identity } from "../identity/identity";
+
+/**
+ * @internal
+ */
+export interface ErrorHandler {
+  (signingProperties: Record<string, unknown>): <E extends Error>(error: E) => never;
+}
+
+/**
+ * @internal
+ */
+export interface SuccessHandler {
+  (httpResponse: HttpResponse | unknown, signingProperties: Record<string, unknown>): void;
+}
 
 /**
  * Interface to sign identity and signing properties.
@@ -14,4 +28,17 @@ export interface HttpSigner {
    * @returns signed request in a promise
    */
   sign(httpRequest: HttpRequest, identity: Identity, signingProperties: Record<string, unknown>): Promise<HttpRequest>;
+  /**
+   * Handler that executes after the {@link HttpSigner.sign} invocation and corresponding
+   * middleware throws an error.
+   * The error handler is expected to throw the error it receives, so the return type of the error handler is `never`.
+   * @internal
+   */
+  errorHandler?: ErrorHandler;
+  /**
+   * Handler that executes after the {@link HttpSigner.sign} invocation and corresponding
+   * middleware succeeds.
+   * @internal
+   */
+  successHandler?: SuccessHandler;
 }

--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -53,6 +53,7 @@ const httpBearerAuthClientDir = path.join(
 const nodeModulesDir = path.join(root, "node_modules");
 
 const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir) => {
+  try {
     console.log(`Building and copying package \`${packageName}\` in \`${codegenDir}\` to \`${nodeModulesDir}\``);
     // Yarn detects that the generated TypeScript package is nested beneath the
     // top-level package.json. Adding an empty lock file allows it to be treated
@@ -67,20 +68,20 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
     await spawnProcess("mkdir", ["-p", packageName], { cwd: nodeModulesDir });
     const targetPackageDir = path.join(nodeModulesDir, packageName);
     await spawnProcess("tar", ["-xf", "package.tgz", "-C", targetPackageDir, "--strip-components", "1"], { cwd: codegenDir });
+  } catch (e) {
+    console.log(`Building and copying package \`${packageName}\` in \`${codegenDir}\` to \`${nodeModulesDir}\` failed:`)
+    console.log(e);
+    process.exit(1);
+  }
 };
 
 (async () => {
-  try {
-    await buildAndCopyToNodeModules("weather", weatherClientDir, nodeModulesDir);
-    await buildAndCopyToNodeModules("weather-ssdk", weatherSsdkDir, nodeModulesDir);
-    // TODO(experimentalIdentityAndAuth): build generic client for integration tests
-    await buildAndCopyToNodeModules("@smithy/weather-experimental-identity-and-auth", weatherExperimentalIdentityAndAuthClientDir, nodeModulesDir);
-    // TODO(experimentalIdentityAndAuth): add `@httpApiKeyAuth` client for integration tests
-    await buildAndCopyToNodeModules("@smithy/identity-and-auth-http-api-key-auth-service", httpApiKeyAuthClientDir, nodeModulesDir);
-    // TODO(experimentalIdentityAndAuth): add `@httpBearerAuth` client for integration tests
-    await buildAndCopyToNodeModules("@smithy/identity-and-auth-http-bearer-auth-service", httpBearerAuthClientDir, nodeModulesDir);
- } catch (e) {
-    console.log(e);
-    process.exit(1);
- }
+  await buildAndCopyToNodeModules("weather", weatherClientDir, nodeModulesDir);
+  await buildAndCopyToNodeModules("weather-ssdk", weatherSsdkDir, nodeModulesDir);
+  // TODO(experimentalIdentityAndAuth): build generic client for integration tests
+  await buildAndCopyToNodeModules("@smithy/weather-experimental-identity-and-auth", weatherExperimentalIdentityAndAuthClientDir, nodeModulesDir);
+  // TODO(experimentalIdentityAndAuth): add `@httpApiKeyAuth` client for integration tests
+  await buildAndCopyToNodeModules("@smithy/identity-and-auth-http-api-key-auth-service", httpApiKeyAuthClientDir, nodeModulesDir);
+  // TODO(experimentalIdentityAndAuth): add `@httpBearerAuth` client for integration tests
+  await buildAndCopyToNodeModules("@smithy/identity-and-auth-http-bearer-auth-service", httpBearerAuthClientDir, nodeModulesDir);
 })();


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add internal error and success handlers to `HttpSigner` for `experimentalIdentityAndAuth`.

Also add some quality of life improvements:

- Log error message per test client for build failures
- Copy `getSmithyContext()` and `normalizeProvider()` to `@smithy/core`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
