### PR TITLE
chore(credential-provider-imds): export IMDS endpoint for v3 utils #5796

### DIFF
--- a/.changeset/tough-tools-fix.md
+++ b/.changeset/tough-tools-fix.md
@@ -1,0 +1,5 @@
+---
+"@smithy/credential-provider-imds": patch
+---
+
+exporting Endpoint from credential-provider-imds to use for JSv3 EC2 IMDS utils

--- a/packages/credential-provider-imds/src/index.ts
+++ b/packages/credential-provider-imds/src/index.ts
@@ -22,3 +22,7 @@ export { httpRequest } from "./remoteProvider/httpRequest";
  * @internal
  */
 export { getInstanceMetadataEndpoint } from "./utils/getInstanceMetadataEndpoint";
+/**
+ * @internal
+ */
+export { Endpoint } from "./config/Endpoint";


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sdk-js-v3/issues/4004

*Description of changes:*
Exporting Endpoint from `credential-provider-imds` to use in `ec2-metadata-service` in JSv3.

Related PR:
https://github.com/aws/aws-sdk-js-v3/pull/5796 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
