### PR TITLE
chore: update dependabot configuration to group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,41 @@ updates:
   - package-ecosystem: "gradle"
     # Look for `build.gradle.kts` file in the `root` directory
     directory: "/"
-    # Check for updates every day (weekdays)
+    # Check for updates every wednesday
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "wednesday"
+    groups:
+      test-deps:
+        patterns:
+          - "org.junit.jupiter:*"
+          - "org.hamcrest:*"
+        # Ignore major version updates
+        update-types:
+          - "minor"
+          - "patch"
+      gradle-deps:
+        # Ignore major version updates
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    # Look for `yarn.lock` file in the `root` directory
+    directory: "/"
+    # Check for updates every wednesday
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every wednesday
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      github:
+        # Ignore major version updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
*Description of changes:*
Updates the dependabot configuration to run on a specific day (wednesday) and to group updates to Gradle or github actions. Updates to NPM dependencies are not grouped.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
