### PR TITLE
fix: handle multi-part token paths in paginator

### DIFF
--- a/.changeset/four-steaks-sip.md
+++ b/.changeset/four-steaks-sip.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+handle multi-part input token in paginator

--- a/packages/core/src/pagination/createPaginator.spec.ts
+++ b/packages/core/src/pagination/createPaginator.spec.ts
@@ -1,0 +1,114 @@
+import { PaginationConfiguration } from "@smithy/types";
+
+import { createPaginator } from "./createPaginator";
+
+describe(createPaginator.name, () => {
+  class Client {
+    private pages = 5;
+    async send(command: CommandObjectToken | CommandStringToken) {
+      if (--this.pages > 0) {
+        return {
+          outToken: {
+            outToken2: {
+              outToken3: "TOKEN_VALUE",
+            },
+          },
+        };
+      }
+      return {};
+    }
+  }
+  class CommandObjectToken {
+    public constructor(public input: any) {
+      expect(input).toEqual({
+        sizeToken: 100,
+        inToken: {
+          outToken2: {
+            outToken3: "TOKEN_VALUE",
+          },
+        },
+      });
+    }
+  }
+
+  class CommandStringToken {
+    public constructor(public input: any) {
+      expect(input).toEqual({
+        sizeToken: 100,
+        inToken: "TOKEN_VALUE",
+      });
+    }
+  }
+
+  it("should create a paginator", async () => {
+    const paginate = createPaginator<PaginationConfiguration, { inToken?: string }, { outToken: string }>(
+      Client,
+      CommandObjectToken,
+      "inToken",
+      "outToken",
+      "sizeToken"
+    );
+
+    let pages = 0;
+
+    for await (const page of paginate(
+      {
+        client: new Client() as any,
+        pageSize: 100,
+        startingToken: {
+          outToken2: {
+            outToken3: "TOKEN_VALUE",
+          },
+        },
+      },
+      {}
+    )) {
+      pages += 1;
+      if (pages === 5) {
+        expect(page.outToken).toBeUndefined();
+      } else {
+        expect(page.outToken).toEqual({
+          outToken2: {
+            outToken3: "TOKEN_VALUE",
+          },
+        });
+      }
+    }
+
+    expect(pages).toEqual(5);
+  });
+
+  it("should handle deep paths", async () => {
+    const paginate = createPaginator<
+      PaginationConfiguration,
+      { inToken?: string },
+      {
+        outToken: {
+          outToken2: {
+            outToken3: string;
+          };
+        };
+      }
+    >(Client, CommandStringToken, "inToken", "outToken.outToken2.outToken3", "sizeToken");
+
+    let pages = 0;
+
+    for await (const page of paginate(
+      {
+        client: new Client() as any,
+        pageSize: 100,
+        startingToken: "TOKEN_VALUE",
+      },
+      {}
+    )) {
+      pages += 1;
+      if (pages === 5) {
+        expect(page.outToken).toBeUndefined();
+      } else {
+        expect(page.outToken.outToken2.outToken3).toEqual("TOKEN_VALUE");
+      }
+    }
+
+    expect(pages).toEqual(5);
+  });
+});

--- a/packages/core/src/pagination/createPaginator.ts
+++ b/packages/core/src/pagination/createPaginator.ts
@@ -49,10 +49,25 @@ export function createPaginator<
       }
       yield page;
       const prevToken = token;
-      token = (page as any)[outputTokenName];
+      token = get(page, outputTokenName);
       hasNext = !!(token && (!config.stopOnSameToken || token !== prevToken));
     }
     // @ts-ignore
     return undefined;
   };
 }
+
+/**
+ * @internal
+ */
+const get = (fromObject: any, path: string): any => {
+  let cursor = fromObject;
+  const pathComponents = path.split(".");
+  for (const step of pathComponents) {
+    if (!cursor || typeof cursor !== "object") {
+      return undefined;
+    }
+    cursor = cursor[step];
+  }
+  return cursor;
+};


### PR DESCRIPTION
fixes https://github.com/aws/aws-sdk-js-v3/issues/5766

In the conversion to the `createPaginator` function, the handling of deep paths was lost. This bug affects 9 paginator functions in CloudFront, Elasticache, Neptune, RDS, and Redshift, out of a total of 2776.