### PR TITLE
fix(middleware-endpoint): check for s3 arn parts

### DIFF
--- a/.changeset/khaki-moose-punch.md
+++ b/.changeset/khaki-moose-punch.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+fix s3 arn check not checking for region or account

--- a/.changeset/khaki-moose-punch.md
+++ b/.changeset/khaki-moose-punch.md
@@ -2,4 +2,4 @@
 "@smithy/middleware-endpoint": patch
 ---
 
-fix s3 arn check not checking for region or account
+Do not require account in checking whether a string is an S3 bucket ARN.

--- a/packages/middleware-endpoint/src/service-customizations/s3.spec.ts
+++ b/packages/middleware-endpoint/src/service-customizations/s3.spec.ts
@@ -1,0 +1,20 @@
+import { isArnBucketName } from "./s3";
+
+describe("S3 customizations for endpoint resolution", () => {
+  describe(isArnBucketName.name, () => {
+    it("should require the partition, service, and a resource id", () => {
+      expect(isArnBucketName("arn:aws:s3:us-east-1:1234567890:bucket_name")).toBe(true);
+
+      expect(() => isArnBucketName("arn::s3:us-east-1:1234567890:bucket_name")).toThrow();
+      expect(() => isArnBucketName("arn:aws::us-east-1:1234567890:bucket_name")).toThrow();
+      expect(() => isArnBucketName("arn:aws:s3:us-east-1:1234567890:")).toThrow();
+    });
+    it("should not require the account id", () => {
+      expect(isArnBucketName("arn:aws:s3:::bucket_name")).toBe(true);
+      expect(isArnBucketName("arn:aws:s3::123456789:bucket_name")).toBe(true);
+
+      expect(() => isArnBucketName("arn:aws:s3:::")).toThrow();
+      expect(() => isArnBucketName("arn:aws:s3::123456789:")).toThrow();
+    });
+  });
+});

--- a/packages/middleware-endpoint/src/service-customizations/s3.ts
+++ b/packages/middleware-endpoint/src/service-customizations/s3.ts
@@ -59,12 +59,15 @@ export const isDnsCompatibleBucketName = (bucketName: string): boolean =>
  * @internal
  */
 export const isArnBucketName = (bucketName: string): boolean => {
-  const [arn, partition, service, region, account, typeOrId] = bucketName.split(":");
+  // region and account are unused between service and bucket.
+  const [arn, partition, service, , , bucket] = bucketName.split(":");
+
   const isArn = arn === "arn" && bucketName.split(":").length >= 6;
-  const isValidArn =
-    [arn, partition, service, typeOrId].filter(Boolean).length === 4 && [region, account].filter(Boolean).length == 0;
+  const isValidArn = Boolean(isArn && partition && service && bucket);
+
   if (isArn && !isValidArn) {
     throw new Error(`Invalid ARN: ${bucketName} was an invalid ARN.`);
   }
-  return arn === "arn" && !!partition && !!service && !!typeOrId;
+
+  return isValidArn;
 };

--- a/packages/middleware-endpoint/src/service-customizations/s3.ts
+++ b/packages/middleware-endpoint/src/service-customizations/s3.ts
@@ -61,9 +61,10 @@ export const isDnsCompatibleBucketName = (bucketName: string): boolean =>
 export const isArnBucketName = (bucketName: string): boolean => {
   const [arn, partition, service, region, account, typeOrId] = bucketName.split(":");
   const isArn = arn === "arn" && bucketName.split(":").length >= 6;
-  const isValidArn = [arn, partition, service, account, typeOrId].filter(Boolean).length === 5;
+  const isValidArn =
+    [arn, partition, service, typeOrId].filter(Boolean).length === 4 && [region, account].filter(Boolean).length == 0;
   if (isArn && !isValidArn) {
     throw new Error(`Invalid ARN: ${bucketName} was an invalid ARN.`);
   }
-  return arn === "arn" && !!partition && !!service && !!account && !!typeOrId;
+  return arn === "arn" && !!partition && !!service && !!typeOrId;
 };


### PR DESCRIPTION
As stated in this issue https://github.com/smithy-lang/smithy-typescript/issues/1121 arn check should not check s3 arns contain nor account nor region since they are not part of s3 arns

*Issue #, if available:*

#1121

*Description of changes:*

Check S3 arn is valid by not expecting account nor region to be in the arn (fail if any of those two are present)

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
