### PR TITLE
feat: add credential scope field

### DIFF
--- a/.changeset/happy-adults-complain.md
+++ b/.changeset/happy-adults-complain.md
@@ -1,0 +1,6 @@
+---
+"@smithy/middleware-endpoint": minor
+"@smithy/types": minor
+---
+
+support credential scope

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
@@ -20,6 +20,17 @@ describe(createConfigValueProvider.name, () => {
     expect(await createConfigValueProvider("x", "a", config)()).toEqual(1);
   });
 
+  it("uses a special lookup for CredentialScope", async () => {
+    const config = {
+      credentials: async () => {
+        return {
+          credentialScope: "cred-scope",
+        };
+      },
+    };
+    expect(await createConfigValueProvider("credentialScope", "CredentialScope", config)()).toEqual("cred-scope");
+  });
+
   it("should normalize endpoint objects into URLs", async () => {
     const sampleUrl = "https://aws.amazon.com/";
     const config = {

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
@@ -24,6 +24,13 @@ export const createConfigValueProvider = <Config extends Record<string, unknown>
     }
     return configValue;
   };
+  if (configKey === "credentialScope" || canonicalEndpointParamKey === "CredentialScope") {
+    return async () => {
+      const credentials = typeof config.credentials === "function" ? await config.credentials() : config.credentials;
+      const configValue: string = credentials?.credentialScope ?? credentials?.CredentialScope;
+      return configValue;
+    };
+  }
   if (configKey === "endpoint" || canonicalEndpointParamKey === "endpoint") {
     return async () => {
       const endpoint = await configProvider();

--- a/packages/types/src/identity/awsCredentialIdentity.ts
+++ b/packages/types/src/identity/awsCredentialIdentity.ts
@@ -19,6 +19,11 @@ export interface AwsCredentialIdentity extends Identity {
    * present for temporary credentials.
    */
   readonly sessionToken?: string;
+
+  /**
+   * AWS credential scope for this set of credentials.
+   */
+  readonly credentialScope?: string;
 }
 
 /**


### PR DESCRIPTION
- Adds the `credentialScope` field to AWS credentials type
- Modifies the endpoints ruleset resolver to pull credentialScope from config.credentials if requested