### PR TITLE
Use map instead of isEmpty when writing shape docs

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -190,10 +190,11 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                         .replace("}", "\\}");
                     docs = preprocessor.apply(docs);
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
-                        DeprecatedTrait deprecatedTrait = shape.getTrait(DeprecatedTrait.class).get();
-                        String deprecationMessage = deprecatedTrait.getMessage().orElse("");
-                        String deprecationString = "@deprecated"
-                            + (deprecationMessage.isEmpty() ? "" : " " + deprecationMessage);
+                        DeprecatedTrait deprecatedTrait = shape.expectTrait(DeprecatedTrait.class);
+                        String deprecationMessage = deprecatedTrait.getMessage()
+                            .map(msg -> " " + msg)
+                            .orElse("");
+                        String deprecationString = "@deprecated" + deprecationMessage;
                         docs = deprecationString + "\n\n" + docs;
                     }
                     docs = addReleaseTag(shape, docs);


### PR DESCRIPTION
*Issue #, if available:*
Missed in https://github.com/smithy-lang/smithy-typescript/pull/1209#discussion_r1526448065

*Description of changes:*
Use map instead of isEmpty when writing shape docs

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
