### PR TITLE
feat: add support for accountId in configValueProvider

### DIFF
--- a/.changeset/brown-bags-leave.md
+++ b/.changeset/brown-bags-leave.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": minor
+---
+
+add support for accountId in configValueProvider

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
@@ -31,6 +31,17 @@ describe(createConfigValueProvider.name, () => {
     expect(await createConfigValueProvider("credentialScope", "CredentialScope", config)()).toEqual("cred-scope");
   });
 
+  it("uses a special lookup for accountId", async () => {
+    const config = {
+      credentials: async () => {
+        return {
+          accountId: "123456789012",
+        };
+      },
+    };
+    expect(await createConfigValueProvider("accountId", "AccountId", config)()).toEqual("123456789012");
+  });
+
   it("should normalize endpoint objects into URLs", async () => {
     const sampleUrl = "https://aws.amazon.com/";
     const config = {

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
@@ -31,6 +31,15 @@ export const createConfigValueProvider = <Config extends Record<string, unknown>
       return configValue;
     };
   }
+
+  if (configKey === "accountId" || canonicalEndpointParamKey === "AccountId") {
+    return async () => {
+      const credentials = typeof config.credentials === "function" ? await config.credentials() : config.credentials;
+      const configValue: string = credentials?.accountId ?? credentials?.AccountId;
+      return configValue;
+    };
+  }
+
   if (configKey === "endpoint" || canonicalEndpointParamKey === "endpoint") {
     return async () => {
       const endpoint = await configProvider();


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-4633
Part 3

*Description of changes:*
adds support for accountId in `configValueProvider` (sourced from credentials)

*Testing*
```console
 PASS  src/adaptors/createConfigValueProvider.spec.ts (14.921 s)
  createConfigValueProvider
    ✓ should create a normalized provider for any config value (10 ms)
    ✓ should look up both the canonical Endpoint ruleset param name and any localized override (1 ms)
    ✓ uses a special lookup for CredentialScope (1 ms)
    ✓ uses a special lookup for accountId (1 ms)
    ✓ should normalize endpoint objects into URLs (1 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        15.411 s
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
