### PR TITLE
docs: add more information about BLOB values in structures

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -212,12 +212,12 @@ final class CommandGenerator implements Runnable {
                 + String.format("const client = new %s(config);%n", serviceName)
                 + String.format("const input = %s%n",
                         StructureExampleGenerator.generateStructuralHintDocumentation(
-                                model.getShape(operation.getInputShape()).get(), model, false))
+                                model.getShape(operation.getInputShape()).get(), model, false, true))
                 + String.format("const command = new %s(input);%n", commandName)
                 + "const response = await client.send(command);\n"
                 + String.format("%s%n",
                         StructureExampleGenerator.generateStructuralHintDocumentation(
-                                model.getShape(operation.getOutputShape()).get(), model, true))
+                                model.getShape(operation.getOutputShape()).get(), model, true, false))
                 + "\n```\n"
                 + "\n"
                 + String.format("@param %s - {@link %s}%n", commandInput, commandInput)

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGenerator.java
@@ -132,7 +132,8 @@ public abstract class StructureExampleGenerator {
                     if (isInput) {
                         if (target.hasTrait(StreamingTrait.class)) {
                             append(indentation, buffer,
-                                "\"MULTIPLE_TYPES_ACCEPTED\", // see \@smithy/types -> StreamingBlobPayloadInputTypes");
+                                "\"MULTIPLE_TYPES_ACCEPTED\", // see \\@smithy/types -> StreamingBlobPayloadInputTypes"
+                            );
                         } else {
                             append(indentation, buffer,
                                 """
@@ -141,7 +142,7 @@ public abstract class StructureExampleGenerator {
                     } else {
                         if (target.hasTrait(StreamingTrait.class)) {
                             append(indentation, buffer,
-                                "\"<SdkStream>\", // see \@smithy/types -> StreamingBlobPayloadOutputTypes");
+                                "\"<SdkStream>\", // see \\@smithy/types -> StreamingBlobPayloadOutputTypes");
                         } else {
                             append(indentation, buffer,
                                 "new Uint8Array(),");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGenerator.java
@@ -22,7 +22,6 @@ import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
-import software.amazon.smithy.model.traits.InputTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 
@@ -45,20 +44,24 @@ public abstract class StructureExampleGenerator {
      * };
      * ```
      */
-    public static String generateStructuralHintDocumentation(Shape shape, Model model, boolean isComment) {
+    public static String generateStructuralHintDocumentation(
+        Shape shape,
+        Model model,
+        boolean isComment,
+        boolean isInput
+    ) {
         StringBuilder buffer = new StringBuilder();
-        boolean isInput = shape.hasTrait(InputTrait.class);
         shape(shape, buffer, model, 0, new ShapeTracker(), isInput);
 
         // replace non-leading whitespace with single space.
         String s = Arrays.stream(
                 buffer.toString()
-                        .split("\n"))
-                .map(line -> line.replaceAll(
-                        "([\\w\\\",:\\[\\{] )\\s+",
-                        "$1")
-                        .replaceAll("\\s+$", ""))
-                .collect(Collectors.joining((isComment) ? "\n// " : "\n"));
+                    .split("\n"))
+            .map(line -> line.replaceAll(
+                    "([\\w\\\",:\\[\\{] )\\s+",
+                    "$1")
+                .replaceAll("\\s+$", ""))
+            .collect(Collectors.joining((isComment) ? "\n// " : "\n"));
 
         return ((isComment) ? "// " : "") + s.replaceAll(",$", ";");
     }
@@ -74,9 +77,9 @@ public abstract class StructureExampleGenerator {
             checkRequired(indentation, buffer, structureShape);
         } else {
             append(indentation, buffer,
-                    "{" + (shapeTracker.getOccurrenceCount(structureShape) == 1
-                            ? " // " + structureShape.getId().getName()
-                            : ""));
+                "{" + (shapeTracker.getOccurrenceCount(structureShape) == 1
+                    ? " // " + structureShape.getId().getName()
+                    : ""));
             checkRequired(indentation, buffer, structureShape);
             structureShape.getAllMembers().values().forEach(member -> {
                 append(indentation + 2, buffer, member.getMemberName() + ": ");
@@ -93,8 +96,8 @@ public abstract class StructureExampleGenerator {
                               ShapeTracker shapeTracker,
                               boolean isInput) {
         append(indentation, buffer, "{" + (shapeTracker.getOccurrenceCount(unionShape) == 1
-                ? " // " + unionShape.getId().getName()
-                : "// ") + " Union: only one key present");
+            ? " // " + unionShape.getId().getName()
+            : "// ") + " Union: only one key present");
         checkRequired(indentation, buffer, unionShape);
         unionShape.getAllMembers().values().forEach(member -> {
             append(indentation + 2, buffer, member.getMemberName() + ": ");
@@ -183,8 +186,8 @@ public abstract class StructureExampleGenerator {
                 case SET:
                 case LIST:
                     append(indentation, buffer, "[" + (shapeTracker.getOccurrenceCount(target) == 1
-                            ? " // " + target.getId().getName()
-                            : ""));
+                        ? " // " + target.getId().getName()
+                        : ""));
                     checkRequired(indentation, buffer, shape);
                     ListShape list = (ListShape) target;
                     shape(list.getMember(), buffer, model, indentation + 2, shapeTracker, isInput);
@@ -192,13 +195,13 @@ public abstract class StructureExampleGenerator {
                     break;
                 case MAP:
                     append(indentation, buffer, "{" + (shapeTracker.getOccurrenceCount(target) == 1
-                            ? " // " + target.getId().getName()
-                            : ""));
+                        ? " // " + target.getId().getName()
+                        : ""));
                     checkRequired(indentation, buffer, shape);
                     append(indentation + 2, buffer, "\"<keys>\": ");
                     MapShape map = (MapShape) target;
                     shape(model.getShape(map.getValue().getTarget()).get(), buffer, model, indentation + 2,
-                            shapeTracker, isInput);
+                        shapeTracker, isInput);
                     append(indentation, buffer, "},\n");
                     break;
 
@@ -214,19 +217,19 @@ public abstract class StructureExampleGenerator {
                 case ENUM:
                     EnumShape enumShape = (EnumShape) target;
                     String enumeration = enumShape.getEnumValues()
-                            .values()
-                            .stream()
-                            .map(s -> "\"" + s + "\"")
-                            .collect(Collectors.joining(" || "));
+                        .values()
+                        .stream()
+                        .map(s -> "\"" + s + "\"")
+                        .collect(Collectors.joining(" || "));
                     append(indentation, buffer, enumeration + ",");
                     break;
                 case INT_ENUM:
                     IntEnumShape intEnumShape = (IntEnumShape) target;
                     String intEnumeration = intEnumShape.getEnumValues()
-                            .values()
-                            .stream()
-                            .map(i -> Integer.toString(i))
-                            .collect(Collectors.joining(" || "));
+                        .values()
+                        .stream()
+                        .map(i -> Integer.toString(i))
+                        .collect(Collectors.joining(" || "));
                     append(indentation, buffer, intEnumeration + ",");
                     break;
                 case OPERATION:
@@ -311,8 +314,8 @@ public abstract class StructureExampleGenerator {
          */
         public boolean shouldTruncate(Shape shape) {
             return (shape instanceof MapShape || shape instanceof UnionShape || shape instanceof StructureShape
-                    || shape instanceof ListShape || shape instanceof SetShape)
-                    && (getOccurrenceCount(shape) > 5 || getOccurrenceDepths(shape) > 2);
+                || shape instanceof ListShape || shape instanceof SetShape)
+                && (getOccurrenceCount(shape) > 5 || getOccurrenceDepths(shape) > 2);
         }
 
         /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGeneratorTest.java
@@ -4,198 +4,254 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.StreamingTrait;
 
 public class StructureExampleGeneratorTest {
 
     StringShape string = StringShape.builder()
-            .id("foo.bar#string")
-            .build();
+        .id("foo.bar#string")
+        .build();
+
+    BlobShape blob = BlobShape.builder()
+        .id("foo.bar#blob")
+        .build();
+
+    BlobShape streamingBlob = BlobShape.builder()
+        .id("foo.bar#streamingBlob")
+        .traits(
+            List.of(
+                new StreamingTrait()
+            )
+        )
+        .build();
 
     ListShape list = ListShape.builder()
-            .id("foo.bar#list")
-            .member(string.getId())
-            .build();
+        .id("foo.bar#list")
+        .member(string.getId())
+        .build();
 
     MapShape map = MapShape.builder()
-            .id("foo.bar#map")
-            .key(MemberShape.builder()
-                    .id("foo.bar#map$member")
-                    .target(string.getId())
-                    .build())
-            .value(MemberShape.builder()
-                    .id("foo.bar#map$member")
-                    .target(string.getId())
-                    .build())
-            .build();
+        .id("foo.bar#map")
+        .key(MemberShape.builder()
+            .id("foo.bar#map$member")
+            .target(string.getId())
+            .build())
+        .value(MemberShape.builder()
+            .id("foo.bar#map$member")
+            .target(string.getId())
+            .build())
+        .build();
 
     MemberShape memberForString = MemberShape.builder()
-            .id("foo.bar#structure$string")
-            .target(string.getId())
-            .build();
+        .id("foo.bar#structure$string")
+        .target(string.getId())
+        .build();
+
+    MemberShape memberForBlob = MemberShape.builder()
+        .id("foo.bar#blobStructure$blob")
+        .target(blob.getId())
+        .build();
+
+    MemberShape memberForStreamingBlob = MemberShape.builder()
+        .id("foo.bar#blobStructure$streamingBlob")
+        .target(streamingBlob.getId())
+        .build();
 
     MemberShape memberForList = MemberShape.builder()
-            .id("foo.bar#structure$list")
-            .target(list.getId())
-            .build();
+        .id("foo.bar#structure$list")
+        .target(list.getId())
+        .build();
 
     MemberShape memberForMap = MemberShape.builder()
-            .id("foo.bar#structure$map")
-            .target(map.getId())
-            .build();
+        .id("foo.bar#structure$map")
+        .target(map.getId())
+        .build();
 
     StructureShape structure = StructureShape.builder()
-            .id("foo.bar#structure")
-            .members(
-                    List.<MemberShape>of(
-                            memberForString, memberForList, memberForMap,
-                            MemberShape.builder()
-                                    .id("foo.bar#structure$list2")
-                                    .target(list.getId())
-                                    .build(),
-                            MemberShape.builder()
-                                    .id("foo.bar#structure$list3")
-                                    .target(list.getId())
-                                    .build(),
-                            MemberShape.builder()
-                                    .id("foo.bar#structure$list4")
-                                    .target(list.getId())
-                                    .build(),
-                            MemberShape.builder()
-                                    .id("foo.bar#structure$list5")
-                                    .target(list.getId())
-                                    .build(),
-                            MemberShape.builder()
-                                    .id("foo.bar#structure$list6")
-                                    .target(list.getId())
-                                    .build(),
-                            MemberShape.builder()
-                                    .id("foo.bar#structure$list7")
-                                    .target(list.getId())
-                                    .build(),
-                            MemberShape.builder()
-                                    .id("foo.bar#structure$structure")
-                                    .target("foo.bar#structure")
-                                    .build()))
-            .build();
+        .id("foo.bar#structure")
+        .members(
+            List.of(
+                memberForString, memberForList, memberForMap,
+                MemberShape.builder()
+                    .id("foo.bar#structure$list2")
+                    .target(list.getId())
+                    .build(),
+                MemberShape.builder()
+                    .id("foo.bar#structure$list3")
+                    .target(list.getId())
+                    .build(),
+                MemberShape.builder()
+                    .id("foo.bar#structure$list4")
+                    .target(list.getId())
+                    .build(),
+                MemberShape.builder()
+                    .id("foo.bar#structure$list5")
+                    .target(list.getId())
+                    .build(),
+                MemberShape.builder()
+                    .id("foo.bar#structure$list6")
+                    .target(list.getId())
+                    .build(),
+                MemberShape.builder()
+                    .id("foo.bar#structure$list7")
+                    .target(list.getId())
+                    .build(),
+                MemberShape.builder()
+                    .id("foo.bar#structure$structure")
+                    .target("foo.bar#structure")
+                    .build()))
+        .build();
+
+
+    StructureShape blobStructure = StructureShape.builder()
+        .id("foo.bar#blobStructure")
+        .members(
+            List.of(
+                memberForBlob, memberForStreamingBlob
+            )
+        )
+        .build();
 
     private Model model = Model.builder()
-            .addShapes(
-                    string, list, map, structure,
-                    memberForString, memberForList, memberForMap)
-            .build();
+        .addShapes(
+            string, list, map, structure,
+            memberForString, memberForList, memberForMap,
+            blob, streamingBlob
+        )
+        .build();
 
     @Test
     public void generatesStructuralHintDocumentation_map() {
         assertThat(
-                StructureExampleGenerator.generateStructuralHintDocumentation(map, model, false),
-                equalTo("""
-                        { // map
-                          "<keys>": "STRING_VALUE",
-                        };"""));
+            StructureExampleGenerator.generateStructuralHintDocumentation(map, model, false, true),
+            equalTo("""
+                { // map
+                  "<keys>": "STRING_VALUE",
+                };"""));
     }
 
     @Test
     public void generatesStructuralHintDocumentation_structure() {
         assertThat(
-                StructureExampleGenerator.generateStructuralHintDocumentation(structure, model, false),
-                equalTo("""
-                        { // structure
-                          string: "STRING_VALUE",
-                          list: [ // list
-                            "STRING_VALUE",
-                          ],
-                          map: { // map
-                            "<keys>": "STRING_VALUE",
-                          },
-                          list2: [
-                            "STRING_VALUE",
-                          ],
-                          list3: [
-                            "STRING_VALUE",
-                          ],
-                          list4: [
-                            "STRING_VALUE",
-                          ],
-                          list5: [
-                            "STRING_VALUE",
-                          ],
-                          list6: "<list>",
-                          list7: "<list>",
-                          structure: {
-                            string: "STRING_VALUE",
-                            list: "<list>",
-                            map: {
-                              "<keys>": "STRING_VALUE",
-                            },
-                            list2: "<list>",
-                            list3: "<list>",
-                            list4: "<list>",
-                            list5: "<list>",
-                            list6: "<list>",
-                            list7: "<list>",
-                            structure: "<structure>",
-                          },
-                        };"""));
+            StructureExampleGenerator.generateStructuralHintDocumentation(structure, model, false, true),
+            equalTo("""
+                { // structure
+                  string: "STRING_VALUE",
+                  list: [ // list
+                    "STRING_VALUE",
+                  ],
+                  map: { // map
+                    "<keys>": "STRING_VALUE",
+                  },
+                  list2: [
+                    "STRING_VALUE",
+                  ],
+                  list3: [
+                    "STRING_VALUE",
+                  ],
+                  list4: [
+                    "STRING_VALUE",
+                  ],
+                  list5: [
+                    "STRING_VALUE",
+                  ],
+                  list6: "<list>",
+                  list7: "<list>",
+                  structure: {
+                    string: "STRING_VALUE",
+                    list: "<list>",
+                    map: {
+                      "<keys>": "STRING_VALUE",
+                    },
+                    list2: "<list>",
+                    list3: "<list>",
+                    list4: "<list>",
+                    list5: "<list>",
+                    list6: "<list>",
+                    list7: "<list>",
+                    structure: "<structure>",
+                  },
+                };"""));
     }
-    
+
     @Test
     public void generatesStructuralHintDocumentation_structure_asComment() {
         assertThat(
-                StructureExampleGenerator.generateStructuralHintDocumentation(structure, model, true),
-                equalTo("""
-                        // { // structure
-                        //   string: "STRING_VALUE",
-                        //   list: [ // list
-                        //     "STRING_VALUE",
-                        //   ],
-                        //   map: { // map
-                        //     "<keys>": "STRING_VALUE",
-                        //   },
-                        //   list2: [
-                        //     "STRING_VALUE",
-                        //   ],
-                        //   list3: [
-                        //     "STRING_VALUE",
-                        //   ],
-                        //   list4: [
-                        //     "STRING_VALUE",
-                        //   ],
-                        //   list5: [
-                        //     "STRING_VALUE",
-                        //   ],
-                        //   list6: "<list>",
-                        //   list7: "<list>",
-                        //   structure: {
-                        //     string: "STRING_VALUE",
-                        //     list: "<list>",
-                        //     map: {
-                        //       "<keys>": "STRING_VALUE",
-                        //     },
-                        //     list2: "<list>",
-                        //     list3: "<list>",
-                        //     list4: "<list>",
-                        //     list5: "<list>",
-                        //     list6: "<list>",
-                        //     list7: "<list>",
-                        //     structure: "<structure>",
-                        //   },
-                        // };"""));
+            StructureExampleGenerator.generateStructuralHintDocumentation(structure, model, true, true),
+            equalTo("""
+                // { // structure
+                //   string: "STRING_VALUE",
+                //   list: [ // list
+                //     "STRING_VALUE",
+                //   ],
+                //   map: { // map
+                //     "<keys>": "STRING_VALUE",
+                //   },
+                //   list2: [
+                //     "STRING_VALUE",
+                //   ],
+                //   list3: [
+                //     "STRING_VALUE",
+                //   ],
+                //   list4: [
+                //     "STRING_VALUE",
+                //   ],
+                //   list5: [
+                //     "STRING_VALUE",
+                //   ],
+                //   list6: "<list>",
+                //   list7: "<list>",
+                //   structure: {
+                //     string: "STRING_VALUE",
+                //     list: "<list>",
+                //     map: {
+                //       "<keys>": "STRING_VALUE",
+                //     },
+                //     list2: "<list>",
+                //     list3: "<list>",
+                //     list4: "<list>",
+                //     list5: "<list>",
+                //     list6: "<list>",
+                //     list7: "<list>",
+                //     structure: "<structure>",
+                //   },
+                // };"""));
     }
 
     @Test
     public void generatesStructuralHintDocumentation_list() {
         assertThat(
-                StructureExampleGenerator.generateStructuralHintDocumentation(list, model, false),
-                equalTo("""
-                        [ // list
-                          "STRING_VALUE",
-                        ];"""));
+            StructureExampleGenerator.generateStructuralHintDocumentation(list, model, false, true),
+            equalTo("""
+                [ // list
+                  "STRING_VALUE",
+                ];"""));
+    }
+
+    @Test
+    public void generateStructuralHintDocumentation_blob() {
+        assertThat(
+            StructureExampleGenerator.generateStructuralHintDocumentation(blobStructure, model, false, true),
+            equalTo("""
+                { // blobStructure
+                  blob: new Uint8Array(), // e.g. Buffer.from("") or new TextEncoder().encode("")
+                  streamingBlob: "MULTIPLE_TYPES_ACCEPTED", // see \\@smithy/types -> StreamingBlobPayloadInputTypes
+                };"""));
+        assertThat(
+            StructureExampleGenerator.generateStructuralHintDocumentation(blobStructure, model, false, false),
+            equalTo("""
+                { // blobStructure
+                  blob: new Uint8Array(),
+                  streamingBlob: "<SdkStream>", // see \\@smithy/types -> StreamingBlobPayloadOutputTypes
+                };"""));
     }
 }


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/5240

The PR improves the inline documentation generated for structural hints for operation inputs and outputs.

It differentiates between input and output of the same Smithy type (BLOB). For TypeScript, the inputs are wider than a single type for convenience, and the output has mixin methods attached, again for user convenience. 

For a sample diff, see first commit in https://github.com/aws/aws-sdk-js-v3/pull/5864


### Examples

#### output side

STREAMING_BLOB_VALUE
```ts
* // { // GetObjectOutput
* //   Body: "STREAMING_BLOB_VALUE",
* //   DeleteMarker: true || false,
```
becomes
```ts
* // { // GetObjectOutput
* //   Body: "<SdkStream>", // see @smithy/types -> StreamingBlobPayloadOutputTypes
* //   DeleteMarker: true || false,
```

BLOB_VALUE
```ts
 * //   Payload: { // SelectObjectContentEventStream Union: only one key present
 * //     Records: { // RecordsEvent
 * //       Payload: "BLOB_VALUE",
 * //     },
```
becomes
```ts
 * //   Payload: { // SelectObjectContentEventStream Union: only one key present
 * //     Records: { // RecordsEvent
 * //       Payload: new Uint8Array(),
 * //     },
```

----

#### input side

STREAMING_BLOB_VALUE
```ts
 *   Body: "STREAMING_BLOB_VALUE",
 *   Bucket: "STRING_VALUE", // required
 *   CacheControl: "STRING_VALUE",
```
becomes
```ts
 *   Body: "MULTIPLE_TYPES_ACCEPTED", // see @smithy/types -> StreamingBlobPayloadInputTypes
 *   Bucket: "STRING_VALUE", // required
 *   CacheControl: "STRING_VALUE",
```

BLOB_VALUE
```ts
 *   RawMessage: { // RawMessage
 *     Data: "BLOB_VALUE", // required
 *   },
```
becomes
```ts
 *   RawMessage: { // RawMessage
 *     Data: new Uint8Array(), // e.g. Buffer.from("") or new TextEncoder().encode("")     // required
 *   },
```