### PR TITLE
chore: make consistent uuid version

### DIFF
--- a/.changeset/fair-spiders-jump.md
+++ b/.changeset/fair-spiders-jump.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-retry": minor
+---
+
+Set uuid to ^9.0.1

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -39,7 +39,7 @@
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-retry": "workspace:^",
     "tslib": "^2.6.2",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/util-test": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,7 +2314,7 @@ __metadata:
     rimraf: 3.0.2
     tslib: ^2.6.2
     typedoc: 0.23.23
-    uuid: ^8.3.2
+    uuid: ^9.0.1
   languageName: unknown
   linkType: soft
 
@@ -11105,12 +11105,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
UUID 9 is already in use in the AWS SDK and the code generator.