### PR TITLE
Make CompressionInputConfig properties optional

### DIFF
--- a/.changeset/nice-pumas-collect.md
+++ b/.changeset/nice-pumas-collect.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-compression": patch
+---
+
+Make CompressionInputConfig properties optional

--- a/packages/middleware-compression/src/configurations.ts
+++ b/packages/middleware-compression/src/configurations.ts
@@ -7,13 +7,13 @@ export interface CompressionInputConfig {
   /**
    * Whether to disable request compression.
    */
-  disableRequestCompression: boolean | Provider<boolean>;
+  disableRequestCompression?: boolean | Provider<boolean>;
 
   /**
    * The minimum size in bytes that a request body should be to trigger compression.
    * The value must be a non-negative integer value between 0 and 10485760 bytes inclusive.
    */
-  requestMinCompressionSizeBytes: number | Provider<number>;
+  requestMinCompressionSizeBytes?: number | Provider<number>;
 }
 
 /**

--- a/packages/middleware-compression/src/resolveCompressionConfig.ts
+++ b/packages/middleware-compression/src/resolveCompressionConfig.ts
@@ -5,7 +5,9 @@ import { CompressionInputConfig, CompressionResolvedConfig } from "./configurati
 /**
  * @internal
  */
-export const resolveCompressionConfig = <T>(input: T & CompressionInputConfig): T & CompressionResolvedConfig => ({
+export const resolveCompressionConfig = <T>(
+  input: T & Required<CompressionInputConfig>
+): T & CompressionResolvedConfig => ({
   ...input,
   disableRequestCompression: normalizeProvider(input.disableRequestCompression),
   requestMinCompressionSizeBytes: async () => {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/5643#issuecomment-1877397637

*Description of changes:*
Make CompressionInputConfig properties optional
* The properties need to be optional, as they don't need to be passed during client creation.
* The properties need to be required during resolution, since they're resolved by runtimeConfig.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
