### PR TITLE
fix(signature-v4): uri escape path (#1224)

### DIFF
--- a/.changeset/little-otters-complain.md
+++ b/.changeset/little-otters-complain.md
@@ -1,0 +1,5 @@
+---
+"@smithy/signature-v4": minor
+---
+
+Escape non-standard characters in URI paths according to RFC 3986

--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -168,7 +168,7 @@ describe("SignatureV4", () => {
       /**
        * An environment specific stream that the signer knows nothing about.
        */
-      class ExoticStream {}
+      class ExoticStream { }
 
       const { query } = await signer.presign(
         new HttpRequest({
@@ -450,7 +450,7 @@ describe("SignatureV4", () => {
       /**
        * An environment specific stream that the signer knows nothing about.
        */
-      class ExoticStream {}
+      class ExoticStream { }
       const { headers } = await signer.sign(
         new HttpRequest({
           ...minimalRequest,
@@ -628,6 +628,13 @@ describe("SignatureV4", () => {
         const { headers } = await signer.sign({ ...minimalRequest, path: "//foo%3Dbar" }, signingOptions);
         expect(headers[AUTH_HEADER]).toEqual(
           expect.stringContaining("Signature=fb4948cab44a9c47ce3b1a2489d01ec939fea9e79eccdb4593c11a94f207e075")
+        );
+      });
+
+      it("should normalize path with non-standard characters by default", async () => {
+        const { headers } = await signer.sign({ ...minimalRequest, path: "/foo/!'()*" }, signingOptions);
+        expect(headers[AUTH_HEADER]).toEqual(
+          expect.stringContaining("Signature=698b237cc68fe34535e57f374fa81f63219314b5a877742f889f6222c9ecab7b")
         );
       });
 

--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -168,7 +168,7 @@ describe("SignatureV4", () => {
       /**
        * An environment specific stream that the signer knows nothing about.
        */
-      class ExoticStream { }
+      class ExoticStream {}
 
       const { query } = await signer.presign(
         new HttpRequest({
@@ -450,7 +450,7 @@ describe("SignatureV4", () => {
       /**
        * An environment specific stream that the signer knows nothing about.
        */
-      class ExoticStream { }
+      class ExoticStream {}
       const { headers } = await signer.sign(
         new HttpRequest({
           ...minimalRequest,

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -48,6 +48,7 @@ import { hasHeader } from "./headerUtil";
 import { moveHeadersToQuery } from "./moveHeadersToQuery";
 import { prepareRequest } from "./prepareRequest";
 import { iso8601 } from "./utilDate";
+import { escapeUri } from "@smithy/util-uri-escape";
 
 export interface SignatureV4Init {
   /**
@@ -331,7 +332,8 @@ ${toHex(hashedRequest)}`;
         normalizedPathSegments.length > 0 && path?.endsWith("/") ? "/" : ""
       }`;
 
-      const doubleEncoded = encodeURIComponent(normalizedPath);
+      // Double encode and replace non-standard characters !'()* according to RFC 3986
+      const doubleEncoded = escapeUri(normalizedPath);
       return doubleEncoded.replace(/%2F/g, "/");
     }
 

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -21,6 +21,7 @@ import {
 } from "@smithy/types";
 import { toHex } from "@smithy/util-hex-encoding";
 import { normalizeProvider } from "@smithy/util-middleware";
+import { escapeUri } from "@smithy/util-uri-escape";
 import { toUint8Array } from "@smithy/util-utf8";
 
 import {
@@ -48,7 +49,6 @@ import { hasHeader } from "./headerUtil";
 import { moveHeadersToQuery } from "./moveHeadersToQuery";
 import { prepareRequest } from "./prepareRequest";
 import { iso8601 } from "./utilDate";
-import { escapeUri } from "@smithy/util-uri-escape";
 
 export interface SignatureV4Init {
   /**


### PR DESCRIPTION
Issue #1224 

*Description of changes:*

URI escape non-standard characters in the URI path according to RFC 3986. 
See #1224 for more information.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
