### PR TITLE
align static create and ctor signatures for http handlers

### DIFF
--- a/.changeset/serious-otters-breathe.md
+++ b/.changeset/serious-otters-breathe.md
@@ -1,0 +1,6 @@
+---
+"@smithy/fetch-http-handler": patch
+"@smithy/node-http-handler": patch
+---
+
+align ctor and static creation signatures for http handlers

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -32,7 +32,9 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
    * @returns the input if it is an HttpHandler of any class,
    * or instantiates a new instance of this handler.
    */
-  public static create(instanceOrOptions?: HttpHandler<any> | FetchHttpHandlerConfig) {
+  public static create(
+    instanceOrOptions?: HttpHandler<any> | FetchHttpHandlerOptions | Provider<FetchHttpHandlerOptions | void>
+  ) {
     if (typeof (instanceOrOptions as any)?.handle === "function") {
       // is already an instance of HttpHandler.
       return instanceOrOptions as HttpHandler<any>;
@@ -41,7 +43,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
     return new FetchHttpHandler(instanceOrOptions as FetchHttpHandlerConfig);
   }
 
-  constructor(options?: FetchHttpHandlerOptions | Provider<FetchHttpHandlerOptions | undefined>) {
+  constructor(options?: FetchHttpHandlerOptions | Provider<FetchHttpHandlerOptions | void>) {
     if (typeof options === "function") {
       this.configProvider = options().then((opts) => opts || {});
     } else {

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -34,7 +34,9 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
    * @returns the input if it is an HttpHandler of any class,
    * or instantiates a new instance of this handler.
    */
-  public static create(instanceOrOptions?: HttpHandler<any> | NodeHttpHandlerOptions) {
+  public static create(
+    instanceOrOptions?: HttpHandler<any> | NodeHttpHandlerOptions | Provider<NodeHttpHandlerOptions | void>
+  ) {
     if (typeof (instanceOrOptions as any)?.handle === "function") {
       // is already an instance of HttpHandler.
       return instanceOrOptions as HttpHandler<any>;

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -53,7 +53,9 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
    * @returns the input if it is an HttpHandler of any class,
    * or instantiates a new instance of this handler.
    */
-  public static create(instanceOrOptions?: HttpHandler<any> | NodeHttp2HandlerOptions) {
+  public static create(
+    instanceOrOptions?: HttpHandler<any> | NodeHttp2HandlerOptions | Provider<NodeHttp2HandlerOptions | void>
+  ) {
     if (typeof (instanceOrOptions as any)?.handle === "function") {
       // is already an instance of HttpHandler.
       return instanceOrOptions as HttpHandler<any>;


### PR DESCRIPTION
followup to https://github.com/smithy-lang/smithy-typescript/pull/1089

makes the signature of the static `create` function more consistent with the instance constructor, allowing an options `Provider` function.