### PR TITLE
feat(types): add accountId to the credential identity interface

### DIFF
--- a/.changeset/strong-timers-join.md
+++ b/.changeset/strong-timers-join.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": minor
+---
+
+adds accountId to the AwsCredentialIdentity interface

--- a/packages/types/src/identity/awsCredentialIdentity.ts
+++ b/packages/types/src/identity/awsCredentialIdentity.ts
@@ -24,6 +24,11 @@ export interface AwsCredentialIdentity extends Identity {
    * AWS credential scope for this set of credentials.
    */
   readonly credentialScope?: string;
+
+  /**
+   * AWS accountId that may be used for endpoint routing.
+   */
+  readonly accountId?: string;
 }
 
 /**

--- a/packages/types/src/identity/awsCredentialIdentity.ts
+++ b/packages/types/src/identity/awsCredentialIdentity.ts
@@ -26,7 +26,7 @@ export interface AwsCredentialIdentity extends Identity {
   readonly credentialScope?: string;
 
   /**
-   * AWS accountId that may be used for endpoint routing.
+   * AWS accountId.
    */
   readonly accountId?: string;
 }


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-4633

*Description of changes:*
Adds `accountId` as optional to the `AwsCredentialIdentity` interface. This `accountId` may be used for endpoint routing. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
