### PR TITLE
feat: enable ctor arg passthrough for requestHandler

### DIFF
--- a/.changeset/three-paws-add.md
+++ b/.changeset/three-paws-add.md
@@ -1,0 +1,6 @@
+---
+"@smithy/protocol-http": minor
+"@smithy/smithy-client": minor
+---
+
+allow constructor parameters pass-through when initializing requestHandler

--- a/packages/protocol-http/src/httpHandler.ts
+++ b/packages/protocol-http/src/httpHandler.ts
@@ -44,5 +44,7 @@ export type HttpHandler<HttpHandlerConfig extends object = {}> = RequestHandler<
  * default is the FetchHttpHandler. In rarer cases specific clients may be
  * configured to use other default implementations such as Websocket or HTTP2.
  *
+ * The fallback type Record<string, unknown> is part of the union to allow
+ * passing constructor params to an unknown requestHandler type.
  */
-export type HttpHandlerUserInput = HttpHandler | NodeHttpHandlerOptions | FetchHttpHandlerOptions;
+export type HttpHandlerUserInput = HttpHandler | NodeHttpHandlerOptions | FetchHttpHandlerOptions | Record<string, unknown>;

--- a/packages/protocol-http/src/httpHandler.ts
+++ b/packages/protocol-http/src/httpHandler.ts
@@ -47,4 +47,8 @@ export type HttpHandler<HttpHandlerConfig extends object = {}> = RequestHandler<
  * The fallback type Record<string, unknown> is part of the union to allow
  * passing constructor params to an unknown requestHandler type.
  */
-export type HttpHandlerUserInput = HttpHandler | NodeHttpHandlerOptions | FetchHttpHandlerOptions | Record<string, unknown>;
+export type HttpHandlerUserInput =
+  | HttpHandler
+  | NodeHttpHandlerOptions
+  | FetchHttpHandlerOptions
+  | Record<string, unknown>;

--- a/packages/protocol-http/src/httpHandler.ts
+++ b/packages/protocol-http/src/httpHandler.ts
@@ -1,7 +1,12 @@
-import { HttpHandlerOptions, RequestHandler } from "@smithy/types";
+import type {
+  FetchHttpHandlerOptions,
+  HttpHandlerOptions,
+  NodeHttpHandlerOptions,
+  RequestHandler,
+} from "@smithy/types";
 
-import { HttpRequest } from "./httpRequest";
-import { HttpResponse } from "./httpResponse";
+import type { HttpRequest } from "./httpRequest";
+import type { HttpResponse } from "./httpResponse";
 
 /**
  * @internal
@@ -23,3 +28,21 @@ export type HttpHandler<HttpHandlerConfig extends object = {}> = RequestHandler<
    */
   httpHandlerConfigs(): HttpHandlerConfig;
 };
+
+/**
+ * @public
+ *
+ * A type representing the accepted user inputs for the `requestHandler` field
+ * of a client's constructor object.
+ *
+ * You may provide an instance of an HttpHandler, or alternatively
+ * provide the constructor arguments as an object which will be passed
+ * to the constructor of the default request handler.
+ *
+ * The default class constructor to which your arguments will be passed
+ * varies. The Node.js default is the NodeHttpHandler and the browser/react-native
+ * default is the FetchHttpHandler. In rarer cases specific clients may be
+ * configured to use other default implementations such as Websocket or HTTP2.
+ *
+ */
+export type HttpHandlerUserInput = HttpHandler | NodeHttpHandlerOptions | FetchHttpHandlerOptions;

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -13,7 +13,11 @@ import {
  * @public
  */
 export interface SmithyConfiguration<HandlerOptions> {
-  requestHandler: RequestHandler<any, any, HandlerOptions> | NodeHttpHandlerOptions | FetchHttpHandlerOptions | Record<string, unknown>;
+  requestHandler:
+    | RequestHandler<any, any, HandlerOptions>
+    | NodeHttpHandlerOptions
+    | FetchHttpHandlerOptions
+    | Record<string, unknown>;
   /**
    * The API version set internally by the SDK, and is
    * not planned to be used by customer code.

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -1,11 +1,19 @@
 import { constructStack } from "@smithy/middleware-stack";
-import { Client as IClient, Command, MetadataBearer, MiddlewareStack, RequestHandler } from "@smithy/types";
+import {
+  Client as IClient,
+  Command,
+  FetchHttpHandlerOptions,
+  MetadataBearer,
+  MiddlewareStack,
+  NodeHttpHandlerOptions,
+  RequestHandler,
+} from "@smithy/types";
 
 /**
  * @public
  */
 export interface SmithyConfiguration<HandlerOptions> {
-  requestHandler: RequestHandler<any, any, HandlerOptions>;
+  requestHandler: RequestHandler<any, any, HandlerOptions> | NodeHttpHandlerOptions | FetchHttpHandlerOptions | any;
   /**
    * The API version set internally by the SDK, and is
    * not planned to be used by customer code.
@@ -17,7 +25,10 @@ export interface SmithyConfiguration<HandlerOptions> {
 /**
  * @internal
  */
-export type SmithyResolvedConfiguration<HandlerOptions> = SmithyConfiguration<HandlerOptions>;
+export type SmithyResolvedConfiguration<HandlerOptions> = {
+  requestHandler: RequestHandler<any, any, HandlerOptions>;
+  readonly apiVersion: string;
+};
 
 /**
  * @public

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -13,7 +13,7 @@ import {
  * @public
  */
 export interface SmithyConfiguration<HandlerOptions> {
-  requestHandler: RequestHandler<any, any, HandlerOptions> | NodeHttpHandlerOptions | FetchHttpHandlerOptions | any;
+  requestHandler: RequestHandler<any, any, HandlerOptions> | NodeHttpHandlerOptions | FetchHttpHandlerOptions | Record<string, unknown>;
   /**
    * The API version set internally by the SDK, and is
    * not planned to be used by customer code.


### PR DESCRIPTION
This implements step 3 of the following progression mentioned earlier in https://github.com/smithy-lang/smithy-typescript/pull/1165.

#### Simplifying provision of custom settings to the requestHandler.

Previously:
```ts
import https from "node:https";
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
import { NodeHttpHandler } from "@smithy/node-http-handler";

const client = new DynamoDBClient({
  requestHandler: new NodeHttpHandler({
    requestTimeout: 3_000,
    httpsAgent: new https.Agent({
      maxSockets: 25
    }),
  }),
});
```

Step 2 (implemented):
```ts
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
import { NodeHttpHandler } from "@smithy/node-http-handler";

const client = new DynamoDBClient({
  requestHandler: new NodeHttpHandler({
    requestTimeout: 3_000,
    httpsAgent: { maxSockets: 25 },
  }),
});
```

Step 3 (this PR):
```ts
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";

const client = new DynamoDBClient({
  requestHandler: {
    requestTimeout: 3_000,
    httpsAgent: { maxSockets: 25 },
  },
});

// the longer forms will still be valid
```

AWS SDK sample diff in https://github.com/aws/aws-sdk-js-v3/pull/5820