### PR TITLE
feat: allow commands to be constructed without arg if all arg fields optional

### DIFF
--- a/.changeset/six-doors-speak.md
+++ b/.changeset/six-doors-speak.md
@@ -1,0 +1,6 @@
+---
+"@smithy/smithy-client": patch
+"@smithy/types": patch
+---
+
+allow command constructor argument to be omitted if no required members

--- a/packages/smithy-client/src/command.spec.ts
+++ b/packages/smithy-client/src/command.spec.ts
@@ -12,11 +12,9 @@ describe(Command.name, () => {
       optional?: string;
     };
 
-    class WithRequiredInputCommand extends Command.classBuilder<RequiredInput, any, any, any, any>()
-      .build() {}
+    class WithRequiredInputCommand extends Command.classBuilder<RequiredInput, any, any, any, any>().build() {}
 
-    class WithOptionalInputCommand extends Command.classBuilder<OptionalInput, any, any, any, any>()
-      .build() {}
+    class WithOptionalInputCommand extends Command.classBuilder<OptionalInput, any, any, any, any>().build() {}
 
     new WithRequiredInputCommand({ key: "1" });
 

--- a/packages/smithy-client/src/command.spec.ts
+++ b/packages/smithy-client/src/command.spec.ts
@@ -1,6 +1,27 @@
 import { Command } from "./command";
 
 describe(Command.name, () => {
+  it("has optional argument if the input type has no required members", async () => {
+    type OptionalInput = {
+      key?: string;
+      optional?: string;
+    };
+
+    type RequiredInput = {
+      key: string | undefined;
+      optional?: string;
+    };
+
+    class WithRequiredInputCommand extends Command.classBuilder<RequiredInput, any, any, any, any>()
+      .build() {}
+
+    class WithOptionalInputCommand extends Command.classBuilder<OptionalInput, any, any, any, any>()
+      .build() {}
+
+    new WithRequiredInputCommand({ key: "1" });
+
+    new WithOptionalInputCommand(); // expect no type error.
+  });
   it("implements a classBuilder", async () => {
     class MyCommand extends Command.classBuilder<any, any, any, any, any>()
       .ep({

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -11,6 +11,7 @@ import type {
   Logger,
   MetadataBearer,
   MiddlewareStack as IMiddlewareStack,
+  OptionalParameter,
   Pluggable,
   RequestHandler,
   SerdeContext,
@@ -217,7 +218,7 @@ class ClassBuilder<
    * @returns a Command class with the classBuilder properties.
    */
   public build(): {
-    new (input: I): CommandImpl<I, O, C, SI, SO>;
+    new (...[input]: OptionalParameter<I>): CommandImpl<I, O, C, SI, SO>;
     getEndpointParameterInstructions(): EndpointParameterInstructions;
   } {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -225,6 +226,8 @@ class ClassBuilder<
     let CommandRef: any;
 
     return (CommandRef = class extends Command<I, O, C, SI, SO> {
+      public readonly input: I;
+
       /**
        * @public
        */
@@ -235,8 +238,9 @@ class ClassBuilder<
       /**
        * @public
        */
-      public constructor(readonly input: I) {
+      public constructor(...[input]: OptionalParameter<I>) {
         super();
+        this.input = input ?? (({} as unknown) as I);
         closure._init(this);
       }
 

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -218,6 +218,7 @@ class ClassBuilder<
    * @returns a Command class with the classBuilder properties.
    */
   public build(): {
+    new (input: I): CommandImpl<I, O, C, SI, SO>;
     new (...[input]: OptionalParameter<I>): CommandImpl<I, O, C, SI, SO>;
     getEndpointParameterInstructions(): EndpointParameterInstructions;
   } {

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,7 +1,7 @@
 import { Command } from "./command";
 import { MiddlewareStack } from "./middleware";
 import { MetadataBearer } from "./response";
-import { Exact } from "./util";
+import { OptionalParameter } from "./util";
 
 /**
  * @public
@@ -9,7 +9,7 @@ import { Exact } from "./util";
  * A type which checks if the client configuration is optional.
  * If all entries of the client configuration are optional, it allows client creation without passing any config.
  */
-export type CheckOptionalClientConfig<T> = Exact<Partial<T>, T> extends true ? [] | [T] : [T];
+export type CheckOptionalClientConfig<T> = OptionalParameter<T>;
 
 /**
  * @public

--- a/packages/types/src/util.spec.ts
+++ b/packages/types/src/util.spec.ts
@@ -1,0 +1,40 @@
+import type { Exact, OptionalParameter } from "./util";
+
+type Assignable<LHS, RHS> = [RHS] extends [LHS] ? true : false;
+
+type OptionalInput = {
+  key?: string;
+  optional?: string;
+};
+
+type RequiredInput = {
+  key: string | undefined;
+  optional?: string;
+};
+
+{
+  // optional parameter transform of an optional input is not equivalent to exactly 1 parameter.
+  type A = [...OptionalParameter<OptionalInput>];
+  type B = [OptionalInput];
+  type C = [OptionalInput] | [];
+
+  const assert1: Exact<A, B> = false as const;
+  const assert2: Exact<A, C> = true as const;
+
+  const assert3: Assignable<A, []> = true as const;
+  const assert4: A = [];
+
+  const assert5: Assignable<A, [{ key: "" }]> = true as const;
+  const assert6: A = [{ key: "" }];
+}
+
+{
+  // optional parameter transform of a required input is equivalent to exactly 1 parameter.
+  type A = [...OptionalParameter<RequiredInput>];
+  type B = [RequiredInput];
+
+  const assert1: Exact<A, B> = true as const;
+  const assert2: Assignable<A, []> = false as const;
+  const assert3: Assignable<A, [{ key: "" }]> = true as const;
+  const assert4: A = [{ key: "" }];
+}

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -188,4 +188,4 @@ export interface RetryStrategy {
  * Indicates the parameter may be omitted if the parameter object T
  * is equivalent to a Partial<T>, i.e. all properties optional.
  */
-export type OptionalParameter<T> = Exact<Partial<T>, T> extends true ? [] | [T] : [T]
+export type OptionalParameter<T> = Exact<Partial<T>, T> extends true ? [] | [T] : [T];

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -181,3 +181,11 @@ export interface RetryStrategy {
     args: FinalizeHandlerArguments<Input>
   ) => Promise<FinalizeHandlerOutput<Output>>;
 }
+
+/**
+ * @public
+ *
+ * Indicates the parameter may be omitted if the parameter object T
+ * is equivalent to a Partial<T>, i.e. all properties optional.
+ */
+export type OptionalParameter<T> = Exact<Partial<T>, T> extends true ? [] | [T] : [T]

--- a/smithy-typescript-codegen-test/model/weather/main.smithy
+++ b/smithy-typescript-codegen-test/model/weather/main.smithy
@@ -167,17 +167,17 @@ apply GetCity @httpResponseTests([
         code: 200
         body: """
             {
-            "name": "Seattle",
-            "coordinates": {
-            "latitude": 12.34,
-            "longitude": -56.78
-            },
-            "city": {
-            "cityId": "123",
-            "name": "Seattle",
-            "number": "One",
-            "case": "Upper"
-            }
+                "name": "Seattle",
+                "coordinates": {
+                    "latitude": 12.34,
+                    "longitude": -56.78
+                },
+                "city": {
+                    "cityId": "123",
+                    "name": "Seattle",
+                    "number": "One",
+                    "case": "Upper"
+                }
             }"""
         bodyMediaType: "application/json"
         params: {
@@ -259,8 +259,8 @@ apply NoSuchResource @httpResponseTests([
         code: 404
         body: """
             {
-            "resourceType": "City",
-            "message": "Your custom message"
+                "resourceType": "City",
+                "message": "Your custom message"
             }"""
         bodyMediaType: "application/json"
         params: { resourceType: "City", message: "Your custom message" }

--- a/smithy-typescript-codegen-test/model/weather/main.smithy
+++ b/smithy-typescript-codegen-test/model/weather/main.smithy
@@ -167,17 +167,17 @@ apply GetCity @httpResponseTests([
         code: 200
         body: """
             {
-                "name": "Seattle",
-                "coordinates": {
-                    "latitude": 12.34,
-                    "longitude": -56.78
-                },
-                "city": {
-                    "cityId": "123",
-                    "name": "Seattle",
-                    "number": "One",
-                    "case": "Upper"
-                }
+            "name": "Seattle",
+            "coordinates": {
+            "latitude": 12.34,
+            "longitude": -56.78
+            },
+            "city": {
+            "cityId": "123",
+            "name": "Seattle",
+            "number": "One",
+            "case": "Upper"
+            }
             }"""
         bodyMediaType: "application/json"
         params: {
@@ -259,8 +259,8 @@ apply NoSuchResource @httpResponseTests([
         code: 404
         body: """
             {
-                "resourceType": "City",
-                "message": "Your custom message"
+            "resourceType": "City",
+            "message": "Your custom message"
             }"""
         bodyMediaType: "application/json"
         params: { resourceType: "City", message: "Your custom message" }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
@@ -99,26 +99,24 @@ final class ServiceAggregatedClientGenerator implements Runnable {
                     shape -> shape.getAllMembers().values().stream().noneMatch(MemberShape::isRequired)
                 ).orElse(true);
                 if (inputOptional) {
-                    writer.addImport("OptionalParameter", null, TypeScriptDependency.SMITHY_TYPES);
-                    writer.write("""
-                        $L(): Promise<$T>;""", methodName, output);
+                    writer.write("$L(): Promise<$T>;", methodName, output);
                 }
                 writer.write("""
-                    $L(
-                      args: $T,
-                      options?: $T,
-                    ): Promise<$T>;""", methodName, input, applicationProtocol.getOptionsType(), output);
-                writer.write("""
-                    $L(
-                      args: $T,
-                      cb: (err: any, data?: $T) => void
-                    ): void;""", methodName, input, output);
-                writer.write("""
-                    $L(
-                      args: $T,
-                      options: $T,
-                      cb: (err: any, data?: $T) => void
-                    ): void;""", methodName, input, applicationProtocol.getOptionsType(), output);
+                    $1L(
+                      args: $2T,
+                      options?: $3T,
+                    ): Promise<$4T>;
+                    $1L(
+                      args: $2T,
+                      cb: (err: any, data?: $4T) => void
+                    ): void;
+                    $1L(
+                      args: $2T,
+                      options: $3T,
+                      cb: (err: any, data?: $4T) => void
+                    ): void;""",
+                    methodName, input, applicationProtocol.getOptionsType(), output
+                );
                 writer.write("");
             }
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
@@ -94,19 +94,27 @@ final class ServiceAggregatedClientGenerator implements Runnable {
                 writer.writeDocs(
                     "@see {@link " + operationSymbol.getName() + "}"
                 );
-                writer.write("$L(\n"
-                            + "  args: $T,\n"
-                            + "  options?: $T,\n"
-                            + "): Promise<$T>;", methodName, input, applicationProtocol.getOptionsType(), output);
-                writer.write("$L(\n"
-                             + "  args: $T,\n"
-                             + "  cb: (err: any, data?: $T) => void\n"
-                             + "): void;", methodName, input, output);
-                writer.write("$L(\n"
-                            + "  args: $T,\n"
-                            + "  options: $T,\n"
-                            + "  cb: (err: any, data?: $T) => void\n"
-                            + "): void;", methodName, input, applicationProtocol.getOptionsType(), output);
+                writer.addImport("OptionalParameter", null, TypeScriptDependency.SMITHY_TYPES);
+                writer.write("""
+                    $L(
+                      ...[args]: OptionalParameter<$T>,
+                    ): Promise<$T>;""", methodName, input, output);
+                writer.write("""
+                    $L(
+                      args: $T,
+                      options?: $T,
+                    ): Promise<$T>;""", methodName, input, applicationProtocol.getOptionsType(), output);
+                writer.write("""
+                    $L(
+                      args: $T,
+                      cb: (err: any, data?: $T) => void
+                    ): void;""", methodName, input, output);
+                writer.write("""
+                    $L(
+                      args: $T,
+                      options: $T,
+                      cb: (err: any, data?: $T) => void
+                    ): void;""", methodName, input, applicationProtocol.getOptionsType(), output);
                 writer.write("");
             }
         });


### PR DESCRIPTION
currently:
```ts
new GetCallerIdentity({}); // empty argument required
sts.getCallerIdentity({}); // empty argument required

new PutObjectCommand({ Key: "", Bucket: "" }); // non-empty argument required
s3.putObject({ Key: "", Bucket: "" }); // non-empty argument required
```

in this PR, feature:
```ts
new GetCallerIdentity(); // argument may be omitted
sts.getCallerIdentity(); // argument may be omitted (codegen TODO)

new PutObjectCommand({ Key: "", Bucket: "" }); // non-empty argument still required
s3.putObject({ Key: "", Bucket: "" }); // non-empty argument still required
```
