### PR TITLE
feat(credential-provider-imds): support ECS and EKS credential uris

### DIFF
--- a/.changeset/silent-ears-film.md
+++ b/.changeset/silent-ears-film.md
@@ -1,0 +1,5 @@
+---
+"@smithy/credential-provider-imds": minor
+---
+
+Support for ECS and EKS credential URI overrides, enabling the use of EKS Pod Identities on EKS

--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -59,6 +59,9 @@ const CMDS_IP = "169.254.170.2";
 const GREENGRASS_HOSTS = {
   localhost: true,
   "127.0.0.1": true,
+  "169.254.170.2": true, // IPv4 address for the ECS container
+  "169.254.170.23": true, // IPv4 address for the EKS container
+  "fd00:ec2::23": true, // IPv6 address for the EKS container
 };
 const GREENGRASS_PROTOCOLS = {
   "http:": true,


### PR DESCRIPTION
closes #1143

I added more allowed hostnames for the `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variable. These allowed hostnames match the ones allowed by the official Go SDK. See: https://github.com/aws/aws-sdk-go-v2/blob/a7db10670faedd542dc92cec6d0c602e5315a3a9/config/resolve_credentials.go#L33-L52

Note that I have not tried deploying an app to EKS with this build of `@smithy/credential-provider-imds`, so I do not know for certain if this is the only issue that is preventing the use of [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) on EKS.