### PR TITLE
Add @tsconfig/node16 as a dependency

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -19,7 +19,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
*Issue #, if available:*
The codegen part of https://github.com/aws/aws-sdk-js-v3/pull/6037

*Description of changes:*
Add @tsconfig/node16 as a dependency

This was missed when working on codegen part in aws-sdk-js-v3.
We're adding it to avoid adding additional dependency in JS SDK v3 during 05/01 release.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
