### PR TITLE
chore: only unit test changed packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
     name: TypeScript Test
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Run unit tests
-        run: yarn test
+        run: yarn test:changed
       - name: Run integration tests
         run: |
           yarn config set enableImmutableInstalls false

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "turbo run clean --force --parallel",
     "build": "turbo run build",
     "test": "turbo run test",
-    "test:changed": "turbo run test --filter=\\[origin/main\\]",
+    "test:changed": "git fetch origin main && turbo run test --filter=\\[origin/main\\]",
     "test:integration": "yarn build-test-packages && turbo run test:integration",
     "lint": "turbo run lint",
     "lint-fix": "turbo run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clean": "turbo run clean --force --parallel",
     "build": "turbo run build",
     "test": "turbo run test",
+    "test:changed": "turbo run test --filter=\\[origin/main\\]",
     "test:integration": "yarn build-test-packages && turbo run test:integration",
     "lint": "turbo run lint",
     "lint-fix": "turbo run lint -- --fix",

--- a/turbo.json
+++ b/turbo.json
@@ -5,10 +5,10 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["src/**/*", "package.json"],
-      "outputs": ["dist-types/**", "dist-cjs/**", "dist-es/**"]
+      "outputs": ["dist-types/**/*", "dist-cjs/**/*", "dist-es/**/*"]
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "outputs": []
     },
     "test:integration": {


### PR DESCRIPTION
the md5 unit test keeps crashing (OOM) the test runner 🤕, let's just run unit tests in changed packages