### PR TITLE
Extend tsconfig from @tsconfig/node16

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,


### PR DESCRIPTION
*Issue #, if available:*
The codegen part of https://github.com/aws/aws-sdk-js-v3/pull/6037

*Description of changes:*
Extend tsconfig from @tsconfig/node16

This won't impact aws-sdk-js-v3 05/01 release as no new services are being released, but it requires fix.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
