### PR TITLE
feat(core): experimental runtime model interpreter 🚧🚧

### DIFF
--- a/.changeset/strong-baboons-sort.md
+++ b/.changeset/strong-baboons-sort.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+add type interfaces for runtime model interpreters

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,7 @@ export * from "./getSmithyContext";
 export * from "./normalizeProvider";
 export * from "./protocols/requestBuilder";
 export { createPaginator } from "./pagination/createPaginator";
+export * from "./protocols/serde/SmithyModel";
+export * from "./protocols/serde/RuntimeModelInterpreter";
+export type { RuntimeModelInterpreterSerialization } from "./protocols/serde/RuntimeModelInterpreterSerialization";
+export type { RuntimeModelInterpreterDeserialization } from "./protocols/serde/RuntimeModelInterpreterDeserialization";

--- a/packages/core/src/protocols/serde/RuntimeModelInterpreter.ts
+++ b/packages/core/src/protocols/serde/RuntimeModelInterpreter.ts
@@ -1,0 +1,123 @@
+import { EndpointParameterInstructions, getEndpointPlugin } from "@smithy/middleware-endpoint";
+import { getSerdePlugin } from "@smithy/middleware-serde";
+import { Command } from "@smithy/smithy-client";
+import type {
+  HttpRequest as IHttpRequest,
+  HttpResponse as IHttpResponse,
+  RuleSetObject,
+  SerdeContext,
+} from "@smithy/types";
+
+import {
+  ISmithyModel,
+  ISmithyModelServiceShape,
+  ISmithyModelShape,
+  ISmithyModelShapeId,
+  SmithyModel,
+} from "./SmithyModel";
+
+export abstract class RuntimeModelInterpreter {
+  /**
+   * The Smithy JSON model data. May be in compressed form.
+   */
+  public model: SmithyModel;
+
+  /**
+   * Used to map endpoint ruleset parameters to implementation names.
+   */
+  protected abstract parameterNameMap: Record<string, string>;
+
+  protected constructor(model: ISmithyModel) {
+    this.model = SmithyModel.from(model);
+  }
+
+  /**
+   * Implemented by extending classes of a concrete protocol.
+   */
+  public abstract serialize<I>(
+    input: I,
+    operationShapeId: ISmithyModelShapeId,
+    context: SerdeContext
+  ): Promise<IHttpRequest>;
+
+  /**
+   * Implemented by extending classes of a concrete protocol.
+   */
+  public abstract deserialize<O>(
+    httpResponse: IHttpResponse,
+    operationShapeId: ISmithyModelShapeId,
+    context: SerdeContext
+  ): Promise<O>;
+
+  /**
+   * Retrieves a shape by its id.
+   * @param id - of the shape to be retrieved.
+   */
+  public getShape<T extends ISmithyModelShape>(id: ISmithyModelShapeId): T {
+    const shape = this.model.shapes[id];
+    if (!shape) {
+      throw new Error("shape not found: " + id);
+    }
+    return shape as T;
+  }
+
+  /**
+   * Retrieves the service shape from the model.
+   */
+  public getServiceShape(): ISmithyModelServiceShape {
+    return Object.values(this.model.shapes).find((shape) => shape.type === "service") as ISmithyModelServiceShape;
+  }
+
+  /**
+   * Retrieves the endpoint ruleset object.
+   */
+  public getEndpointRuleSet(): RuleSetObject {
+    const service = this.getServiceShape();
+    if (!service.traits["smithy.rules#endpointRuleSet"]) {
+      throw new Error("@smithy/core: service does not have endpointRuleSet trait.");
+    }
+    return service.traits["smithy.rules#endpointRuleSet"];
+  }
+
+  /**
+   * Creates a command constructor given the operation's shape id.
+   * @param operationShapeId
+   */
+  public createCommand<I, O>(operationShapeId: ISmithyModelShapeId) {
+    const operation = this.getShape(operationShapeId);
+    const service = this.getServiceShape();
+    const ruleset = this.getEndpointRuleSet();
+    const operationName = operationShapeId.split("#")[1];
+    const sdkId = service.traits["aws.api#service"]!.sdkId;
+
+    return Command.classBuilder<I, O, any, any, any>()
+      .ep(
+        (() => {
+          const parameters: EndpointParameterInstructions = {};
+          for (const [name, parameterMetadata] of Object.entries(ruleset.parameters)) {
+            parameters[name] = {
+              type: parameterMetadata.builtIn ? "builtInParams" : "clientContextParams",
+              name: this.parameterNameMap[name as string] ?? name[0].toLowerCase() + name.slice(1),
+            } as EndpointParameterInstructions[""];
+          }
+          // TODO: context params and static context params from this operation.
+          return parameters;
+        })()
+      )
+      .m(function (this: any, Command: any, cs: any, config: any) {
+        return [
+          getSerdePlugin(config, this.serialize, this.deserialize),
+          getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+        ];
+      })
+      .s(sdkId, operationName[1], {})
+      .n(sdkId + "Client", operationName[1] + "Command")
+      .f(
+        (_) => _,
+        (_) => _
+      )
+      .ser((input, context) => this.serialize(input, operationShapeId, context))
+      .de((httpResponse, context) => this.deserialize(httpResponse, operationShapeId, context))
+      .build();
+  }
+}

--- a/packages/core/src/protocols/serde/RuntimeModelInterpreterDeserialization.ts
+++ b/packages/core/src/protocols/serde/RuntimeModelInterpreterDeserialization.ts
@@ -1,0 +1,103 @@
+import type { HttpResponse as IHttpResponse, MetadataBearer, SerdeContext } from "@smithy/types";
+
+import type {
+  ISmithyModelOperationShape,
+  ISmithyModelShapeId,
+  ISmithyModelStructureShape,
+  ISmithyModelTraits,
+} from "./SmithyModel";
+
+/**
+ * This is an optional guide-rail for extending {@link RuntimeModelInterpreter}
+ * which helps with implementing the deserialization side.
+ *
+ * Extend {@link RuntimeModelInterpreter} and then implement this interface
+ * using it as a reference for what functionality is needed.
+ *
+ * The interface's methods are grouped by number prefix, and the implementation
+ * should find that all methods are accounted for (none unused) and
+ * are called in the order of their grouping prefix.
+ * Methods having the same number prefix can be called in any order.
+ */
+export interface RuntimeModelInterpreterDeserialization {
+  /**
+   * This is the primary top level method this interface will outline.
+   */
+  deserialize<O>(httpResponse: IHttpResponse, operationShapeId: ISmithyModelShapeId, context: SerdeContext): Promise<O>;
+
+  /**
+   * Handle error status, such as statusCode >= 300.
+   */
+  de_0_handleErrorStatusCode(httpResponse: IHttpResponse): void;
+
+  /**
+   * Initialize the operation shape from the top level input, to
+   * retrieve the response shape next.
+   */
+  de_1_getOperationShape(operationShapeId: ISmithyModelShapeId): ISmithyModelOperationShape;
+
+  /**
+   * Get the response shape. The implementation will iterate over its members.
+   */
+  de_2_getResponseShape(responseShapeId: ISmithyModelShapeId): ISmithyModelStructureShape;
+
+  /**
+   * Initialize output object to be returned at the end.
+   * It should be a MetadataBearer.
+   */
+  de_3_initializeOutputWithMetadata(httpResponse: IHttpResponse): MetadataBearer & any;
+
+  /**
+   * Iterate over Object.entries(responseShape.members).
+   * After this loop, the output from {@link #de_initializeOutputWithMetadata} should be ready to be returned in the top level
+   * deserialize function.
+   */
+  de_5_iterateResponseShapeMembers(
+    entries: [string, ISmithyModelStructureShape["members"][""]][],
+    iterationFn: (entry: typeof entries[0]) => Promise<void>
+  ): Promise<void>;
+
+  /**
+   * Within member iteration, conditionally handle member trait
+   * httpResponseCode.
+   */
+  de_6_memberTraitHttpResponseCode(
+    httpResponseCode: ISmithyModelTraits["smithy.api#httpResponseCode"],
+    memberName: string,
+    output: any,
+    httpResponse: IHttpResponse
+  ): void;
+
+  /**
+   * Within member iteration, conditionally handle member trait
+   * httpHeader.
+   */
+  de_6_memberTraitHttpHeader(
+    httpHeader: ISmithyModelTraits["smithy.api#httpHeader"],
+    memberName: string,
+    output: any,
+    httpResponse: IHttpResponse
+  ): void;
+
+  /**
+   * Within member iteration, conditionally handle member trait
+   * httpPayload.
+   */
+  de_6_memberTraitHttpPayload(
+    httpPayload: ISmithyModelTraits["smithy.api#httpPayload"],
+    memberName: string,
+    output: any,
+    httpResponse: IHttpResponse,
+    context: SerdeContext
+  ): Promise<void>;
+
+  /**
+   * Within member iteration, conditionally handle members with no trait.
+   * This usually means they are to be written to the response object as-is
+   * or with some formatting transform.
+   *
+   * Since the implementation varies for this step, it is only a caller
+   * of your supplied function.
+   */
+  de_6_memberWithoutTrait(fn: () => void | Promise<void>): void | Promise<void>;
+}

--- a/packages/core/src/protocols/serde/RuntimeModelInterpreterSerialization.ts
+++ b/packages/core/src/protocols/serde/RuntimeModelInterpreterSerialization.ts
@@ -1,0 +1,117 @@
+import type { HttpRequest as IHttpRequest, SerdeContext } from "@smithy/types";
+
+import type { RequestBuilder } from "../requestBuilder";
+import type {
+  ISmithyModelOperationShape,
+  ISmithyModelShapeId,
+  ISmithyModelStructureShape,
+  ISmithyModelTraits,
+} from "./SmithyModel";
+
+/**
+ * This is an optional guide-rail for extending {@link RuntimeModelInterpreter}
+ * which helps with implementing the serialization side.
+ *
+ * Extend {@link RuntimeModelInterpreter} and then implement this interface
+ * using it as a reference for what functionality is needed.
+ *
+ * The interface's methods are grouped by number prefix, and the implementation
+ * should find that all methods are accounted for (none unused) and
+ * are called in the order of their grouping prefix.
+ * Methods having the same number prefix can be called in any order.
+ */
+export interface RuntimeModelInterpreterSerialization {
+  /**
+   * This is the primary top level method this interface will outline.
+   */
+  serialize<I>(input: I, operationShapeId: ISmithyModelShapeId, context: SerdeContext): Promise<IHttpRequest>;
+
+  /**
+   * Initialize the operation shape from the top level input, to
+   * retrieve the request shape next.
+   */
+  se_0_getOperationShape(operationShapeId: ISmithyModelShapeId): ISmithyModelOperationShape;
+
+  /**
+   * Get the request shape. The implementation will be iterating over its members.
+   */
+  se_1_getRequestShape(responseShapeId: ISmithyModelShapeId): ISmithyModelStructureShape;
+
+  /**
+   * Call {@link RequestBuilder.prototype.bp} with the operation's http trait.
+   */
+  se_2_traitHttp(http: ISmithyModelTraits["smithy.api#http"], b: RequestBuilder): void;
+
+  /**
+   * Initialize headers object.
+   */
+  se_2_initHeaders(): Record<string, string>;
+
+  /**
+   * initialize query object.
+   */
+  se_2_initQuery(): Record<string, string>;
+
+  /**
+   * Iterate over Object.entries(requestShape.members).
+   */
+  se_3_iterateRequestShapeMembers(
+    entries: [string, ISmithyModelStructureShape["members"][""]][],
+    iterationFn: (entry: typeof entries[0]) => Promise<void>
+  ): Promise<void>;
+
+  /**
+   * Within member iteration, conditionally handle the http header trait.
+   * Set the value on the headers object.
+   */
+  se_4_memberTraitHttpHeader(
+    httpHeader: ISmithyModelTraits["smithy.api#httpHeader"],
+    memberName: string,
+    input: any,
+    headers: Record<string, string>
+  ): void;
+
+  /**
+   * Within member iteration, conditionally handle the http query trait.
+   * Set the value on the query object.
+   */
+  se_4_memberTraitHttpQuery(
+    httpQuery: ISmithyModelTraits["smithy.api#httpQuery"],
+    memberName: string,
+    input: any,
+    query: Record<string, string>
+  ): void;
+
+  /**
+   * Within member iteration, conditionally handle the http label trait.
+   * Call {@link RequestBuilder.prototype.p}.
+   */
+  se_4_memberTraitHttpLabel(
+    httpLabel: ISmithyModelTraits["smithy.api#httpLabel"],
+    memberName: string,
+    input: any,
+    b: RequestBuilder
+  ): void;
+
+  /**
+   * Within member iteration, conditionally handle the http header trait.
+   *
+   * @returns the HttpRequest body value.
+   */
+  se_4_memberTraitHttpPayload(
+    httpPayload: ISmithyModelTraits["smithy.api#httpPayload"],
+    memberName: string,
+    input: any
+  ): any;
+
+  /**
+   * Conditionally handle a member with no trait. This usually means being written
+   * to the same field on the body object before its serialization.
+   *
+   * This should be exclusive with the httpPayload trait.
+   *
+   * Since the implementation varies for this step, it is only a caller
+   * of your supplied function.
+   */
+  se_4_memberWithoutTrait(fn: () => void | Promise<void>): void | Promise<void>;
+}

--- a/packages/core/src/protocols/serde/SmithyModel.ts
+++ b/packages/core/src/protocols/serde/SmithyModel.ts
@@ -1,0 +1,83 @@
+import { RuleSetObject } from "@smithy/types";
+
+export interface ISmithyModel {
+  smithy: "2.0";
+  metadata: {
+    suppressions: { id: string; namespace: string }[];
+  };
+  shapes: Record<ISmithyModelShapeId, ISmithyModelShape>;
+}
+
+export interface ISmithyModelShape {
+  type: string;
+}
+
+export interface ISmithyModelServiceShape extends ISmithyModelShape {
+  type: "service";
+  version: string;
+  operations: { target: ISmithyModelShapeId }[];
+  traits: ISmithyModelTraits;
+}
+
+export interface ISmithyModelStructureShape extends ISmithyModelShape {
+  type: "structure";
+  members: {
+    [memberName: string]: {
+      target: ISmithyModelShapeId;
+      traits: ISmithyModelTraits;
+    };
+  };
+  traits: ISmithyModelTraits;
+}
+
+export interface ISmithyModelOperationShape extends ISmithyModelShape {
+  type: "operation";
+  input: {
+    target: ISmithyModelShapeId;
+  };
+  output: {
+    target: ISmithyModelShapeId;
+  };
+  errors: { target: ISmithyModelShapeId }[];
+  traits: ISmithyModelTraits;
+}
+
+export type ISmithyModelTraits = {
+  "smithy.api#http"?: {
+    method: string;
+    uri: string;
+    code: number;
+  };
+  "smithy.api#httpLabel"?: {} | undefined;
+  "smithy.api#httpHeader"?: string;
+  "smithy.api#httpQuery"?: string;
+  "smithy.api#httpPayload"?: {} | undefined;
+  "smithy.api#jsonName"?: string;
+  "smithy.api#httpResponseCode"?: {} | undefined;
+  "smithy.rules#endpointRuleSet"?: RuleSetObject | undefined;
+  "aws.api#service"?: {
+    sdkId: string;
+  };
+  [traitName: string]: unknown;
+};
+
+export type ISmithyModelShapeId = `${string}#${string}`;
+
+export class SmithyModel implements ISmithyModel {
+  public smithy: ISmithyModel["smithy"];
+  public metadata: ISmithyModel["metadata"];
+  public shapes: ISmithyModel["shapes"];
+
+  public static from(model: ISmithyModel) {
+    if (model instanceof SmithyModel) {
+      return model;
+    }
+    return new SmithyModel(model);
+  }
+
+  public constructor(public readonly _jsonObject: ISmithyModel) {
+    this.smithy = _jsonObject.smithy;
+    this.metadata = _jsonObject.metadata;
+    this.shapes = _jsonObject.shapes;
+  }
+}


### PR DESCRIPTION
🚧🚧🚧

Prototyping serde alternative that accepts a Smithy json model at runtime.

AwsRestJson1 implementation is in https://github.com/aws/aws-sdk-js-v3/pull/5935

Goals:
- performance and code size parity or improvement vs. current code gen serde
- allow runtime provision of models such as a regular Smithy JSON model file or compressed form
- swap protocols at runtime in the same client?? 🤔