### PR TITLE
fix(util-base64): allow arrays to stand in for Uint8Array (runtime only)

### DIFF
--- a/.changeset/old-kangaroos-rhyme.md
+++ b/.changeset/old-kangaroos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-base64": patch
+---
+
+allow arrays to stand in for Uint8Array in toBase64

--- a/packages/util-base64/src/toBase64.browser.spec.ts
+++ b/packages/util-base64/src/toBase64.browser.spec.ts
@@ -4,6 +4,7 @@
 import type { Encoder } from "@smithy/types";
 
 import testCases from "./__mocks__/testCases.json";
+import { fromBase64 } from "./fromBase64.browser";
 import { toBase64 } from "./toBase64.browser";
 
 describe(toBase64.name, () => {
@@ -18,5 +19,12 @@ describe(toBase64.name, () => {
   it("throws on non-string non-Uint8Array", () => {
     expect(() => (toBase64 as Encoder)(new Date())).toThrow();
     expect(() => (toBase64 as Encoder)({})).toThrow();
+  });
+
+  it("allows array to stand in for Uint8Array", () => {
+    expect(() => (toBase64 as Encoder)([])).not.toThrow();
+
+    const helloUtf8Array = fromBase64("aGVsbG8=");
+    expect(toBase64(([...helloUtf8Array] as unknown) as Uint8Array)).toEqual("aGVsbG8=");
   });
 });

--- a/packages/util-base64/src/toBase64.browser.ts
+++ b/packages/util-base64/src/toBase64.browser.ts
@@ -17,9 +17,17 @@ export function toBase64(_input: Uint8Array | string): string {
   } else {
     input = _input as Uint8Array;
   }
-  if (typeof input !== "object" || typeof input.byteOffset !== "number" || typeof input.byteLength !== "number") {
+
+  const isArrayLike = typeof input === "object" && typeof input.length === "number";
+  const isUint8Array =
+    typeof input === "object" &&
+    typeof (input as Uint8Array).byteOffset === "number" &&
+    typeof (input as Uint8Array).byteLength === "number";
+
+  if (!isArrayLike && !isUint8Array) {
     throw new Error("@smithy/util-base64: toBase64 encoder function only accepts string | Uint8Array.");
   }
+
   let str = "";
   for (let i = 0; i < input.length; i += 3) {
     let bits = 0;


### PR DESCRIPTION
There was some application code using arrays `[]` instead of `Uint8Array`, ignoring types. 

https://github.com/aws-amplify/amplify-ui/blob/bd05991f9bf0f666694c90d6445b63dcc8c795f3/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts#L174-L198

We requested the client code to patch the behavior, but we can modify this to be consistent with prior runtime behavior as well.

ArrayLike values are acceptable but not preferred (for compactness) in lieu of Uint8Array because in the browser implementation, data is read from index entries of the input object. 