### PR TITLE
Move documentation before release tag and deprecation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -189,15 +189,15 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                     docs = docs.replace("{", "\\{")
                         .replace("}", "\\}");
                     docs = preprocessor.apply(docs);
+                    docs = addReleaseTag(shape, docs);
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
                         DeprecatedTrait deprecatedTrait = shape.expectTrait(DeprecatedTrait.class);
                         String deprecationMessage = deprecatedTrait.getMessage()
                             .map(msg -> " " + msg)
                             .orElse("");
                         String deprecationString = "@deprecated" + deprecationMessage;
-                        docs = deprecationString + "\n\n" + docs;
+                        docs = docs + "\n" + deprecationString;
                     }
-                    docs = addReleaseTag(shape, docs);
                     writeDocs(docs);
                     return true;
                 }).orElse(false);
@@ -248,9 +248,9 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
 
     private String addReleaseTag(Shape shape, String docs) {
         if (shape.getTrait(InternalTrait.class).isPresent()) {
-            docs = "@internal\n" + docs;
+            docs = docs + "\n@internal";
         } else {
-            docs = "@public\n" + docs;
+            docs = docs + "\n@public";
         }
         return docs;
     }


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5074

Currently the documentation is read as part of deprecation
Example: https://github.com/aws/aws-sdk-js-v3/blob/a967bfc08aac5714420bef63c55832da49492d4a/clients/client-qconnect/src/commands/QueryAssistantCommand.ts#L34-L40
This will move the documentation before release tag, so that it's read separately and not as deprecation.

TSDoc references:
* https://tsdoc.org/pages/tags/public/
* https://tsdoc.org/pages/tags/deprecated/

*Description of changes:*
Move documentation before release tag and deprecation.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
