### PR TITLE
fix: allow error deserializers to populate error response body

### DIFF
--- a/.changeset/lazy-olives-film.md
+++ b/.changeset/lazy-olives-film.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-serde": patch
+---
+
+allow deserializers to populate error response body

--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -78,7 +78,12 @@ describe("deserializerMiddleware", () => {
   });
 
   it("adds a hint about $response to the message of the thrown error", async () => {
-    const exception = Object.assign(new Error("MockException"), mockNextResponse.response);
+    const exception = Object.assign(new Error("MockException"), mockNextResponse.response, {
+      $response: {
+        body: "",
+      },
+      $responseBodyText: "oh no",
+    });
     mockDeserializer.mockReset();
     mockDeserializer.mockRejectedValueOnce(exception);
     try {
@@ -88,6 +93,7 @@ describe("deserializerMiddleware", () => {
       expect(e.message).toContain(
         "to see the raw response, inspect the hidden field {error}.$response on this object."
       );
+      expect(e.$response.body).toEqual("oh no");
     }
   });
 });

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -33,6 +33,14 @@ export const deserializerMiddleware = <Input extends object, Output extends obje
       // only apply this to non-ServiceException.
       const hint = `Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.`;
       error.message += "\n  " + hint;
+
+      if (typeof error.$responseBodyText !== "undefined") {
+        // if $responseBodyText was collected by the error parser, assign it to
+        // replace the response body, because it was consumed and is now empty.
+        if (error.$response) {
+          error.$response.body = error.$responseBodyText;
+        }
+      }
     }
 
     throw error;


### PR DESCRIPTION
Currently, deserializer collectors read response body streams prior to attempting to deserialize them. 

If there is a parsing error, such as when a JSON service front end layer (load balancer, CDN, etc) has an error and returns non-JSON, the raw text of this error is lost since the stream collector has read the stream.

For this PR, addressing such cases, if the error contains a field called `$responseBodyText`, it will be written over the response body's (consumed and therefore empty) stream, so the user can read the body text instead of only having an empty stream.

It is up to the deserializer implementation to write the body text to this field. 

Example:

```ts
export const parseJsonBody = (streamBody: any, context: SerdeContext): any =>
  collectBodyString(streamBody, context).then((encoded) => {
    if (encoded.length) {
      try {
        return JSON.parse(encoded);
      } catch (e: any) {
        if (e?.name === "SyntaxError") {
          Object.defineProperty(e, "$responseBodyText", {
            value: encoded,
          });
        }
        throw e;
      }
    }
    return {};
  });
```

```ts
export const parseXmlBody = (streamBody: any, context: SerdeContext): any =>
  collectBodyString(streamBody, context).then((encoded) => {
    if (encoded.length) {
      const parser = new XMLParser({
        attributeNamePrefix: "",
        htmlEntities: true,
        ignoreAttributes: false,
        ignoreDeclaration: true,
        parseTagValue: false,
        trimValues: false,
        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
      });
      parser.addEntity("#xD", "\r");
      parser.addEntity("#10", "\n");

      let parsedObj;
      try {
        parsedObj = parser.parse(encoded);
      } catch (e: any) {
        if (e && typeof e === "object") {
          Object.defineProperty(e, "$responseBodyText", {
            value: encoded,
          });
        }
        throw e;
      }

      const textNodeName = "#text";
      const key = Object.keys(parsedObj)[0];
      const parsedObjToReturn = parsedObj[key];
      if (parsedObjToReturn[textNodeName]) {
        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
        delete parsedObjToReturn[textNodeName];
      }
      return getValueFromTextNode(parsedObjToReturn);
    }
    return {};
  });
```