### PR TITLE
feat: endpoint caching

### DIFF
--- a/.changeset/silly-deers-divide.md
+++ b/.changeset/silly-deers-divide.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": minor
+---
+
+add endpoint resolver cache

--- a/packages/util-endpoints/src/EndpointResolverCache.spec.ts
+++ b/packages/util-endpoints/src/EndpointResolverCache.spec.ts
@@ -1,0 +1,57 @@
+import { EndpointResolverCache } from "./EndpointResolverCache";
+
+describe(EndpointResolverCache.name, () => {
+  it("can generate string keys", () => {
+    const cache = new EndpointResolverCache();
+    const key = cache.key({
+      a: "a",
+      b: false,
+    });
+    expect(key).toEqual("a=(string)a,b=(boolean)false,");
+  });
+
+  it("can write and retrieve entries", () => {
+    const dummyEndpoint = {} as any;
+    const cache = new EndpointResolverCache();
+    cache.set("a", dummyEndpoint);
+    expect(cache.get("a")).toBe(dummyEndpoint);
+    expect(cache.get("a")).toBe(dummyEndpoint);
+    expect(cache.get("b")).toBeUndefined();
+  });
+
+  it("maintains a maximum capacity", () => {
+    const dummyEndpoint = {} as any;
+    const cache = new EndpointResolverCache(3);
+    cache.set("a", dummyEndpoint);
+    cache.set("b", dummyEndpoint);
+    cache.set("c", dummyEndpoint);
+    cache.set("d", dummyEndpoint);
+    cache.set("e", dummyEndpoint);
+    cache.set("f", dummyEndpoint);
+
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("c")).toBeUndefined();
+    expect(cache.get("d")).toBe(dummyEndpoint);
+    expect(cache.get("e")).toBe(dummyEndpoint);
+    expect(cache.get("f")).toBe(dummyEndpoint);
+  });
+
+  it("can be cleared", () => {
+    const dummyEndpoint = {} as any;
+    const cache = new EndpointResolverCache(3);
+    cache.set("a", dummyEndpoint);
+    cache.set("b", dummyEndpoint);
+    cache.set("c", dummyEndpoint);
+    cache.set("d", dummyEndpoint);
+    cache.set("e", dummyEndpoint);
+    cache.set("f", dummyEndpoint);
+    cache.clear();
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("c")).toBeUndefined();
+    expect(cache.get("d")).toBeUndefined();
+    expect(cache.get("e")).toBeUndefined();
+    expect(cache.get("f")).toBeUndefined();
+  });
+});

--- a/packages/util-endpoints/src/EndpointResolverCache.ts
+++ b/packages/util-endpoints/src/EndpointResolverCache.ts
@@ -1,0 +1,90 @@
+import type { EndpointParams, EndpointV2, RuleSetObject } from "@smithy/types";
+
+/**
+ * @internal
+ *
+ * Used by the resolveEndpoint function.
+ */
+export class EndpointResolverCache {
+  private static rulesetMap = new Map<RuleSetObject, EndpointResolverCache>();
+  private store = new Map<string, EndpointV2>();
+
+  public constructor(
+    /**
+     * Desired maximum number of entries in the cache.
+     */
+    public capacity: number = 100
+  ) {}
+
+  /**
+   * @returns the instance associated with a particular ruleset object.
+   */
+  public static forRuleset(ruleset: RuleSetObject): EndpointResolverCache {
+    if (!EndpointResolverCache.rulesetMap.get(ruleset)) {
+      EndpointResolverCache.rulesetMap.set(ruleset, new EndpointResolverCache());
+    }
+    return EndpointResolverCache.rulesetMap.get(ruleset)!;
+  }
+
+  /**
+   * Clear all registered instances and their caches.
+   */
+  public static clearAll(): void {
+    for (const [, cache] of EndpointResolverCache.rulesetMap) {
+      cache.clear();
+    }
+    EndpointResolverCache.rulesetMap.clear();
+  }
+
+  /**
+   * Create a cache key.
+   */
+  public key(endpointParams: EndpointParams): string {
+    let buffer = "";
+    for (const key in endpointParams) {
+      buffer += key;
+      buffer += `=(${typeof endpointParams[key]})`;
+      buffer += endpointParams[key];
+      buffer += ",";
+    }
+    return buffer;
+  }
+
+  /**
+   * Read from the cache.
+   */
+  public get(key: string): EndpointV2 | undefined {
+    return this.store.get(key);
+  }
+
+  /**
+   * Write to the cache.
+   */
+  public set(key: string, endpoint: EndpointV2): void {
+    this.store.set(key, endpoint);
+    this.trim();
+  }
+
+  /**
+   * Remove items from the cache until capacity is
+   * within the limit.
+   */
+  public trim(): void {
+    if (this.store.size <= this.capacity) {
+      return;
+    }
+    for (const [key] of this.store) {
+      this.store.delete(key);
+      if (this.store.size <= this.capacity) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Clear the cache.
+   */
+  public clear(): void {
+    this.store.clear();
+  }
+}

--- a/packages/util-endpoints/src/resolveEndpoint.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.spec.ts
@@ -1,3 +1,4 @@
+import { EndpointResolverCache } from "./EndpointResolverCache";
 import { resolveEndpoint } from "./resolveEndpoint";
 import { EndpointError, EndpointParams, ParameterObject, RuleSetObject } from "./types";
 import { evaluateRules } from "./utils";
@@ -45,6 +46,7 @@ describe(resolveEndpoint.name, () => {
   const mockResolvedEndpoint = { url: new URL("http://example.com") };
 
   beforeEach(() => {
+    EndpointResolverCache.clearAll();
     (evaluateRules as jest.Mock).mockReturnValue(mockResolvedEndpoint);
   });
 


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/5723

this PR adds a cache for the `resolveEndpoint` function keyed on two levels, the ruleset object as a first key and the endpoint parameters as the second key.  

This makes resolving endpoints repeatedly, such as when generating multiple signed URLs, faster. 

The expected effect on endpoint resolution with a cache hit is 1-5ms (depending on hardware) to <0.5ms. 