### PR TITLE
fix: apply filtering when walking json arrays

### DIFF
--- a/.changeset/shaggy-apes-call.md
+++ b/.changeset/shaggy-apes-call.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+apply json default filtering when walking through arrays

--- a/packages/smithy-client/src/serde-json.spec.ts
+++ b/packages/smithy-client/src/serde-json.spec.ts
@@ -36,4 +36,17 @@ describe(_json.name, () => {
       a: { b: 5, c: [6] },
     });
   });
+
+  it("recursively removes nullish entries in arrays", () => {
+    expect(
+      _json({
+        a: {
+          b: 5,
+          c: [, , { a: 5, b: 6, c: null, d: undefined }, 6],
+        },
+      })
+    ).toEqual({
+      a: { b: 5, c: [{ a: 5, b: 6 }, 6] },
+    });
+  });
 });

--- a/packages/smithy-client/src/serde-json.ts
+++ b/packages/smithy-client/src/serde-json.ts
@@ -12,7 +12,7 @@ export const _json = (obj: any): any => {
     return {};
   }
   if (Array.isArray(obj)) {
-    return obj.filter((_: any) => _ != null);
+    return obj.filter((_: any) => _ != null).map(_json);
   }
   if (typeof obj === "object") {
     const target: any = {};


### PR DESCRIPTION
`_json` is a recursive serde function for the default JSON protocol behavior. It was missing a recursive call when walking through an array type.

- [x] protocol tests passing in AWS SDK JSv3
