### PR TITLE
fix(types): use SerdeFunctions type as serde plugin input, but call serde functions as type SerdeContext

### DIFF
--- a/.changeset/many-stingrays-bow.md
+++ b/.changeset/many-stingrays-bow.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-serde": patch
+---
+
+use SerdeFunctions as input type and SerdeContext as resolved type for serde plugin

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -5,6 +5,7 @@ import {
   DeserializeMiddleware,
   HandlerExecutionContext,
   ResponseDeserializer,
+  SerdeContext,
   SerdeFunctions,
 } from "@smithy/types";
 
@@ -13,9 +14,9 @@ import {
  *
  * 3rd type parameter is deprecated and unused.
  */
-export const deserializerMiddleware = <Input extends object, Output extends object, _ = any>(
+export const deserializerMiddleware = <Input extends object, Output extends object, CommandSerdeContext extends SerdeContext = any>(
   options: SerdeFunctions,
-  deserializer: ResponseDeserializer<any, any, SerdeFunctions>
+  deserializer: ResponseDeserializer<any, any, CommandSerdeContext>
 ): DeserializeMiddleware<Input, Output> => (
   next: DeserializeHandler<Input, Output>,
   context: HandlerExecutionContext
@@ -24,7 +25,7 @@ export const deserializerMiddleware = <Input extends object, Output extends obje
 ): Promise<DeserializeHandlerOutput<Output>> => {
   const { response } = await next(args);
   try {
-    const parsed = await deserializer(response, options);
+    const parsed = await deserializer(response, options as CommandSerdeContext);
     return {
       response,
       output: parsed as Output,

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -15,8 +15,8 @@ import {
  * 3rd type parameter is deprecated and unused.
  */
 export const deserializerMiddleware = <
-  Input extends object,
-  Output extends object,
+  Input extends object = any,
+  Output extends object = any,
   CommandSerdeContext extends SerdeContext = any
 >(
   options: SerdeFunctions,

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -14,7 +14,11 @@ import {
  *
  * 3rd type parameter is deprecated and unused.
  */
-export const deserializerMiddleware = <Input extends object, Output extends object, CommandSerdeContext extends SerdeContext = any>(
+export const deserializerMiddleware = <
+  Input extends object,
+  Output extends object,
+  CommandSerdeContext extends SerdeContext = any
+>(
   options: SerdeFunctions,
   deserializer: ResponseDeserializer<any, any, CommandSerdeContext>
 ): DeserializeMiddleware<Input, Output> => (
@@ -25,6 +29,13 @@ export const deserializerMiddleware = <Input extends object, Output extends obje
 ): Promise<DeserializeHandlerOutput<Output>> => {
   const { response } = await next(args);
   try {
+    /**
+     * [options] is upgraded from SerdeFunctions to CommandSerdeContext,
+     * since the generated deserializer expects CommandSerdeContext.
+     *
+     * This is okay because options is from the same client's resolved config,
+     * and the deserializer doesn't need the `endpoint` field.
+     */
     const parsed = await deserializer(response, options as CommandSerdeContext);
     return {
       response,

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -11,8 +11,6 @@ import {
 
 /**
  * @internal
- *
- * 3rd type parameter is deprecated and unused.
  */
 export const deserializerMiddleware = <
   Input extends object = any,

--- a/packages/middleware-serde/src/serdePlugin.ts
+++ b/packages/middleware-serde/src/serdePlugin.ts
@@ -45,7 +45,11 @@ export type V1OrV2Endpoint = {
  *
  * Note: 2nd type parameter is deprecated and unused.
  */
-export function getSerdePlugin<InputType extends object, CommandSerdeContext extends SerdeContext, OutputType extends MetadataBearer>(
+export function getSerdePlugin<
+  InputType extends object,
+  CommandSerdeContext extends SerdeContext,
+  OutputType extends MetadataBearer
+>(
   config: V1OrV2Endpoint & SerdeFunctions,
   serializer: RequestSerializer<any, CommandSerdeContext>,
   deserializer: ResponseDeserializer<OutputType, any, CommandSerdeContext>

--- a/packages/middleware-serde/src/serdePlugin.ts
+++ b/packages/middleware-serde/src/serdePlugin.ts
@@ -1,13 +1,13 @@
 import {
   DeserializeHandlerOptions,
   Endpoint,
-  EndpointBearer,
   MetadataBearer,
   MiddlewareStack,
   Pluggable,
   Provider,
   RequestSerializer,
   ResponseDeserializer,
+  SerdeContext,
   SerdeFunctions,
   SerializeHandlerOptions,
   UrlParser,
@@ -45,10 +45,10 @@ export type V1OrV2Endpoint = {
  *
  * Note: 2nd type parameter is deprecated and unused.
  */
-export function getSerdePlugin<InputType extends object, _, OutputType extends MetadataBearer>(
+export function getSerdePlugin<InputType extends object, CommandSerdeContext extends SerdeContext, OutputType extends MetadataBearer>(
   config: V1OrV2Endpoint & SerdeFunctions,
-  serializer: RequestSerializer<any, SerdeFunctions & EndpointBearer>,
-  deserializer: ResponseDeserializer<OutputType, any, SerdeFunctions>
+  serializer: RequestSerializer<any, CommandSerdeContext>,
+  deserializer: ResponseDeserializer<OutputType, any, CommandSerdeContext>
 ): Pluggable<InputType, OutputType> {
   return {
     applyToStack: (commandStack: MiddlewareStack<InputType, OutputType>) => {

--- a/packages/middleware-serde/src/serdePlugin.ts
+++ b/packages/middleware-serde/src/serdePlugin.ts
@@ -43,12 +43,11 @@ export type V1OrV2Endpoint = {
 /**
  * @internal
  *
- * Note: 2nd type parameter is deprecated and unused.
  */
 export function getSerdePlugin<
-  InputType extends object,
-  CommandSerdeContext extends SerdeContext,
-  OutputType extends MetadataBearer
+  InputType extends object = any,
+  CommandSerdeContext extends SerdeContext = any,
+  OutputType extends MetadataBearer = any
 >(
   config: V1OrV2Endpoint & SerdeFunctions,
   serializer: RequestSerializer<any, CommandSerdeContext>,

--- a/packages/middleware-serde/src/serializerMiddleware.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.ts
@@ -19,8 +19,8 @@ import type { V1OrV2Endpoint } from "./serdePlugin";
  * Note: 3rd type parameter is deprecated and unused.
  */
 export const serializerMiddleware = <
-  Input extends object,
-  Output extends object,
+  Input extends object = any,
+  Output extends object = any,
   CommandSerdeContext extends SerdeContext = any
 >(
   options: V1OrV2Endpoint & SerdeFunctions,

--- a/packages/middleware-serde/src/serializerMiddleware.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.ts
@@ -15,8 +15,6 @@ import type { V1OrV2Endpoint } from "./serdePlugin";
 
 /**
  * @internal
- *
- * Note: 3rd type parameter is deprecated and unused.
  */
 export const serializerMiddleware = <
   Input extends object = any,

--- a/packages/middleware-serde/src/serializerMiddleware.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.ts
@@ -1,7 +1,7 @@
 import {
-  EndpointBearer,
   HandlerExecutionContext,
   RequestSerializer,
+  SerdeContext,
   SerdeFunctions,
   SerializeHandler,
   SerializeHandlerArguments,
@@ -16,9 +16,9 @@ import type { V1OrV2Endpoint } from "./serdePlugin";
  *
  * Note: 3rd type parameter is deprecated and unused.
  */
-export const serializerMiddleware = <Input extends object, Output extends object, _>(
+export const serializerMiddleware = <Input extends object, Output extends object, CommandSerdeContext extends SerdeContext = any>(
   options: V1OrV2Endpoint & SerdeFunctions,
-  serializer: RequestSerializer<any, SerdeFunctions & EndpointBearer>
+  serializer: RequestSerializer<any, CommandSerdeContext>
 ): SerializeMiddleware<Input, Output> => (
   next: SerializeHandler<Input, Output>,
   context: HandlerExecutionContext
@@ -34,7 +34,7 @@ export const serializerMiddleware = <Input extends object, Output extends object
     throw new Error("No valid endpoint provider available.");
   }
 
-  const request = await serializer(args.input, { ...options, endpoint });
+  const request = await serializer(args.input, { ...options, endpoint } as CommandSerdeContext);
 
   return next({
     ...args,


### PR DESCRIPTION
This fixes type compatibility of the latest version of `serdePlugin` with older code generation that isn't on the `classBuilder` syntax.