### PR TITLE
feat: paginator factory

### DIFF
--- a/.changeset/big-kings-shop.md
+++ b/.changeset/big-kings-shop.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+add paginator factory

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from "./util-identity-and-auth";
 export * from "./getSmithyContext";
 export * from "./normalizeProvider";
 export * from "./protocols/requestBuilder";
+export { createPaginator } from "./pagination/createPaginator";

--- a/packages/core/src/pagination/createPaginator.ts
+++ b/packages/core/src/pagination/createPaginator.ts
@@ -1,0 +1,58 @@
+import type { Client, PaginationConfiguration, Paginator } from "@smithy/types";
+
+/**
+ * @internal
+ */
+const makePagedClientRequest = async <ClientType extends Client<any, any, any>, InputType, OutputType>(
+  CommandCtor: any,
+  client: ClientType,
+  input: InputType,
+  ...args: any[]
+): Promise<OutputType> => {
+  return await client.send(new CommandCtor(input), ...args);
+};
+
+/**
+ * @internal
+ *
+ * Creates a paginator.
+ */
+export function createPaginator<
+  PaginationConfigType extends PaginationConfiguration,
+  InputType extends object,
+  OutputType extends object
+>(
+  ClientCtor: any,
+  CommandCtor: any,
+  inputTokenName: string,
+  outputTokenName: string,
+  pageSizeTokenName?: string
+): (config: PaginationConfigType, input: InputType, ...additionalArguments: any[]) => Paginator<OutputType> {
+  return async function* paginateOperation(
+    config: PaginationConfigType,
+    input: InputType,
+    ...additionalArguments: any[]
+  ): Paginator<OutputType> {
+    let token: any = config.startingToken || undefined;
+    let hasNext = true;
+    let page: OutputType;
+
+    while (hasNext) {
+      (input as any)[inputTokenName] = token;
+      if (pageSizeTokenName) {
+        (input as any)[pageSizeTokenName] = (input as any)[pageSizeTokenName] ?? config.pageSize;
+      }
+      if (config.client instanceof ClientCtor) {
+        page = await makePagedClientRequest(CommandCtor, config.client, input, ...additionalArguments);
+      } else {
+        throw new Error(`Invalid client, expected instance of ${ClientCtor.name}`);
+      }
+      yield page;
+      const prevToken = token;
+      token = (page as any)[outputTokenName];
+      hasNext = !!(token && (!config.stopOnSameToken || token !== prevToken));
+    }
+    // @ts-ignore
+    return undefined;
+  };
+}


### PR DESCRIPTION
Creates a paginator template function to reduce generated code of paginators.

The `type` returned by the paginator factory is identical to the pre-existing pagination functions. ✅ 

sample diff: https://github.com/aws/aws-sdk-js-v3/pull/5590

before
```js
import { ListFunctionsCommand, } from "../commands/ListFunctionsCommand";
import { LambdaClient } from "../LambdaClient";
const makePagedClientRequest = async (client, input, ...args) => {
    return await client.send(new ListFunctionsCommand(input), ...args);
};
export async function* paginateListFunctions(config, input, ...additionalArguments) {
    let token = config.startingToken || undefined;
    let hasNext = true;
    let page;
    while (hasNext) {
        input.Marker = token;
        input["MaxItems"] = config.pageSize;
        if (config.client instanceof LambdaClient) {
            page = await makePagedClientRequest(config.client, input, ...additionalArguments);
        }
        else {
            throw new Error("Invalid client, expected Lambda | LambdaClient");
        }
        yield page;
        const prevToken = token;
        token = page.NextMarker;
        hasNext = !!(token && (!config.stopOnSameToken || token !== prevToken));
    }
    return undefined;
}
```


after
```js
import { createPaginator } from "@smithy/core";
import { ListFunctionsCommand, } from "../commands/ListFunctionsCommand";
import { LambdaClient } from "../LambdaClient";
export const paginateListFunctions = 
  createPaginator(LambdaClient, ListFunctionsCommand, "Marker", "NextMarker", "MaxItems");

```