### PR TITLE
fix: use 9.0.1 for uuid

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -79,7 +79,7 @@ public enum TypeScriptDependency implements Dependency {
 
     NODE_CONFIG_PROVIDER("dependencies", "@smithy/node-config-provider", false),
 
-    UUID("dependencies", "uuid", "^8.3.2", false),
+    UUID("dependencies", "uuid", "^9.0.1", false),
 
     // Conditionally added when httpChecksumRequired trait exists
     MD5_BROWSER("dependencies", "@smithy/md5-js", false),


### PR DESCRIPTION
AWS SDK is already using `^9.0.1` for uuid.