### PR TITLE
fix(middleware-retry): retry on clock skew errors

### DIFF
--- a/.changeset/gold-bats-divide.md
+++ b/.changeset/gold-bats-divide.md
@@ -1,0 +1,6 @@
+---
+"@smithy/middleware-retry": patch
+"@smithy/types": patch
+---
+
+Retry on clock skew errors and expose errors to RetryErrorInfo.

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -48,6 +48,9 @@ export interface RetryInputConfig {
   retryStrategy?: RetryStrategy | RetryStrategyV2;
 }
 
+/**
+ * @internal
+ */
 interface PreviouslyResolved {
   /**
    * Specifies provider for retry algorithm to use.
@@ -56,6 +59,9 @@ interface PreviouslyResolved {
   retryMode: string | Provider<string>;
 }
 
+/**
+ * @internal
+ */
 export interface RetryResolvedConfig {
   /**
    * Resolved value for input config {@link RetryInputConfig.maxAttempts}

--- a/packages/middleware-retry/src/retryMiddleware.spec.ts
+++ b/packages/middleware-retry/src/retryMiddleware.spec.ts
@@ -138,6 +138,7 @@ describe(retryMiddleware.name, () => {
         (isThrottlingError as jest.Mock).mockReturnValue(true);
         const next = jest.fn().mockRejectedValue(requestError);
         const errorInfo = {
+          error: requestError,
           errorType: "THROTTLING",
         };
         const mockRetryStrategy = {
@@ -172,6 +173,7 @@ describe(retryMiddleware.name, () => {
         (isThrottlingError as jest.Mock).mockReturnValue(true);
         const next = jest.fn().mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockSuccess);
         const errorInfo = {
+          error: mockError,
           errorType: "THROTTLING",
         };
         const { response, output } = await retryMiddleware({
@@ -193,6 +195,7 @@ describe(retryMiddleware.name, () => {
         (isThrottlingError as jest.Mock).mockReturnValue(false);
         const next = jest.fn().mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockSuccess);
         const errorInfo = {
+          error: mockError,
           errorType: "TRANSIENT",
         };
         const { response, output } = await retryMiddleware({
@@ -215,6 +218,7 @@ describe(retryMiddleware.name, () => {
         (isThrottlingError as jest.Mock).mockReturnValue(false);
         const next = jest.fn().mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockSuccess);
         const errorInfo = {
+          error: mockError,
           errorType: "SERVER_ERROR",
         };
         const { response, output } = await retryMiddleware({
@@ -237,6 +241,7 @@ describe(retryMiddleware.name, () => {
         (isThrottlingError as jest.Mock).mockReturnValue(false);
         const next = jest.fn().mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockSuccess);
         const errorInfo = {
+          error: mockError,
           errorType: "CLIENT_ERROR",
         };
         const { response, output } = await retryMiddleware({
@@ -265,6 +270,7 @@ describe(retryMiddleware.name, () => {
           });
           const next = jest.fn().mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockSuccess);
           const errorInfo = {
+            error: mockError,
             errorType: "CLIENT_ERROR",
           };
           const { response, output } = await retryMiddleware({
@@ -289,6 +295,7 @@ describe(retryMiddleware.name, () => {
         const { isInstance } = HttpResponse;
         ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
         const errorInfo = {
+          error: mockError,
           errorType: "CLIENT_ERROR",
           retryAfterHint: retryAfterDate,
         };

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -1,5 +1,5 @@
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { isServerError, isThrottlingError, isTransientError } from "@smithy/service-error-classification";
+import { isClockSkewError, isServerError, isThrottlingError, isTransientError } from "@smithy/service-error-classification";
 import { NoOpLogger } from "@smithy/smithy-client";
 import {
   AbsoluteLocation,
@@ -97,6 +97,7 @@ const isRetryStrategyV2 = (retryStrategy: RetryStrategy | RetryStrategyV2) =>
 
 const getRetryErrorInfo = (error: SdkError): RetryErrorInfo => {
   const errorInfo: RetryErrorInfo = {
+    error,
     errorType: getRetryErrorType(error),
   };
   const retryAfterHint = getRetryAfterHint(error.$response);
@@ -109,6 +110,7 @@ const getRetryErrorInfo = (error: SdkError): RetryErrorInfo => {
 const getRetryErrorType = (error: SdkError): RetryErrorType => {
   if (isThrottlingError(error)) return "THROTTLING";
   if (isTransientError(error)) return "TRANSIENT";
+  if (isClockSkewError(error)) return "TRANSIENT";
   if (isServerError(error)) return "SERVER_ERROR";
   return "CLIENT_ERROR";
 };

--- a/packages/types/src/retry.ts
+++ b/packages/types/src/retry.ts
@@ -1,3 +1,5 @@
+import { SdkError } from "./shapes";
+
 /**
  * @public
  */
@@ -33,6 +35,11 @@ export type RetryErrorType =
  * @public
  */
 export interface RetryErrorInfo {
+  /**
+   * The error thrown during the initial request, if available.
+   */
+  error?: SdkError;
+
   errorType: RetryErrorType;
 
   /**
@@ -40,7 +47,7 @@ export interface RetryErrorInfo {
    * something from MQTT or any other protocol that has the ability to convey
    * retry info from a peer.
    *
-   * @returns the Date after which a retry should be attempted.
+   * The Date after which a retry should be attempted.
    */
   retryAfterHint?: Date;
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Retry on clock skew errors.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
