### PR TITLE
fix: empty the contents of the dependencyVersions.properties file when creating it

### DIFF
--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -57,6 +57,8 @@ tasks.register("set-dependency-versions") {
         mkdir("$buildDir/generated/resources/software/amazon/smithy/typescript/codegen")
         val versionsFile =
                 file("$buildDir/generated/resources/software/amazon/smithy/typescript/codegen/dependencyVersions.properties")
+        versionsFile.printWriter().close()
+
         val roots = project.file("../packages").listFiles().toMutableList() + project.file("../smithy-typescript-ssdk-libs").listFiles().toList()
         roots.forEach { packageDir ->
             val packageJsonFile = File(packageDir, "package.json")


### PR DESCRIPTION
I found that my dependencyVersions.properties and sdkVersions.properties files had thousands of lines in them, which is redundant.

The build process creates these files by reading the package json versions of AWS code and of Smithy packages.

These file numbers are used in our dependency enums when initializing an enum value with no particular version number:

```java
public enum TypeScriptDependency implements Dependency {

    SMITHY_CORE("dependencies", "@smithy/core", false),
```

During releases to maven, the then-current versions within the workspace are stamped into the maven artifact. Since the action appends the version to the end of the file, presumably the latest versions will be written in the HashMap, regardless of what may exist already in the file. 

There was a report that 0.19.0 of the smithy-aws-typescript-codegen package had duplicate entries in the `sdkVersions.properties` file.