### PR TITLE
Accept Provider in CompressionInputConfig

### DIFF
--- a/.changeset/bright-elephants-walk.md
+++ b/.changeset/bright-elephants-walk.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-compression": patch
+---
+
+Accept Provider in CompressionInputConfig

--- a/packages/middleware-compression/package.json
+++ b/packages/middleware-compression/package.json
@@ -18,6 +18,7 @@
     "@smithy/node-config-provider": "workspace:^",
     "@smithy/types": "workspace:^",
     "@smithy/util-config-provider": "workspace:^",
+    "@smithy/util-middleware": "workspace:^",
     "fflate": "0.8.1",
     "tslib": "^2.5.0"
   },

--- a/packages/middleware-compression/src/compressionMiddleware.spec.ts
+++ b/packages/middleware-compression/src/compressionMiddleware.spec.ts
@@ -15,8 +15,8 @@ describe(compressionMiddleware.name, () => {
   const mockBody = "body";
   const mockConfig = {
     bodyLengthChecker: jest.fn().mockReturnValue(mockBody.length),
-    disableRequestCompression: false,
-    requestMinCompressionSizeBytes: 0,
+    disableRequestCompression: () => Promise.resolve(false),
+    requestMinCompressionSizeBytes: () => Promise.resolve(0),
   };
   const mockMiddlewareConfig = {
     encodings: [CompressionAlgorithm.GZIP],
@@ -32,7 +32,7 @@ describe(compressionMiddleware.name, () => {
 
   it("skips compression if it's not an HttpRequest", async () => {
     const { isInstance } = HttpRequest;
-    (isInstance as unknown as jest.Mock).mockReturnValue(false);
+    ((isInstance as unknown) as jest.Mock).mockReturnValue(false);
     await compressionMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext)({ ...mockArgs } as any);
     expect(mockNext).toHaveBeenCalledWith(mockArgs);
   });
@@ -40,12 +40,15 @@ describe(compressionMiddleware.name, () => {
   describe("HttpRequest", () => {
     beforeEach(() => {
       const { isInstance } = HttpRequest;
-      (isInstance as unknown as jest.Mock).mockReturnValue(true);
+      ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
       (isStreaming as jest.Mock).mockReturnValue(false);
     });
 
     it("skips compression if disabled", async () => {
-      await compressionMiddleware({ ...mockConfig, disableRequestCompression: true }, mockMiddlewareConfig)(
+      await compressionMiddleware(
+        { ...mockConfig, disableRequestCompression: () => Promise.resolve(true) },
+        mockMiddlewareConfig
+      )(
         mockNext,
         mockContext
       )({ ...mockArgs } as any);
@@ -107,7 +110,7 @@ describe(compressionMiddleware.name, () => {
     describe("not streaming", () => {
       it("skips compression if body is smaller than min size", async () => {
         await compressionMiddleware(
-          { ...mockConfig, requestMinCompressionSizeBytes: mockBody.length + 1 },
+          { ...mockConfig, requestMinCompressionSizeBytes: () => Promise.resolve(mockBody.length + 1) },
           mockMiddlewareConfig
         )(
           mockNext,

--- a/packages/middleware-compression/src/compressionMiddleware.spec.ts
+++ b/packages/middleware-compression/src/compressionMiddleware.spec.ts
@@ -15,8 +15,8 @@ describe(compressionMiddleware.name, () => {
   const mockBody = "body";
   const mockConfig = {
     bodyLengthChecker: jest.fn().mockReturnValue(mockBody.length),
-    disableRequestCompression: () => Promise.resolve(false),
-    requestMinCompressionSizeBytes: () => Promise.resolve(0),
+    disableRequestCompression: async () => false,
+    requestMinCompressionSizeBytes: async () => 0,
   };
   const mockMiddlewareConfig = {
     encodings: [CompressionAlgorithm.GZIP],
@@ -45,10 +45,7 @@ describe(compressionMiddleware.name, () => {
     });
 
     it("skips compression if disabled", async () => {
-      await compressionMiddleware(
-        { ...mockConfig, disableRequestCompression: () => Promise.resolve(true) },
-        mockMiddlewareConfig
-      )(
+      await compressionMiddleware({ ...mockConfig, disableRequestCompression: async () => true }, mockMiddlewareConfig)(
         mockNext,
         mockContext
       )({ ...mockArgs } as any);
@@ -110,7 +107,7 @@ describe(compressionMiddleware.name, () => {
     describe("not streaming", () => {
       it("skips compression if body is smaller than min size", async () => {
         await compressionMiddleware(
-          { ...mockConfig, requestMinCompressionSizeBytes: () => Promise.resolve(mockBody.length + 1) },
+          { ...mockConfig, requestMinCompressionSizeBytes: async () => mockBody.length + 1 },
           mockMiddlewareConfig
         )(
           mockNext,

--- a/packages/middleware-compression/src/configurations.ts
+++ b/packages/middleware-compression/src/configurations.ts
@@ -1,27 +1,42 @@
-import { BodyLengthCalculator } from "@smithy/types";
+import { BodyLengthCalculator, Provider } from "@smithy/types";
 
 /**
  * @public
  */
 export interface CompressionInputConfig {
   /**
-   * A function that can calculate the length of a body.
-   */
-  bodyLengthChecker: BodyLengthCalculator;
-
-  /**
    * Whether to disable request compression.
    */
-  disableRequestCompression: boolean;
+  disableRequestCompression: boolean | Provider<boolean>;
 
   /**
    * The minimum size in bytes that a request body should be to trigger compression.
    * The value must be a non-negative integer value between 0 and 10485760 bytes inclusive.
    */
-  requestMinCompressionSizeBytes: number;
+  requestMinCompressionSizeBytes: number | Provider<number>;
 }
 
 /**
  * @internal
  */
-export interface CompressionResolvedConfig extends CompressionInputConfig {}
+export interface CompressionPreviouslyResolved {
+  /**
+   * A function that can calculate the length of a body.
+   */
+  bodyLengthChecker: BodyLengthCalculator;
+}
+
+/**
+ * @internal
+ */
+export interface CompressionResolvedConfig {
+  /**
+   * Resolved value for input config {@link CompressionInputConfig.disableRequestCompression}
+   */
+  disableRequestCompression: Provider<boolean>;
+
+  /**
+   * Resolved value for input config {@link CompressionInputConfig.requestMinCompressionSizeBytes}
+   */
+  requestMinCompressionSizeBytes: Provider<number>;
+}

--- a/packages/middleware-compression/src/getCompressionPlugin.spec.ts
+++ b/packages/middleware-compression/src/getCompressionPlugin.spec.ts
@@ -6,8 +6,8 @@ jest.mock("./compressionMiddleware");
 describe(getCompressionPlugin.name, () => {
   const config = {
     bodyLengthChecker: jest.fn(),
-    disableRequestCompression: false,
-    requestMinCompressionSizeBytes: 0,
+    disableRequestCompression: () => Promise.resolve(false),
+    requestMinCompressionSizeBytes: () => Promise.resolve(0),
   };
   const middlewareConfig = { encodings: [] };
 

--- a/packages/middleware-compression/src/getCompressionPlugin.spec.ts
+++ b/packages/middleware-compression/src/getCompressionPlugin.spec.ts
@@ -6,8 +6,8 @@ jest.mock("./compressionMiddleware");
 describe(getCompressionPlugin.name, () => {
   const config = {
     bodyLengthChecker: jest.fn(),
-    disableRequestCompression: () => Promise.resolve(false),
-    requestMinCompressionSizeBytes: () => Promise.resolve(0),
+    disableRequestCompression: async () => false,
+    requestMinCompressionSizeBytes: async () => 0,
   };
   const middlewareConfig = { encodings: [] };
 

--- a/packages/middleware-compression/src/getCompressionPlugin.ts
+++ b/packages/middleware-compression/src/getCompressionPlugin.ts
@@ -5,13 +5,13 @@ import {
   CompressionMiddlewareConfig,
   compressionMiddlewareOptions,
 } from "./compressionMiddleware";
-import { CompressionResolvedConfig } from "./configurations";
+import { CompressionPreviouslyResolved, CompressionResolvedConfig } from "./configurations";
 
 /**
  * @internal
  */
 export const getCompressionPlugin = (
-  config: CompressionResolvedConfig,
+  config: CompressionResolvedConfig & CompressionPreviouslyResolved,
   middlewareConfig: CompressionMiddlewareConfig
 ): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {

--- a/packages/middleware-compression/src/resolveCompressionConfig.spec.ts
+++ b/packages/middleware-compression/src/resolveCompressionConfig.spec.ts
@@ -6,11 +6,11 @@ describe(resolveCompressionConfig.name, () => {
     disableRequestCompression: false,
     requestMinCompressionSizeBytes: 0,
   };
-  it("should throw an error if requestMinCompressionSizeBytes is less than 0", () => {
+
+  it("should throw an error if requestMinCompressionSizeBytes is less than 0", async () => {
     const requestMinCompressionSizeBytes = -1;
-    expect(() => {
-      resolveCompressionConfig({ ...mockConfig, requestMinCompressionSizeBytes });
-    }).toThrow(
+    const resolvedConfig = resolveCompressionConfig({ ...mockConfig, requestMinCompressionSizeBytes });
+    await expect(resolvedConfig.requestMinCompressionSizeBytes()).rejects.toThrow(
       new RangeError(
         "The value for requestMinCompressionSizeBytes must be between 0 and 10485760 inclusive. " +
           `The provided value ${requestMinCompressionSizeBytes} is outside this range."`
@@ -18,11 +18,10 @@ describe(resolveCompressionConfig.name, () => {
     );
   });
 
-  it("should throw an error if requestMinCompressionSizeBytes is greater than 10485760", () => {
+  it("should throw an error if requestMinCompressionSizeBytes is greater than 10485760", async () => {
     const requestMinCompressionSizeBytes = 10485761;
-    expect(() => {
-      resolveCompressionConfig({ ...mockConfig, requestMinCompressionSizeBytes });
-    }).toThrow(
+    const resolvedConfig = resolveCompressionConfig({ ...mockConfig, requestMinCompressionSizeBytes });
+    await expect(resolvedConfig.requestMinCompressionSizeBytes()).rejects.toThrow(
       new RangeError(
         "The value for requestMinCompressionSizeBytes must be between 0 and 10485760 inclusive. " +
           `The provided value ${requestMinCompressionSizeBytes} is outside this range."`
@@ -30,15 +29,18 @@ describe(resolveCompressionConfig.name, () => {
     );
   });
 
-  it.each([0, 10240, 10485760])("returns requestMinCompressionSizeBytes value %s", (requestMinCompressionSizeBytes) => {
-    const inputConfig = { ...mockConfig, requestMinCompressionSizeBytes };
-    const resolvedConfig = resolveCompressionConfig(inputConfig);
-    expect(inputConfig).toEqual(resolvedConfig);
-  });
+  it.each([0, 10240, 10485760])(
+    "returns requestMinCompressionSizeBytes value %s",
+    async (requestMinCompressionSizeBytes) => {
+      const inputConfig = { ...mockConfig, requestMinCompressionSizeBytes };
+      const resolvedConfig = resolveCompressionConfig(inputConfig);
+      await expect(resolvedConfig.requestMinCompressionSizeBytes()).resolves.toEqual(requestMinCompressionSizeBytes);
+    }
+  );
 
-  it.each([false, true])("returns disableRequestCompression value %s", (disableRequestCompression) => {
+  it.each([false, true])("returns disableRequestCompression value %s", async (disableRequestCompression) => {
     const inputConfig = { ...mockConfig, disableRequestCompression };
     const resolvedConfig = resolveCompressionConfig(inputConfig);
-    expect(inputConfig).toEqual(resolvedConfig);
+    await expect(resolvedConfig.disableRequestCompression()).resolves.toEqual(disableRequestCompression);
   });
 });

--- a/packages/middleware-compression/src/resolveCompressionConfig.ts
+++ b/packages/middleware-compression/src/resolveCompressionConfig.ts
@@ -1,19 +1,12 @@
+import { normalizeProvider } from "@smithy/util-middleware";
+
 import { CompressionInputConfig, CompressionResolvedConfig } from "./configurations";
 
 /**
  * @internal
  */
-export const resolveCompressionConfig = <T>(input: T & CompressionInputConfig): T & CompressionResolvedConfig => {
-  const { requestMinCompressionSizeBytes } = input;
-
-  // The requestMinCompressionSizeBytes should be less than the upper limit for API Gateway
-  // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-openapi-minimum-compression-size.html
-  if (requestMinCompressionSizeBytes < 0 || requestMinCompressionSizeBytes > 10485760) {
-    throw new RangeError(
-      "The value for requestMinCompressionSizeBytes must be between 0 and 10485760 inclusive. " +
-        `The provided value ${requestMinCompressionSizeBytes} is outside this range."`
-    );
-  }
-
-  return input;
-};
+export const resolveCompressionConfig = <T>(input: T & CompressionInputConfig): T & CompressionResolvedConfig => ({
+  ...input,
+  disableRequestCompression: normalizeProvider(input.disableRequestCompression),
+  requestMinCompressionSizeBytes: normalizeProvider(input.requestMinCompressionSizeBytes),
+});

--- a/packages/middleware-compression/src/resolveCompressionConfig.ts
+++ b/packages/middleware-compression/src/resolveCompressionConfig.ts
@@ -8,5 +8,18 @@ import { CompressionInputConfig, CompressionResolvedConfig } from "./configurati
 export const resolveCompressionConfig = <T>(input: T & CompressionInputConfig): T & CompressionResolvedConfig => ({
   ...input,
   disableRequestCompression: normalizeProvider(input.disableRequestCompression),
-  requestMinCompressionSizeBytes: normalizeProvider(input.requestMinCompressionSizeBytes),
+  requestMinCompressionSizeBytes: async () => {
+    const requestMinCompressionSizeBytes = await normalizeProvider(input.requestMinCompressionSizeBytes)();
+
+    // The requestMinCompressionSizeBytes should be less than the upper limit for API Gateway
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-openapi-minimum-compression-size.html
+    if (requestMinCompressionSizeBytes < 0 || requestMinCompressionSizeBytes > 10485760) {
+      throw new RangeError(
+        "The value for requestMinCompressionSizeBytes must be between 0 and 10485760 inclusive. " +
+          `The provided value ${requestMinCompressionSizeBytes} is outside this range."`
+      );
+    }
+
+    return requestMinCompressionSizeBytes;
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,6 +2085,7 @@ __metadata:
     "@smithy/node-config-provider": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/util-config-provider": "workspace:^"
+    "@smithy/util-middleware": "workspace:^"
     "@tsconfig/recommended": 1.0.1
     concurrently: 7.0.0
     downlevel-dts: 0.10.1


### PR DESCRIPTION
*Issue #, if available:*
Noticed while doing E2E testing in https://github.com/aws/aws-sdk-js-v3/pull/5625

*Description of changes:*
Accept Provider in CompressionInputConfig

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
