### PR TITLE
feat(credential-provider-imds): source accountId from IMDS

### DIFF
--- a/.changeset/stale-ladybugs-reflect.md
+++ b/.changeset/stale-ladybugs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@smithy/credential-provider-imds": minor
+---
+
+sources accountId from IMDS

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
@@ -14,6 +14,7 @@ describe("isImdsCredentials", () => {
   it("should accept valid ImdsCredentials objects", () => {
     expect(isImdsCredentials(creds)).toBe(true);
     const { AccountId, ...credsWithoutAccountId } = creds;
+    expect(AccountId).toBe("123456789012");
     expect(isImdsCredentials(credsWithoutAccountId)).toBe(true);
   });
 

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
@@ -13,6 +13,8 @@ const creds: ImdsCredentials = Object.freeze({
 describe("isImdsCredentials", () => {
   it("should accept valid ImdsCredentials objects", () => {
     expect(isImdsCredentials(creds)).toBe(true);
+    const { AccountId, ...credsWithoutAccountId } = creds;
+    expect(isImdsCredentials(credsWithoutAccountId)).toBe(true);
   });
 
   it("should reject credentials without an AccessKeyId", () => {
@@ -61,6 +63,6 @@ describe("fromImdsCredentials", () => {
     expect(converted.secretAccessKey).toEqual(credsWithoutAccountId.SecretAccessKey);
     expect(converted.sessionToken).toEqual(credsWithoutAccountId.Token);
     expect(converted.expiration).toEqual(new Date(credsWithoutAccountId.Expiration));
-    expect(converted).not.toHaveProperty('accountId'); // Verify accountId is not included
+    expect(converted).not.toHaveProperty("accountId"); // Verify accountId is not included
   });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
@@ -7,6 +7,7 @@ const creds: ImdsCredentials = Object.freeze({
   SecretAccessKey: "bar",
   Token: "baz",
   Expiration: new Date().toISOString(),
+  AccountId: "123456789012",
 });
 
 describe("isImdsCredentials", () => {
@@ -44,5 +45,22 @@ describe("fromImdsCredentials", () => {
     expect(converted.secretAccessKey).toEqual(creds.SecretAccessKey);
     expect(converted.sessionToken).toEqual(creds.Token);
     expect(converted.expiration).toEqual(new Date(creds.Expiration));
+    expect(converted.accountId).toEqual(creds.AccountId);
+  });
+
+  it("should convert IMDS credentials to a credentials object without accountId when it's not provided", () => {
+    const credsWithoutAccountId: ImdsCredentials = {
+      AccessKeyId: "foo",
+      SecretAccessKey: "bar",
+      Token: "baz",
+      Expiration: new Date().toISOString(),
+      // AccountId is omitted
+    };
+    const converted: AwsCredentialIdentity = fromImdsCredentials(credsWithoutAccountId);
+    expect(converted.accessKeyId).toEqual(credsWithoutAccountId.AccessKeyId);
+    expect(converted.secretAccessKey).toEqual(credsWithoutAccountId.SecretAccessKey);
+    expect(converted.sessionToken).toEqual(credsWithoutAccountId.Token);
+    expect(converted.expiration).toEqual(new Date(credsWithoutAccountId.Expiration));
+    expect(converted).not.toHaveProperty('accountId'); // Verify accountId is not included
   });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
@@ -63,6 +63,6 @@ describe("fromImdsCredentials", () => {
     expect(converted.secretAccessKey).toEqual(credsWithoutAccountId.SecretAccessKey);
     expect(converted.sessionToken).toEqual(credsWithoutAccountId.Token);
     expect(converted.expiration).toEqual(new Date(credsWithoutAccountId.Expiration));
-    expect(converted).not.toHaveProperty("accountId"); // Verify accountId is not included
+    expect(converted.accountId).toBeUndefined(); // Verify accountId is undefined
   });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
@@ -8,6 +8,7 @@ export interface ImdsCredentials {
   SecretAccessKey: string;
   Token: string;
   Expiration: string;
+  AccountId?: string;
 }
 
 /**
@@ -29,4 +30,5 @@ export const fromImdsCredentials = (creds: ImdsCredentials): AwsCredentialIdenti
   secretAccessKey: creds.SecretAccessKey,
   sessionToken: creds.Token,
   expiration: new Date(creds.Expiration),
+  accountId: creds.AccountId,
 });

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
@@ -30,5 +30,5 @@ export const fromImdsCredentials = (creds: ImdsCredentials): AwsCredentialIdenti
   secretAccessKey: creds.SecretAccessKey,
   sessionToken: creds.Token,
   expiration: new Date(creds.Expiration),
-  accountId: creds.AccountId,
+  ...(creds.AccountId && { accountId: creds.AccountId }),
 });


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-4633
Part 1

*Description of changes:*
Sources accountId from IMDS credential provider.

PR to update `AwsCredentialIdentity` interface: #1240 

*Testing*
Verify unit tests pass after above PR to update `AwsCredentialIdentity` interface is merged:
Done in https://github.com/aws/aws-sdk-js-v3/pull/6019


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
