### PR TITLE
Process config files for profile names containing prefix separator

### DIFF
--- a/.changeset/sharp-pants-hug.md
+++ b/.changeset/sharp-pants-hug.md
@@ -2,4 +2,4 @@
 "@smithy/shared-ini-file-loader": patch
 ---
 
-Validate IniSectionType for profile names containing config prefix separator
+Process config files for profile names containing prefix separator

--- a/.changeset/sharp-pants-hug.md
+++ b/.changeset/sharp-pants-hug.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Validate IniSectionType for profile names containing config prefix separator

--- a/packages/shared-ini-file-loader/src/getConfigData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getConfigData.spec.ts
@@ -21,6 +21,11 @@ describe(getConfigData.name, () => {
   it.each([IniSectionType.SSO_SESSION, IniSectionType.SERVICES])("includes sections with '%s' prefix", (prefix) => {
     const mockInput = { [[prefix, "test"].join(CONFIG_PREFIX_SEPARATOR)]: { key: "value" } };
     expect(getConfigData(mockInput)).toStrictEqual(mockInput);
+
+    // Profile name containing CONFIG_PREFIX_SEPARATOR
+    const profileName = ["foo", "bar"].join(CONFIG_PREFIX_SEPARATOR);
+    const mockInput2 = { [[prefix, profileName].join(CONFIG_PREFIX_SEPARATOR)]: { key: "value" } };
+    expect(getConfigData(mockInput2)).toStrictEqual(mockInput2);
   });
 
   describe("normalizes profile names", () => {

--- a/packages/shared-ini-file-loader/src/getConfigData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getConfigData.spec.ts
@@ -43,6 +43,13 @@ describe(getConfigData.name, () => {
         {}
       );
 
+    it("profile containing CONFIG_PREFIX_SEPARATOR", () => {
+      const profileName = ["foo", "bar"].join(CONFIG_PREFIX_SEPARATOR);
+      const mockOutput = getMockOutput([profileName]);
+      const mockInput = getMockInput(mockOutput);
+      expect(getConfigData(mockInput)).toStrictEqual(mockOutput);
+    });
+
     it("single profile", () => {
       const mockOutput = getMockOutput(["one"]);
       const mockInput = getMockInput(mockOutput);

--- a/packages/shared-ini-file-loader/src/getConfigData.ts
+++ b/packages/shared-ini-file-loader/src/getConfigData.ts
@@ -10,13 +10,13 @@ import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
  */
 export const getConfigData = (data: ParsedIniData): ParsedIniData =>
   Object.entries(data)
-    // filter out
     .filter(([key]) => {
-      const sections = key.split(CONFIG_PREFIX_SEPARATOR);
-      if (sections.length === 2 && Object.values(IniSectionType).includes(sections[0] as IniSectionType)) {
-        return true;
+      if (key.indexOf(CONFIG_PREFIX_SEPARATOR) === -1) {
+        // filter out keys which do not contain CONFIG_PREFIX_SEPARATOR.
+        return false;
       }
-      return false;
+      // Check if prefix is a valid IniSectionType.
+      return Object.values(IniSectionType).includes(key.split(CONFIG_PREFIX_SEPARATOR)[0] as IniSectionType);
     })
     // replace profile prefix, if present.
     .reduce(

--- a/packages/shared-ini-file-loader/src/getConfigData.ts
+++ b/packages/shared-ini-file-loader/src/getConfigData.ts
@@ -11,17 +11,20 @@ import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
 export const getConfigData = (data: ParsedIniData): ParsedIniData =>
   Object.entries(data)
     .filter(([key]) => {
-      if (key.indexOf(CONFIG_PREFIX_SEPARATOR) === -1) {
+      const indexOfSeparator = key.indexOf(CONFIG_PREFIX_SEPARATOR);
+      if (indexOfSeparator === -1) {
         // filter out keys which do not contain CONFIG_PREFIX_SEPARATOR.
         return false;
       }
       // Check if prefix is a valid IniSectionType.
-      return Object.values(IniSectionType).includes(key.split(CONFIG_PREFIX_SEPARATOR)[0] as IniSectionType);
+      return Object.values(IniSectionType).includes(key.substring(0, indexOfSeparator) as IniSectionType);
     })
-    // replace profile prefix, if present.
+    // remove profile prefix, if present.
     .reduce(
       (acc, [key, value]) => {
-        const updatedKey = key.startsWith(IniSectionType.PROFILE) ? key.split(CONFIG_PREFIX_SEPARATOR)[1] : key;
+        const indexOfSeparator = key.indexOf(CONFIG_PREFIX_SEPARATOR);
+        const updatedKey =
+          key.substring(0, indexOfSeparator) === IniSectionType.PROFILE ? key.substring(indexOfSeparator + 1) : key;
         acc[updatedKey] = value;
         return acc;
       },


### PR DESCRIPTION
*Issue #, if available:*

* Fixes: https://github.com/smithy-lang/smithy-typescript/issues/1053
* Fixes: https://github.com/aws/aws-sdk-js-v3/issues/5521

*Description of changes:*

Validate IniSectionType for profile names containing config prefix separator

*Testing:*

```console
$ cat test.mjs
import { loadSharedConfigFiles } from "../smithy-typescript/packages/shared-ini-file-loader/dist-cjs/index.js";
console.log(await loadSharedConfigFiles());

$ cat ~/.aws/credentials
[foo.bar]
aws_access_key_id = aws_access_key_id
aws_secret_access_key = aws_secret_access_key

[foo@bar]
aws_access_key_id = aws_access_key_id
aws_secret_access_key = aws_secret_access_key

$ cat ~/.aws/config
[profile foo.bar]
region = eu-west-2

[profile foo@bar]
region = eu-west-2

$ node test.mjs
{
  configFile: {
    'foo.bar': { region: 'eu-west-2' },
    'foo@bar': { region: 'eu-west-2' }
  },
  credentialsFile: {
    'foo.bar': {
      aws_access_key_id: 'aws_access_key_id',
      aws_secret_access_key: 'aws_secret_access_key'
    },
    'foo@bar': {
      aws_access_key_id: 'aws_access_key_id',
      aws_secret_access_key: 'aws_secret_access_key'
    }
  }
}
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
