### PR TITLE
chore: update to use new smithy gradle plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Then, add the `smithy-typescript-codegen` dependency in `build.gradle.kts`:
 ```kotlin
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.10.1")
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 smithyVersion=1.45.0
-smithyGradleVersion=0.6.0
+smithyGradleVersion=0.10.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,12 @@ file(
     }
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+        id("software.amazon.smithy.gradle.smithy-base").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/smithy-typescript-codegen-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     val smithyVersion: String by project
 
-    // Put plugins and integrations on the
+    // Put plugins and integrations on the smithy build classpath
     smithyBuild(project(":smithy-typescript-codegen"))
     smithyBuild(project(":smithy-typescript-codegen-test:example-weather-customizations"))
     smithyBuild(project(":smithy-typescript-ssdk-codegen-test-utils"))

--- a/smithy-typescript-codegen-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/build.gradle.kts
@@ -16,23 +16,10 @@
 extra["displayName"] = "Smithy :: Typescript :: Codegen :: Test"
 extra["moduleName"] = "software.amazon.smithy.typescript.codegen.test"
 
-val smithyVersion: String by project
-
-buildscript {
-    val smithyVersion: String by project
-
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
-    }
-}
 
 plugins {
-    val smithyGradleVersion: String by project
-
-    id("software.amazon.smithy").version(smithyGradleVersion)
+    `java-library`
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 repositories {
@@ -41,9 +28,13 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":smithy-typescript-codegen"))
-    implementation(project(":smithy-typescript-codegen-test:example-weather-customizations"))
-    implementation(project(":smithy-typescript-ssdk-codegen-test-utils"))
+    val smithyVersion: String by project
+
+    // Put plugins and integrations on the
+    smithyBuild(project(":smithy-typescript-codegen"))
+    smithyBuild(project(":smithy-typescript-codegen-test:example-weather-customizations"))
+    smithyBuild(project(":smithy-typescript-ssdk-codegen-test-utils"))
+
     implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")

--- a/smithy-typescript-codegen-test/example-weather-customizations/build.gradle.kts
+++ b/smithy-typescript-codegen-test/example-weather-customizations/build.gradle.kts
@@ -3,20 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-val smithyVersion: String by project
-
-buildscript {
-    val smithyVersion: String by project
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-    dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
-    }
-}
-
 plugins {
     `java-library`
 }

--- a/smithy-typescript-codegen-test/released-version-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/released-version-test/build.gradle.kts
@@ -3,24 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tasks["jar"].enabled = false
-
-val smithyVersion: String by project
-val version: String by project
-
-buildscript {
-    val smithyVersion: String by project
-
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
-    }
-}
-
 plugins {
-    id("software.amazon.smithy")
+    java
+    id("software.amazon.smithy.gradle.smithy-base")
 }
 
 repositories {
@@ -28,8 +13,18 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:$version!!")
-    implementation("software.amazon.smithy.typescript:smithy-aws-typescript-codegen:$version!!")
+    val smithyVersion: String by project
+    val version: String by project
+
+    smithyBuild("software.amazon.smithy.typescript:smithy-typescript-codegen:$version!!")
+    smithyBuild("software.amazon.smithy.typescript:smithy-aws-typescript-codegen:$version!!")
+    smithyBuild(project(":smithy-typescript-codegen-test:example-weather-customizations"))
+
+    // Explicitly configure for CLI version
+    smithyBuild("software.amazon.smithy:smithy-model:$smithyVersion")
+
+    // Includes example model so must be runtime dependency
     implementation(project(":smithy-typescript-codegen-test"))
-    implementation(project(":smithy-typescript-codegen-test:example-weather-customizations"))
 }
+
+tasks["jar"].enabled = false

--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -27,16 +27,20 @@ buildscript {
     repositories {
         mavenCentral()
     }
+
     dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
+        classpath("software.amazon.smithy:smithy-model:$smithyVersion")
     }
 }
 
 dependencies {
+    val smithyVersion: String by project
+
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     api("software.amazon.smithy:smithy-model:$smithyVersion")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
+
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
 }
 
@@ -51,16 +55,16 @@ sourceSets {
 tasks.register("set-dependency-versions") {
     doLast {
         mkdir("$buildDir/generated/resources/software/amazon/smithy/typescript/codegen")
-        var versionsFile =
+        val versionsFile =
                 file("$buildDir/generated/resources/software/amazon/smithy/typescript/codegen/dependencyVersions.properties")
-        var roots = project.file("../packages").listFiles().toMutableList() + project.file("../smithy-typescript-ssdk-libs").listFiles().toList()
+        val roots = project.file("../packages").listFiles().toMutableList() + project.file("../smithy-typescript-ssdk-libs").listFiles().toList()
         roots.forEach { packageDir ->
-            var packageJsonFile = File(packageDir, "package.json")
+            val packageJsonFile = File(packageDir, "package.json")
             if (packageJsonFile.isFile()) {
-                var packageJson = Node.parse(packageJsonFile.readText()).expectObjectNode()
-                var packageName = packageJson.expectStringMember("name").getValue()
-                var packageVersion = packageJson.expectStringMember("version").getValue()
-                var isPrivate = packageJson.getBooleanMemberOrDefault("private", false)
+                val packageJson = Node.parse(packageJsonFile.readText()).expectObjectNode()
+                val packageName = packageJson.expectStringMember("name").getValue()
+                val packageVersion = packageJson.expectStringMember("version").getValue()
+                val isPrivate = packageJson.getBooleanMemberOrDefault("private", false)
                 if (!isPrivate) {
                     versionsFile.appendText("$packageName=$packageVersion\n")
                 }

--- a/smithy-typescript-ssdk-codegen-test-utils/build.gradle.kts
+++ b/smithy-typescript-ssdk-codegen-test-utils/build.gradle.kts
@@ -1,24 +1,8 @@
 extra["displayName"] = "Smithy :: Typescript :: SSDK :: Codegen :: Test :: Utils"
 extra["moduleName"] = "software.amazon.smithy.typescript.ssdk.codegen.test.utils"
 
-val smithyVersion: String by project
-
-buildscript {
-    val smithyVersion: String by project
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-    dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
-    }
-}
-
 plugins {
-    val smithyGradleVersion: String by project
-
-    id("software.amazon.smithy").version(smithyGradleVersion)
+    `java-library`
 }
 
 repositories {
@@ -28,5 +12,4 @@ repositories {
 
 dependencies {
     implementation(project(":smithy-typescript-codegen"))
-    implementation("software.amazon.smithy:smithy-model:$smithyVersion")
 }


### PR DESCRIPTION
*Description of changes:*
Updates to use the newer split smithy gradle plugins. (see: https://smithy.io/2.0/guides/gradle-plugin/gradle-migration-guide.html)

*test*
Checked with js v3 by published `smithy-typescript` to maven localexecuted `./gradlew clean build` from the `codegen` dir of jsv3

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
