### PR TITLE
chore(package.json): bump engines to node >= 16.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 For Client SDK code generation, the `typescript-client-codegen` plugin provides a framework for generating extensible TypeScript clients that can support multiple JavaScript platforms, including Node.js, Browser, and React-Native. See [the section on generating a client to see how to get started](#generating-a-client), or [the `typescript-client-codegen` documentation](#client-sdk-code-generation-typescript-client-codegen-plugin).
 
-> Note: Node.js support includes versions >= 14, and is subject to change.
+> Note: Node.js support includes versions >= 16, and is subject to change.
 
 For Server SDK code generation, the `typescript-server-codegen` plugin provides a framework for generating server scaffolding at a higher level of abstraction and with type safety. More documentation can be found at in [the `typescript-server-codegen` documentation](#server-sdk-code-generation-typescript-server-codegen-plugin), or [smithy.io](https://smithy.io/2.0/ts-ssdk/index.html).
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.9.5"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "typesVersions": {
     "<4.0": {


### PR DESCRIPTION
*Issue #, if available:*

This changes generated artifacts (client / server) to support Node.js 16.x as the minimum Node.js version.

We announced [the end of support for Node.js 14.x in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-14-x-in-the-aws-sdk-for-javascript-v3/) starting May 1, 2024 back in October, 2023.

*Description of changes:*
Bump engines to node >= 16.0.0

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
