### PR TITLE
fix: model bucketing edge case with resource shape

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -463,9 +463,9 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             }
             // Add models into buckets no bigger than chunk size.
             String path;
-            if (shape.getId().equals(UnitTypeTrait.UNIT)) {
-                // Unit should only be put in the zero bucket, since it does not
-                // generate anything. It also does not contribute to bucket size.
+            if (shape.getId().equals(UnitTypeTrait.UNIT) || shape.isResourceShape()) {
+                // Unit or Resource shapes should only be put in the zero bucket, since they do not
+                // generate anything. They also do not contribute to bucket size.
                 path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "models_0");
             } else {
                 path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "models_" + bucketCount);


### PR DESCRIPTION
*Issue:*
Similar to [this issue](https://github.com/smithy-lang/smithy-typescript/pull/714), when a resource shape is the only model assigned to the last bucket, an export statement for the file is included in index.ts, yet the file is never created, as there is no codgen for resources.

```typescript
// smithy-typescript generated code
export * from "./models_0";
export * from "./models_1"; // file doesn't exist
```

*Description of changes:*
- Update SymbolVisitor to always place resource shapes in initial bucket
- Add unit test