### PR TITLE
fix: credential expiration extension log message

### DIFF
--- a/.changeset/tough-bikes-sit.md
+++ b/.changeset/tough-bikes-sit.md
@@ -1,0 +1,5 @@
+---
+"@smithy/credential-provider-imds": patch
+---
+
+fix: credential expiration extension log message

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
@@ -19,7 +19,7 @@ export const getExtendedInstanceMetadataCredentials = (
   const newExpiration = new Date(Date.now() + refreshInterval * 1000);
   logger.warn(
     "Attempting credential expiration extension due to a credential service availability issue. A refresh of these " +
-      "credentials will be attempted after ${new Date(newExpiration)}.\nFor more information, please visit: " +
+      `credentials will be attempted after ${new Date(newExpiration)}.\nFor more information, please visit: ` +
       STATIC_STABILITY_DOC_URL
   );
   const originalExpiration = credentials.originalExpiration ?? credentials.expiration;


### PR DESCRIPTION
The log message is currently:
> Attempting credential expiration extension due to a credential service availability issue. A refresh of these credentials will be attempted after ${new Date(newExpiration)}.

This PR switches to using \`backticks\` so the code date is interpolated as expected.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
