### PR TITLE
feat: allow http(s).Agent ctor arg in lieu of instance

### DIFF
--- a/.changeset/fifty-ghosts-live.md
+++ b/.changeset/fifty-ghosts-live.md
@@ -1,0 +1,6 @@
+---
+"@smithy/node-http-handler": minor
+"@smithy/types": minor
+---
+
+allow ctor args in lieu of Agent instances in node-http-handler ctor

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -37,7 +37,22 @@ describe("NodeHttpHandler", () => {
       hRequestSpy.mockRestore();
       hsRequestSpy.mockRestore();
     });
+
     describe("constructor", () => {
+      it("allows https.Agent and http.Agent ctor args in place of actual instances", async () => {
+        const nodeHttpHandler = new NodeHttpHandler({
+          httpAgent: { maxSockets: 37 },
+          httpsAgent: { maxSockets: 39, keepAlive: false },
+        });
+
+        await nodeHttpHandler.handle({} as any);
+        expect(hRequestSpy.mock.calls[0][0]?.agent.maxSockets).toEqual(37);
+        expect(hRequestSpy.mock.calls[0][0]?.agent.keepAlive).toEqual(true);
+
+        expect((nodeHttpHandler as any).config.httpsAgent.maxSockets).toEqual(39);
+        expect((nodeHttpHandler as any).config.httpsAgent.keepAlive).toEqual(false);
+      });
+
       it.each([
         ["empty", undefined],
         ["a provider", async () => {}],

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -116,18 +116,16 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
       connectionTimeout,
       requestTimeout: requestTimeout ?? socketTimeout,
       httpAgent: (() => {
-        if (httpAgent instanceof hAgent) {
-          return httpAgent;
+        if (httpAgent instanceof hAgent || typeof (httpAgent as hAgent)?.destroy === "function") {
+          return httpAgent as hAgent;
         }
-        return httpAgent ? new hAgent({ keepAlive, maxSockets, ...httpAgent }) : new hAgent({ keepAlive, maxSockets });
+        return new hAgent({ keepAlive, maxSockets, ...httpAgent });
       })(),
       httpsAgent: (() => {
-        if (httpsAgent instanceof hsAgent) {
-          return httpsAgent;
+        if (httpsAgent instanceof hsAgent || typeof (httpsAgent as hsAgent)?.destroy === "function") {
+          return httpsAgent as hsAgent;
         }
-        return httpsAgent
-          ? new hsAgent({ keepAlive, maxSockets, ...httpsAgent })
-          : new hsAgent({ keepAlive, maxSockets });
+        return new hsAgent({ keepAlive, maxSockets, ...httpsAgent });
       })(),
     };
   }

--- a/packages/types/src/http/httpHandlerInitialization.ts
+++ b/packages/types/src/http/httpHandlerInitialization.ts
@@ -1,5 +1,5 @@
-import type { Agent as hAgent } from "http";
-import type { Agent as hsAgent } from "https";
+import type { Agent as hAgent, AgentOptions as hAgentOptions } from "http";
+import type { Agent as hsAgent, AgentOptions as hsAgentOptions } from "https";
 
 /**
  *
@@ -51,8 +51,15 @@ export interface NodeHttpHandlerOptions {
    */
   socketTimeout?: number;
 
-  httpAgent?: hAgent;
-  httpsAgent?: hsAgent;
+  /**
+   * You can pass http.Agent or its constructor options.
+   */
+  httpAgent?: hAgent | hAgentOptions;
+
+  /**
+   * You can pass https.Agent or its constructor options.
+   */
+  httpsAgent?: hsAgent | hsAgentOptions;
 }
 
 /**


### PR DESCRIPTION
Simplify usage by allowing `http(s).Agent` constructor argument instead of an instance of such.

Before:
```ts
import https from "node:https";
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
import { NodeHttpHandler } from "@smithy/node-http-handler";

const client = new DynamoDBClient({
  requestHandler: new NodeHttpHandler({
    requestTimeout: 3_000,
    httpsAgent: new https.Agent({
      maxSockets: 25
    }),
  }),
});
```

After:
```ts
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
import { NodeHttpHandler } from "@smithy/node-http-handler";

const client = new DynamoDBClient({
  requestHandler: new NodeHttpHandler({
    requestTimeout: 3_000,
    httpsAgent: { maxSockets: 25 },
  }),
});
```

End goal:
```ts
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";

const client = new DynamoDBClient({
  requestHandler: {
    requestTimeout: 3_000,
    httpsAgent: { maxSockets: 25 },
  },
});

// the longer forms will still be valid
```
