### PR TITLE
fix(core): Strict dependency for @smithy/core

### DIFF
--- a/.changeset/soft-scissors-brake.md
+++ b/.changeset/soft-scissors-brake.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix(core): strict core deps

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "@smithy/protocol-http": "workspace:^",
     "@smithy/smithy-client": "workspace:^",
     "@smithy/types": "workspace:^",
+    "@smithy/util-middleware": "workspace:^",
     "tslib": "^2.5.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1781,6 +1781,7 @@ __metadata:
     "@smithy/protocol-http": "workspace:^"
     "@smithy/smithy-client": "workspace:^"
     "@smithy/types": "workspace:^"
+    "@smithy/util-middleware": "workspace:^"
     "@tsconfig/recommended": 1.0.1
     concurrently: 7.0.0
     downlevel-dts: 0.10.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We will make the dependencies of core explicit and tighten them.
This will prevent errors with pnpm.

ref
https://github.com/smithy-lang/smithy-typescript/blob/main/packages/core/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts#L16
https://github.com/smithy-lang/smithy-typescript/blob/main/packages/core/src/middleware-http-signing/httpSigningMiddleware.ts#L13

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
