### PR TITLE
feat: add checked socket exhaustion warning when throughput is slow

### DIFF
--- a/.changeset/lazy-elephants-hope.md
+++ b/.changeset/lazy-elephants-hope.md
@@ -1,0 +1,6 @@
+---
+"@smithy/node-http-handler": minor
+"@smithy/types": minor
+---
+
+add socket exhaustion checked warning to node-http-handler

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -741,7 +741,8 @@ describe("NodeHttpHandler", () => {
       expect(console.warn).toHaveBeenCalledWith(
         "@smithy/node-http-handler:WARN",
         "socket usage at capacity=2 and 4 additional requests are enqueued.",
-        "See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html"
+        "See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html",
+        "or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler config."
       );
     });
   });

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -720,10 +720,18 @@ describe("NodeHttpHandler", () => {
         {
           maxSockets: 2,
           sockets: {
-            addr: [null, null],
+            addr: [],
+            addr2: [null],
+            addr3: [null, null],
+            // this is not checked because an earlier addr causes the warning to be emitted.
+            addr4: Array.from({ length: 400 }),
           },
           requests: {
-            addr: [null, null, null, null],
+            addr: Array.from({ length: 0 }),
+            addr2: Array.from({ length: 3 }),
+            addr3: Array.from({ length: 4 }),
+            // this is not checked because an earlier addr causes the warning to be emitted.
+            addr4: Array.from({ length: 800 }),
           },
         } as any,
         lastTimestamp

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -704,4 +704,37 @@ describe("NodeHttpHandler", () => {
       expect(nodeHttpHandler.httpHandlerConfigs()).toEqual({});
     });
   });
+
+  describe("checkSocketUsage", () => {
+    beforeEach(() => {
+      jest.spyOn(console, "warn").mockImplementation(jest.fn());
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it("warns when socket exhaustion is detected", async () => {
+      const lastTimestamp = Date.now() - 30_000;
+      const warningTimestamp = NodeHttpHandler.checkSocketUsage(
+        {
+          maxSockets: 2,
+          sockets: {
+            addr: [null, null],
+          },
+          requests: {
+            addr: [null, null, null, null],
+          },
+        } as any,
+        lastTimestamp
+      );
+
+      expect(warningTimestamp).toBeGreaterThan(lastTimestamp);
+      expect(console.warn).toHaveBeenCalledWith(
+        "@smithy/node-http-handler:WARN",
+        "socket usage at capacity=2 and 4 additional requests are enqueued.",
+        "See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html"
+      );
+    });
+  });
 });

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -85,7 +85,8 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
           console.warn(
             "@smithy/node-http-handler:WARN",
             `socket usage at capacity=${socketsInUse} and ${requestsEnqueued} additional requests are enqueued.`,
-            "See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html"
+            "See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html",
+            "or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler config."
           );
           return Date.now();
         }

--- a/packages/types/src/http/httpHandlerInitialization.ts
+++ b/packages/types/src/http/httpHandlerInitialization.ts
@@ -35,6 +35,15 @@ export interface NodeHttpHandlerOptions {
   requestTimeout?: number;
 
   /**
+   * Delay before the NodeHttpHandler checks for socket exhaustion,
+   * and emits a warning if the active sockets and enqueued request count is greater than
+   * 2x the maxSockets count.
+   *
+   * Defaults to connectionTimeout + requestTimeout or 3000ms if those are not set.
+   */
+  socketAcquisitionWarningTimeout?: number;
+
+  /**
    * @deprecated Use {@link requestTimeout}
    *
    * The maximum time in milliseconds that a socket may remain idle before it


### PR DESCRIPTION
Addresses https://github.com/aws/aws-sdk-js-v3/issues/3560

This PR adds a warning:
```
@smithy/node-http-handler:WARN socket usage at capacity=<X> and <Y> additional 
requests are enqueued. 
See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html
```

Where `X` is the configured maxSockets for the Node http(s) agent, and `Y` is the number of open requests. 

This warning is emitted in the following situation:

- a request is taking more than `socketAcquisitionWarningTimeout ?? connectTimeout + requestTimeout` to complete.
  - indicates delay in acquiring a socket
- no similar warning has been emitted in the last 15 seconds.
  - prevent log spam
- the number of active sockets is equal to `maxSockets`
  - indicates socket saturation
- the number of enqueued requests is greater than or equal to 2x `maxSockets`
  - indicates socket saturation

Notes:
- it's easy to reach the maxSocket limit even in normal usage. This is why we can't immediately emit the warning on reaching the limit. 
- this is why the PR uses a timeout function, and only when there is a backed up queue of requests both in timing and in request count is a warning emitted.