### PR TITLE
Increase performance of body length calculation for larger payloads on browser

### DIFF
--- a/.changeset/silent-waves-fly.md
+++ b/.changeset/silent-waves-fly.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-body-length-browser": patch
+---
+
+Use TextEncoder to calculate body length on browsers (where available)

--- a/packages/util-body-length-browser/src/calculateBodyLength.ts
+++ b/packages/util-body-length-browser/src/calculateBodyLength.ts
@@ -1,8 +1,14 @@
+const TEXT_ENCODER = typeof TextEncoder == "function" ? new TextEncoder() : null;
+
 /**
  * @internal
  */
 export const calculateBodyLength = (body: any): number | undefined => {
   if (typeof body === "string") {
+    if (TEXT_ENCODER) {
+      return TEXT_ENCODER.encode(body).byteLength;
+    }
+
     let len = body.length;
 
     for (let i = len - 1; i >= 0; i--) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use TextEncoder to calculate body length on browsers where available to massively improve performance of larger bodies.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
