### PR TITLE
Add service client doc generator only when typedoc is selected

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
@@ -77,6 +77,14 @@ final class PackageJsonGenerator {
                 node = node.withMember("devDependencies", devDeps);
             }
 
+            // Add @smithy/service-client-documentation-generator to the "devDependencies" if not present
+            if (devDeps.getMember(TypeScriptDependency.AWS_SDK_CLIENT_DOCGEN.packageName).isEmpty()) {
+                devDeps = devDeps.withMember(
+                    TypeScriptDependency.AWS_SDK_CLIENT_DOCGEN.packageName,
+                    TypeScriptDependency.AWS_SDK_CLIENT_DOCGEN.version);
+                node = node.withMember("devDependencies", devDeps);
+            }
+
             // Add build:docs script
             ObjectNode scripts = node.getObjectMember("scripts").orElse(Node.objectNode());
             scripts = scripts.withMember("build:docs", "typedoc");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -39,7 +39,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public enum TypeScriptDependency implements Dependency {
 
     SMITHY_CORE("dependencies", "@smithy/core", false),
-    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@smithy/service-client-documentation-generator", true),
+    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@smithy/service-client-documentation-generator", false),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", true),
     SMITHY_TYPES("dependencies", "@smithy/types", true),
     AWS_SMITHY_CLIENT("dependencies", "@smithy/smithy-client", true),

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDependencyTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDependencyTest.java
@@ -26,7 +26,7 @@ public class TypeScriptDependencyTest {
     @Test
     public void getsUnconditionalDependencies() {
         assertThat(TypeScriptDependency.getUnconditionalDependencies(),
-                   hasItem(TypeScriptDependency.AWS_SDK_CLIENT_DOCGEN.dependency));
+                   hasItem(TypeScriptDependency.SMITHY_TYPES.dependency));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
Noticed while working on https://github.com/smithy-lang/smithy-typescript/pull/1249

*Description of changes:*
Add service client doc generator only when typedoc is selected

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
