### PR TITLE
Move deprecation after description in docs

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -188,16 +188,16 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                     // Escape valid '{' and '}'
                     docs = docs.replace("{", "\\{")
                         .replace("}", "\\}");
-                    docs = preprocessor.apply(docs);
-                    docs = addReleaseTag(shape, docs);
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
                         DeprecatedTrait deprecatedTrait = shape.expectTrait(DeprecatedTrait.class);
                         String deprecationMessage = deprecatedTrait.getMessage()
                             .map(msg -> " " + msg)
                             .orElse("");
                         String deprecationString = "@deprecated" + deprecationMessage;
-                        docs = docs + "\n" + deprecationString;
+                        docs = docs + "\n\n" + deprecationString;
                     }
+                    docs = preprocessor.apply(docs);
+                    docs = addReleaseTag(shape, docs);
                     writeDocs(docs);
                     return true;
                 }).orElse(false);


### PR DESCRIPTION
*Issue #, if available:*
Internal discussion as a follow-up to https://github.com/smithy-lang/smithy-typescript/pull/1211

*Description of changes:*
Neither the jsdoc or tsdoc provide any explicit recommendation on the order of tags. However, when an interface is deprecated, it should appear at the top if developers are reading from top to down.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
