### PR TITLE
feat: omit endpoint params from generation in the client interface

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -116,7 +116,7 @@ public final class EndpointsV2Generator implements Runnable {
                     () -> {
                         RuleSetParameterFinder ruleSetParameterFinder = new RuleSetParameterFinder(service);
 
-                        Map<String, String> clientInputParams = ruleSetParameterFinder.getClientContextParams();                        
+                        Map<String, String> clientInputParams = ruleSetParameterFinder.getClientContextParams();
                         //Omit Endpoint params that should not be a part of the ClientInputEndpointParameters interface
                         Map<String, String> builtInParams = ruleSetParameterFinder.getBuiltInParams();
                         builtInParams.keySet().removeIf(OmitEndpointParams::isOmitted);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -116,12 +116,10 @@ public final class EndpointsV2Generator implements Runnable {
                     () -> {
                         RuleSetParameterFinder ruleSetParameterFinder = new RuleSetParameterFinder(service);
 
-                        Map<String, String> clientInputParams = ruleSetParameterFinder.getClientContextParams();
-                        
+                        Map<String, String> clientInputParams = ruleSetParameterFinder.getClientContextParams();                        
                         //Omit Endpoint params that should not be a part of the ClientInputEndpointParameters interface
                         Map<String, String> builtInParams = ruleSetParameterFinder.getBuiltInParams();
                         builtInParams.keySet().removeIf(OmitEndpointParams::isOmitted);
-
                         clientInputParams.putAll(builtInParams);
 
                         ObjectNode ruleSet = endpointRuleSetTrait.getRuleSet().expectObjectNode();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -117,7 +117,12 @@ public final class EndpointsV2Generator implements Runnable {
                         RuleSetParameterFinder ruleSetParameterFinder = new RuleSetParameterFinder(service);
 
                         Map<String, String> clientInputParams = ruleSetParameterFinder.getClientContextParams();
-                        clientInputParams.putAll(ruleSetParameterFinder.getBuiltInParams());
+                        
+                        //Omit Endpoint params that should not be a part of the ClientInputEndpointParameters interface
+                        Map<String, String> builtInParams = ruleSetParameterFinder.getBuiltInParams();
+                        builtInParams.keySet().removeIf(OmitEndpointParams::isOmitted);
+
+                        clientInputParams.putAll(builtInParams);
 
                         ObjectNode ruleSet = endpointRuleSetTrait.getRuleSet().expectObjectNode();
                         ruleSet.getObjectMember("parameters").ifPresent(parameters -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+package software.amazon.smithy.typescript.codegen.endpointsV2;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -2,30 +2,31 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package software.amazon.smithy.typescript.codegen.endpointsV2;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+ package software.amazon.smithy.typescript.codegen.endpointsV2;
 
-/**
- * Manages a collection of endpoint parameter names to be omitted from a specific interface. 
- * While this could be extensible in the future, as of right now, this collection is maintaining endpoint parameter names to be omitted from the `ClientInputEndpointParameters` interface.
- */
-public class OmitEndpointParams {
-    private static Set<String> OMITTED_PARAMS = new HashSet<>();
-
-    private OmitEndpointParams() {}
-    
-    public static void addOmittedParams(Set<String> paramNames) {
-        OMITTED_PARAMS.addAll(paramNames);
-    }
-
-    public static boolean isOmitted(String paramName) {
-        return OMITTED_PARAMS.contains(paramName);
-    }
-
-    public static Set<String> getOmittedParams() {
-        return Collections.unmodifiableSet(OMITTED_PARAMS);
-    }
-}
+ import java.util.Collections;
+ import java.util.HashSet;
+ import java.util.Set;
+ 
+ /**
+  * Manages a collection of endpoint parameter names to be omitted from a specific interface.
+  * While this could be extensible in the future, as of right now, this collection is maintaining endpoint parameter names to be omitted from the `ClientInputEndpointParameters` interface.
+  */
+ public final class OmitEndpointParams { 
+     private static final Set<String> omittedParams = new HashSet<>(); 
+ 
+     private OmitEndpointParams() {}
+ 
+     public static void addOmittedParams(Set<String> paramNames) {
+         omittedParams.addAll(paramNames);
+     }
+ 
+     public static boolean isOmitted(String paramName) {
+         return omittedParams.contains(paramName);
+     }
+ 
+     public static Set<String> getOmittedParams() {
+         return Collections.unmodifiableSet(omittedParams);
+     }
+ }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -1,26 +1,15 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package software.amazon.smithy.typescript.codegen.endpointsV2;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Manages a collection of endpoint parameter names to be omitted from a specific interface.
+ * Manages a collection of endpoint parameter names to be omitted from a specific interface. While this could be extensible in the future, as of right now, this collection is maintaining endpoint parameter names to be omitted from the `ClientInputEndpointParameters` interface.
  */
 public final class OmitEndpointParams {
     private static final Set<String> OMITTED_PARAMS = new HashSet<>();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.typescript.codegen.endpointsV2;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+package software.amazon.smithy.typescript.codegen.endpointsV2;
 
 /**
- * Manages a collection of endpoint parameter names to be omitted from a specific interface. While this could be extensible in the future, as of right now, this collection is maintaining endpoint parameter names to be omitted from the `ClientInputEndpointParameters` interface.
+ * Manages a collection of endpoint parameter names to be omitted from a specific interface. 
+ * While this could be extensible in the future, as of right now, this collection is maintaining endpoint parameter names to be omitted from the `ClientInputEndpointParameters` interface.
  */
 public final class OmitEndpointParams {
     private static final Set<String> OMITTED_PARAMS = new HashSet<>();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.typescript.codegen.endpointsV2;
 
 import java.util.Collections;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -1,0 +1,26 @@
+package software.amazon.smithy.typescript.codegen.endpointsV2;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Manages a collection of endpoint parameter names to be omitted from a specific interface.
+ */
+public final class OmitEndpointParams {
+    private static final Set<String> OMITTED_PARAMS = new HashSet<>();
+
+    private OmitEndpointParams() {}
+    
+    public static void addOmittedParams(Set<String> paramNames) {
+        OMITTED_PARAMS.addAll(paramNames);
+    }
+
+    public static boolean isOmitted(String paramName) {
+        return OMITTED_PARAMS.contains(paramName);
+    }
+
+    public static Set<String> getOmittedParams() {
+        return Collections.unmodifiableSet(OMITTED_PARAMS);
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -6,7 +6,6 @@
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-package software.amazon.smithy.typescript.codegen.endpointsV2;
 
 /**
  * Manages a collection of endpoint parameter names to be omitted from a specific interface. 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -12,8 +12,8 @@ package software.amazon.smithy.typescript.codegen.endpointsV2;
  * Manages a collection of endpoint parameter names to be omitted from a specific interface. 
  * While this could be extensible in the future, as of right now, this collection is maintaining endpoint parameter names to be omitted from the `ClientInputEndpointParameters` interface.
  */
-public final class OmitEndpointParams {
-    private static final Set<String> OMITTED_PARAMS = new HashSet<>();
+public class OmitEndpointParams {
+    private static Set<String> OMITTED_PARAMS = new HashSet<>();
 
     private OmitEndpointParams() {}
     

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -8,25 +8,26 @@
  import java.util.Collections;
  import java.util.HashSet;
  import java.util.Set;
- 
  /**
   * Manages a collection of endpoint parameter names to be omitted from a specific interface.
-  * While this could be extensible in the future, as of right now, this collection is maintaining endpoint parameter names to be omitted from the `ClientInputEndpointParameters` interface.
+  * While this could be extensible in the future, as of right now,
+  * this collection is maintaining endpoint params to be omitted from the `ClientInputEndpointParameters` interface.
   */
- public final class OmitEndpointParams { 
-     private static final Set<String> omittedParams = new HashSet<>(); 
- 
+
+ public final class OmitEndpointParams {
+     private static final Set<String> OMITTED_PARAMS = new HashSet<>();
+
      private OmitEndpointParams() {}
- 
+
      public static void addOmittedParams(Set<String> paramNames) {
-         omittedParams.addAll(paramNames);
+         OMITTED_PARAMS.addAll(paramNames);
      }
- 
+
      public static boolean isOmitted(String paramName) {
-         return omittedParams.contains(paramName);
+         return OMITTED_PARAMS.contains(paramName);
      }
- 
+
      public static Set<String> getOmittedParams() {
-         return Collections.unmodifiableSet(omittedParams);
+         return Collections.unmodifiableSet(OMITTED_PARAMS);
      }
- }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/OmitEndpointParams.java
@@ -8,12 +8,12 @@
  import java.util.Collections;
  import java.util.HashSet;
  import java.util.Set;
+
  /**
   * Manages a collection of endpoint parameter names to be omitted from a specific interface.
   * While this could be extensible in the future, as of right now,
   * this collection is maintaining endpoint params to be omitted from the `ClientInputEndpointParameters` interface.
   */
-
  public final class OmitEndpointParams {
      private static final Set<String> OMITTED_PARAMS = new HashSet<>();
 


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-4633 
Part 2

*Description of changes:*
Omits (a collection of) Endpoint params from being generated into the `ClientInputEndpointParameters` interface. This collection can be used for omission from other interfaces as well accordingly. 

Partner PR in JSv3:  https://github.com/aws/aws-sdk-js-v3/pull/6035


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
