### PR TITLE
Add numberSelector utility

### DIFF
--- a/.changeset/forty-stingrays-lay.md
+++ b/.changeset/forty-stingrays-lay.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-config-provider": minor
+---
+
+Add numberSelector utility

--- a/packages/util-config-provider/src/booleanSelector.spec.ts
+++ b/packages/util-config-provider/src/booleanSelector.spec.ts
@@ -1,4 +1,5 @@
-import { booleanSelector, SelectorType } from "./booleanSelector";
+import { booleanSelector } from "./booleanSelector";
+import { SelectorType } from "./types";
 
 describe(booleanSelector.name, () => {
   const key = "key";

--- a/packages/util-config-provider/src/booleanSelector.ts
+++ b/packages/util-config-provider/src/booleanSelector.ts
@@ -1,7 +1,4 @@
-export enum SelectorType {
-  ENV = "env",
-  CONFIG = "shared config entry",
-}
+import { SelectorType } from "./types";
 
 /**
  * Returns boolean value true/false for string value "true"/"false",

--- a/packages/util-config-provider/src/index.ts
+++ b/packages/util-config-provider/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./booleanSelector";
+export * from "./numberSelector";
+export * from "./types";

--- a/packages/util-config-provider/src/numberSelector.spec.ts
+++ b/packages/util-config-provider/src/numberSelector.spec.ts
@@ -1,0 +1,32 @@
+import { numberSelector } from "./numberSelector";
+import { SelectorType } from "./types";
+
+describe(numberSelector.name, () => {
+  const key = "key";
+  const obj: { [key]: any } = {} as any;
+
+  describe.each(Object.entries(SelectorType))(`Selector %s`, (selectorKey, selectorValue) => {
+    beforeEach(() => {
+      delete obj[key];
+    });
+
+    it(`should return undefined if ${key} is not defined`, () => {
+      expect(numberSelector(obj, key, SelectorType[selectorKey])).toBeUndefined();
+    });
+
+    it.each([
+      [0, "0"],
+      [1, "1"],
+    ])(`should return number %s if ${key}="%s"`, (output, input) => {
+      obj[key] = input;
+      expect(numberSelector(obj, key, SelectorType[selectorKey])).toBe(output);
+    });
+
+    it.each(["yes", "no", undefined, null, void 0, ""])(`should throw if ${key}=%s`, (input) => {
+      obj[key] = input;
+      expect(() => numberSelector(obj, key, SelectorType[selectorKey])).toThrow(
+        new TypeError(`Cannot load ${selectorValue} '${key}'. Expected number, got '${obj[key]}'.`)
+      );
+    });
+  });
+});

--- a/packages/util-config-provider/src/numberSelector.ts
+++ b/packages/util-config-provider/src/numberSelector.ts
@@ -1,0 +1,19 @@
+import { SelectorType } from "./types";
+
+/**
+ * Returns number value for string value, if the string is defined in obj[key].
+ * Returns undefined, if obj[key] is not defined.
+ * Throws error for all other cases.
+ *
+ * @internal
+ */
+export const numberSelector = (obj: Record<string, string | undefined>, key: string, type: SelectorType) => {
+  if (!(key in obj)) return undefined;
+
+  const numberValue = parseInt(obj[key] as string, 10);
+  if (Number.isNaN(numberValue)) {
+    throw new TypeError(`Cannot load ${type} '${key}'. Expected number, got '${obj[key]}'.`);
+  }
+
+  return numberValue;
+};

--- a/packages/util-config-provider/src/types.ts
+++ b/packages/util-config-provider/src/types.ts
@@ -1,0 +1,4 @@
+export enum SelectorType {
+  ENV = "env",
+  CONFIG = "shared config entry",
+}


### PR DESCRIPTION
*Issue #, if available:*
* Currently used in NODE_MAX_ATTEMPT_CONFIG_OPTIONS https://github.com/smithy-lang/smithy-typescript/blob/2df620b6882388ce4773eb4ea5a012eb44b001f8/packages/middleware-retry/src/configurations.ts#L15-L35
* Required in https://github.com/aws/aws-sdk-js-v3/pull/5618

*Description of changes:*

Add numberSelector utility in util-config-selector

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
