### PR TITLE
feat: add external package importer-exporter

### DIFF
--- a/.changeset/flat-ducks-behave.md
+++ b/.changeset/flat-ducks-behave.md
@@ -1,0 +1,8 @@
+---
+"@smithy/service-client-documentation-generator": minor
+"@smithy/node-http-handler": minor
+"@smithy/middleware-retry": minor
+"@smithy/external": patch
+---
+
+create external package importer

--- a/packages/external/.gitignore
+++ b/packages/external/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/external/README.md
+++ b/packages/external/README.md
@@ -1,0 +1,11 @@
+# @smithy/external
+
+[![NPM version](https://img.shields.io/npm/v/@smithy/external/latest.svg)](https://www.npmjs.com/package/@smithy/external)
+[![NPM downloads](https://img.shields.io/npm/dm/@smithy/external.svg)](https://www.npmjs.com/package/@smithy/external)
+
+This is an _internal_ package used by other `@smithy/...` packages.
+
+It acts as a centralized importer and re-exporter for external packages.
+It applies build transforms on those packages as needed on a case-by-case basis.
+
+You should _not_ use this package directly in your application code.

--- a/packages/external/api-extractor.json
+++ b/packages/external/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/external/jest.config.js
+++ b/packages/external/jest.config.js
@@ -1,0 +1,7 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+  testEnvironment: "jsdom",
+  testPathIgnorePatterns: ["/node_modules/", "(.*).browser.spec.js"],
+};

--- a/packages/external/package.json
+++ b/packages/external/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@smithy/service-client-documentation-generator",
-  "version": "2.2.0",
+  "name": "@smithy/external",
+  "version": "2.0.0",
+  "description": "Centralized provider and transformer for external packages",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
-    "build:cjs": "node ../../scripts/inline service-client-documentation-generator",
+    "build:cjs": "node ./scripts/esbuild.js",
     "build:es": "yarn g:tsc -p tsconfig.es.json",
     "build:types": "yarn g:tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
@@ -11,32 +12,36 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo || exit 0",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
-    "test": "exit 0"
+    "extract:docs": "api-extractor run --local",
+    "test": "yarn g:jest --passWithNoTests"
   },
+  "author": {
+    "name": "AWS Smithy Team",
+    "url": "https://smithy.io"
+  },
+  "license": "Apache-2.0",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
-  "author": {
-    "name": "AWS SDK for JavaScript Team",
-    "url": "https://aws.amazon.com/javascript/"
+  "exports": {
+    "./package.json": "./package.json",
+    "./uuid": {
+      "types": "./dist-types/packages/uuid/index.d.ts",
+      "require": "./dist-cjs/packages/uuid/index.js",
+      "node": "./dist-cjs/packages/uuid/index.js",
+      "default": "./dist-es/packages/uuid/index.js"
+    }
   },
-  "license": "Apache-2.0",
-  "keywords": [
-    "typedocplugin"
-  ],
   "dependencies": {
     "tslib": "^2.6.2",
-    "typedoc": "0.23.23"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
-    "rimraf": "3.0.2"
-  },
-  "typedoc": {
-    "entryPoint": "src/index.ts"
+    "rimraf": "3.0.2",
+    "typedoc": "0.23.23"
   },
   "typesVersions": {
     "<4.0": {
@@ -48,11 +53,14 @@
   "files": [
     "dist-*/**"
   ],
-  "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/client-documentation-generator",
+  "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/external",
   "repository": {
     "type": "git",
     "url": "https://github.com/awslabs/smithy-typescript.git",
-    "directory": "packages/client-documentation-generator"
+    "directory": "packages/external"
+  },
+  "typedoc": {
+    "entryPoint": "src/index.ts"
   },
   "publishConfig": {
     "directory": ".release/package"

--- a/packages/external/scripts/esbuild.js
+++ b/packages/external/scripts/esbuild.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+const esbuild = require("esbuild");
+
+(async () => {
+  const packages = fs.readdirSync(path.join(__dirname, "..", "src", "packages"));
+
+  for (const pkg of packages) {
+    await esbuild.build({
+      platform: "node",
+      target: ["node14"],
+      bundle: true,
+      format: "cjs",
+      mainFields: ["module", "main"],
+      allowOverwrite: true,
+      entryPoints: [path.join(__dirname, "..", "src", "packages", pkg, "index.ts")],
+      supported: {
+        "dynamic-import": false,
+      },
+      outfile: path.join(__dirname, "..", "dist-cjs", "packages", pkg, "index.js"),
+      keepNames: true,
+      external: [],
+    });
+  }
+})();

--- a/packages/external/src/index.ts
+++ b/packages/external/src/index.ts
@@ -1,0 +1,5 @@
+export {};
+
+throw new Error(
+  "Index export of @smithy/external is not available. See https://github.com/smithy-lang/smithy-typescript/tree/main/packages/external for usage."
+);

--- a/packages/external/src/packages/uuid/index.ts
+++ b/packages/external/src/packages/uuid/index.ts
@@ -1,0 +1,3 @@
+import { v4 } from "uuid";
+
+export { v4 };

--- a/packages/external/tsconfig.cjs.json
+++ b/packages/external/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/external/tsconfig.es.json
+++ b/packages/external/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["dom"],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/external/tsconfig.types.json
+++ b/packages/external/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -31,6 +31,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/external": "workspace:^",
     "@smithy/node-config-provider": "workspace:^",
     "@smithy/protocol-http": "workspace:^",
     "@smithy/service-error-classification": "workspace:^",
@@ -38,8 +39,7 @@
     "@smithy/types": "workspace:^",
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-retry": "workspace:^",
-    "tslib": "^2.6.2",
-    "uuid": "^8.3.2"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/util-test": "workspace:^",

--- a/packages/middleware-retry/src/StandardRetryStrategy.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.ts
@@ -1,3 +1,4 @@
+import { v4 } from "@smithy/external/uuid";
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { isThrottlingError } from "@smithy/service-error-classification";
 import { SdkError } from "@smithy/types";
@@ -11,7 +12,6 @@ import {
   RETRY_MODES,
   THROTTLING_RETRY_DELAY_BASE,
 } from "@smithy/util-retry";
-import { v4 } from "uuid";
 
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { defaultDelayDecider } from "./delayDecider";

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -1,3 +1,4 @@
+import { v4 } from "@smithy/external/uuid";
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { isServerError, isThrottlingError, isTransientError } from "@smithy/service-error-classification";
 import { NoOpLogger } from "@smithy/smithy-client";
@@ -18,7 +19,6 @@ import {
   SdkError,
 } from "@smithy/types";
 import { INVOCATION_ID_HEADER, REQUEST_HEADER } from "@smithy/util-retry";
-import { v4 } from "uuid";
 
 import { RetryResolvedConfig } from "./configurations";
 import { isStreamingPayload } from "./isStreamingPayload/isStreamingPayload";

--- a/packages/node-http-handler/src/set-connection-timeout.ts
+++ b/packages/node-http-handler/src/set-connection-timeout.ts
@@ -1,5 +1,5 @@
 import { ClientRequest } from "http";
-import { Socket } from "net";
+import type { Socket } from "net";
 
 export const setConnectionTimeout = (request: ClientRequest, reject: (err: Error) => void, timeoutInMs = 0) => {
   if (!timeoutInMs) {

--- a/packages/service-client-documentation-generator/src/utils.ts
+++ b/packages/service-client-documentation-generator/src/utils.ts
@@ -1,5 +1,5 @@
 import { sep } from "path";
-import { Reflection } from "typedoc";
+import type { Reflection } from "typedoc";
 
 /**
  * @internal

--- a/scripts/package-json-enforcement.js
+++ b/scripts/package-json-enforcement.js
@@ -26,7 +26,7 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
   const errors = [];
 
   const pkgJson = require(pkgJsonFilePath);
-  if (!pkgJson.name.endsWith("/core")) {
+  if (!pkgJson.name.endsWith("/core") && !pkgJson.name.endsWith("/external")) {
     if ("exports" in pkgJson) {
       errors.push(`${pkgJson.name} must not have an 'exports' field.`);
       if (overwrite) {

--- a/smithy-typescript-codegen-test/model/weather/main.smithy
+++ b/smithy-typescript-codegen-test/model/weather/main.smithy
@@ -167,17 +167,17 @@ apply GetCity @httpResponseTests([
         code: 200
         body: """
             {
-                "name": "Seattle",
-                "coordinates": {
-                    "latitude": 12.34,
-                    "longitude": -56.78
-                },
-                "city": {
-                    "cityId": "123",
-                    "name": "Seattle",
-                    "number": "One",
-                    "case": "Upper"
-                }
+            "name": "Seattle",
+            "coordinates": {
+            "latitude": 12.34,
+            "longitude": -56.78
+            },
+            "city": {
+            "cityId": "123",
+            "name": "Seattle",
+            "number": "One",
+            "case": "Upper"
+            }
             }"""
         bodyMediaType: "application/json"
         params: {
@@ -259,8 +259,8 @@ apply NoSuchResource @httpResponseTests([
         code: 404
         body: """
             {
-                "resourceType": "City",
-                "message": "Your custom message"
+            "resourceType": "City",
+            "message": "Your custom message"
             }"""
         bodyMediaType: "application/json"
         params: { resourceType: "City", message: "Your custom message" }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "esModuleInterop": true,
     "incremental": true,
     "lib": ["es2015", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "@aws-smithy/*": ["smithy-typescript-ssdk-libs/*/src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,6 +2072,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@smithy/external@workspace:^, @smithy/external@workspace:packages/external":
+  version: 0.0.0-use.local
+  resolution: "@smithy/external@workspace:packages/external"
+  dependencies:
+    "@tsconfig/recommended": 1.0.1
+    concurrently: 7.0.0
+    downlevel-dts: 0.10.1
+    rimraf: 3.0.2
+    tslib: ^2.6.2
+    typedoc: 0.23.23
+    uuid: ^9.0.1
+  languageName: unknown
+  linkType: soft
+
 "@smithy/fetch-http-handler@workspace:^, @smithy/fetch-http-handler@workspace:packages/fetch-http-handler":
   version: 0.0.0-use.local
   resolution: "@smithy/fetch-http-handler@workspace:packages/fetch-http-handler"
@@ -2299,6 +2313,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/middleware-retry@workspace:packages/middleware-retry"
   dependencies:
+    "@smithy/external": "workspace:^"
     "@smithy/node-config-provider": "workspace:^"
     "@smithy/protocol-http": "workspace:^"
     "@smithy/service-error-classification": "workspace:^"
@@ -2314,7 +2329,6 @@ __metadata:
     rimraf: 3.0.2
     tslib: ^2.6.2
     typedoc: 0.23.23
-    uuid: ^8.3.2
   languageName: unknown
   linkType: soft
 
@@ -2449,6 +2463,7 @@ __metadata:
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
     tslib: ^2.6.2
+    typedoc: 0.23.23
   languageName: unknown
   linkType: soft
 
@@ -11105,12 +11120,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a package called `@smithy/external`, which re-exports external dependencies.

Why:
- Using `package.json->"exports"` introduced in Node.js 12, this package provides Node.js runtimes a bundled re-export of `uuid` and potentially other external dependencies in the future. This reduces the file count, since otherwise direct import of `uuid` adds a dozen or so files.
- Using browser or ESM build systems and runtimes continues to use the actual `uuid` package, avoiding redundant bundling in web. 

This doesn't actually require Node.js 16 as the minimum, but TypeScript won't understand the sub-export otherwise.