### PR TITLE
Process sso-session names with config prefix separator

### DIFF
--- a/.changeset/swift-cups-count.md
+++ b/.changeset/swift-cups-count.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Process sso-session names with config prefix separator

--- a/packages/shared-ini-file-loader/src/getSsoSessionData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getSsoSessionData.spec.ts
@@ -33,6 +33,12 @@ describe(getSsoSessionData.name, () => {
         {}
       );
 
+    it(`sso-session section with prefix separator ${CONFIG_PREFIX_SEPARATOR}`, () => {
+      const mockOutput = getMockOutput(["prefix.suffix"]);
+      const mockInput = getMockInput(mockOutput);
+      expect(getSsoSessionData(mockInput)).toStrictEqual(mockOutput);
+    });
+
     it("single sso-session section", () => {
       const mockOutput = getMockOutput(["one"]);
       const mockInput = getMockInput(mockOutput);

--- a/packages/shared-ini-file-loader/src/getSsoSessionData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getSsoSessionData.spec.ts
@@ -34,7 +34,7 @@ describe(getSsoSessionData.name, () => {
       );
 
     it(`sso-session section with prefix separator ${CONFIG_PREFIX_SEPARATOR}`, () => {
-      const mockOutput = getMockOutput(["prefix.suffix"]);
+      const mockOutput = getMockOutput([["prefix", "suffix"].join(CONFIG_PREFIX_SEPARATOR)]);
       const mockInput = getMockInput(mockOutput);
       expect(getSsoSessionData(mockInput)).toStrictEqual(mockOutput);
     });

--- a/packages/shared-ini-file-loader/src/getSsoSessionData.ts
+++ b/packages/shared-ini-file-loader/src/getSsoSessionData.ts
@@ -11,4 +11,4 @@ export const getSsoSessionData = (data: ParsedIniData): ParsedIniData =>
     // filter out non sso-session keys
     .filter(([key]) => key.startsWith(IniSectionType.SSO_SESSION + CONFIG_PREFIX_SEPARATOR))
     // replace sso-session key with sso-session name
-    .reduce((acc, [key, value]) => ({ ...acc, [key.split(CONFIG_PREFIX_SEPARATOR)[1]]: value }), {});
+    .reduce((acc, [key, value]) => ({ ...acc, [key.substring(key.indexOf(CONFIG_PREFIX_SEPARATOR) + 1)]: value }), {});


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/smithy-lang/smithy-typescript/issues/1163

*Description of changes:*
Process sso-session names with config prefix separator

*Testing:*

```console
$ cat test.mjs
import { loadSsoSessionData } from "../smithy-typescript/packages/shared-ini-file-loader/dist-cjs/index.js";
console.log(await loadSsoSessionData());

$ cat ~/.aws/config
[profile my.big.profile]
region = us-east-1
sso_session = my.sso
sso_account_id = 123456789
sso_role_name = BigRole

[sso-session my.sso]
sso_region = us-east-1
sso_start_url = https://magic-app.awsapps.com/start
sso_registration_scopes = sso:account:access

$ node test.mjs 
{
  'my.sso': {
    sso_region: 'us-east-1',
    sso_start_url: 'https://magic-app.awsapps.com/start',
    sso_registration_scopes: 'sso:account:access'
  }
}
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
