### PR TITLE
fix(json-rpc): merge initial-response event into operation response

### DIFF
--- a/.changeset/shaggy-owls-happen.md
+++ b/.changeset/shaggy-owls-happen.md
@@ -1,0 +1,6 @@
+---
+"@smithy/eventstream-serde-universal": patch
+"@smithy/eventstream-codec": patch
+---
+
+merge initial-response event into operation output

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ smithy-typescript-integ-tests/yarn.lock
 
 # Issue https://github.com/awslabs/smithy-typescript/issues/425
 smithy-typescript-codegen/bin/
+smithy-typescript-codegen-test/bin/
 smithy-typescript-ssdk-codegen-test-utils/bin/
 smithy-typescript-codegen-test/example-weather-customizations/bin/
 

--- a/packages/eventstream-codec/src/SmithyMessageDecoderStream.spec.ts
+++ b/packages/eventstream-codec/src/SmithyMessageDecoderStream.spec.ts
@@ -35,4 +35,29 @@ describe("SmithyMessageDecoderStream", () => {
     expect(messages[0]).toEqual("first");
     expect(messages[1]).toEqual("second");
   });
+
+  it("is bufferable", async () => {
+    const stream = new SmithyMessageDecoderStream({
+      deserializer: (_) => _ as any,
+      messageStream: [1, 2, 3, 4, 5] as any,
+    });
+
+    stream.push(10);
+    stream.unshift(9);
+
+    const it = stream[Symbol.asyncIterator]();
+
+    expect(await it.next()).toEqual({ value: 9, done: false });
+    expect(await it.next()).toEqual({ value: 10, done: false });
+    expect(await it.next()).toEqual({ value: 1, done: false });
+    expect(await it.next()).toEqual({ value: 2, done: false });
+
+    stream.push(11);
+    expect(await it.next()).toEqual({ value: 11, done: false });
+
+    expect(await it.next()).toEqual({ value: 3, done: false });
+    expect(await it.next()).toEqual({ value: 4, done: false });
+    expect(await it.next()).toEqual({ value: 5, done: false });
+    expect(await it.next()).toEqual({ value: undefined, done: true });
+  });
 });

--- a/packages/eventstream-codec/src/SmithyMessageDecoderStream.ts
+++ b/packages/eventstream-codec/src/SmithyMessageDecoderStream.ts
@@ -12,14 +12,26 @@ export interface SmithyMessageDecoderStreamOptions<T> {
  * @internal
  */
 export class SmithyMessageDecoderStream<T> implements AsyncIterable<T> {
+  private buffer = [] as T[];
   constructor(private readonly options: SmithyMessageDecoderStreamOptions<T>) {}
 
   [Symbol.asyncIterator](): AsyncIterator<T> {
     return this.asyncIterator();
   }
 
+  public unshift(item: T) {
+    this.buffer.unshift(item);
+  }
+
+  public push(item: T) {
+    this.buffer.push(item);
+  }
+
   private async *asyncIterator() {
     for await (const message of this.options.messageStream) {
+      while (this.buffer.length > 0) {
+        yield this.buffer.shift() as Awaited<T>;
+      }
       const deserialized = await this.options.deserializer(message);
       if (deserialized === undefined) continue;
       yield deserialized;

--- a/packages/eventstream-serde-universal/src/bufferInitialResponse.ts
+++ b/packages/eventstream-serde-universal/src/bufferInitialResponse.ts
@@ -10,7 +10,12 @@ import { EventStreamSerdeContext } from "@smithy/types";
  * iterator and the remaining iterations are pass-through to the
  * event stream.
  */
-export async function bufferInitialResponse(field: string, deser: Function, output: any, context: EventStreamSerdeContext) {
+export async function bufferInitialResponse(
+  field: string,
+  deser: Function,
+  output: any,
+  context: EventStreamSerdeContext
+) {
   const contents = { [field]: null as any };
   const controller = deser(output.body, context) as any;
   const it = controller[Symbol.asyncIterator]() as any;

--- a/packages/eventstream-serde-universal/src/bufferInitialResponse.ts
+++ b/packages/eventstream-serde-universal/src/bufferInitialResponse.ts
@@ -1,0 +1,35 @@
+import { EventStreamSerdeContext } from "@smithy/types";
+
+/**
+ * @internal
+ *
+ * Attempts to merge the first event if it is the initial-response event type
+ * into the operation output.
+ *
+ * If it is not the initial-response type, the value is restacked into the
+ * iterator and the remaining iterations are pass-through to the
+ * event stream.
+ */
+export async function bufferInitialResponse(field: string, deser: Function, output: any, context: EventStreamSerdeContext) {
+  const contents = { [field]: null as any };
+  const controller = deser(output.body, context) as any;
+  const it = controller[Symbol.asyncIterator]() as any;
+
+  const initialResponse = (await it.next()) ?? {};
+
+  if ("initial-response" in (initialResponse.value || {})) {
+    Object.assign(contents, initialResponse.value["initial-response"]);
+  } else {
+    controller.push(initialResponse.value);
+  }
+
+  contents[field] = {
+    async *[Symbol.asyncIterator]() {
+      while (!it.done) {
+        yield (await it.next()).value;
+      }
+    },
+  };
+
+  return contents;
+}

--- a/packages/eventstream-serde-universal/src/index.ts
+++ b/packages/eventstream-serde-universal/src/index.ts
@@ -6,3 +6,7 @@ export * from "./EventStreamMarshaller";
  * @internal
  */
 export * from "./provider";
+/**
+ * @internal
+ */
+export * from './bufferInitialResponse';

--- a/packages/eventstream-serde-universal/src/index.ts
+++ b/packages/eventstream-serde-universal/src/index.ts
@@ -9,4 +9,4 @@ export * from "./provider";
 /**
  * @internal
  */
-export * from './bufferInitialResponse';
+export * from "./bufferInitialResponse";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -101,6 +101,7 @@ public enum TypeScriptDependency implements Dependency {
         false),
     AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@smithy/eventstream-serde-node", false),
     AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@smithy/eventstream-serde-browser", false),
+    AWS_SDK_EVENTSTREAM_SERDE_UNIVERSAL("dependencies", "@smithy/eventstream-serde-universal", false),
 
     // Conditionally added if a big decimal shape is found in a model.
     BIG_JS("dependencies", "big.js", "^6.0.0", false),


### PR DESCRIPTION
This adds an eventStream serde helper for checking the first event of an event stream. 

- if the type is `initial-response`, then it is merged into the operation output.
- if the type is not `initial-response`, then it is re-emplaced onto the iterator given to the user.


Additionally, for eventStream deser functions, deserialization of the implicit `initial-response` event is added to the union to avoid ignoring that unmodeled union member.

Note: this behavior is specific to AWS. It should have no effect on JSON eventstreams that do not implement `initial-response`, but there are also no hooks available to override this behavior in AWS SDK TypeScript codegen at the moment.

If non-AWS users want to have members other than the streaming member for the output, this could also be of use to them.