### PR TITLE
feat: improve support for fetch and web-streams in Node.js

### DIFF
--- a/.changeset/happy-monkeys-tap.md
+++ b/.changeset/happy-monkeys-tap.md
@@ -1,0 +1,6 @@
+---
+"@smithy/node-http-handler": minor
+"@smithy/util-stream": minor
+---
+
+handle web streams in streamCollector and sdkStreamMixin

--- a/packages/fetch-http-handler/README.md
+++ b/packages/fetch-http-handler/README.md
@@ -2,3 +2,10 @@
 
 [![NPM version](https://img.shields.io/npm/v/@smithy/fetch-http-handler/latest.svg)](https://www.npmjs.com/package/@smithy/fetch-http-handler)
 [![NPM downloads](https://img.shields.io/npm/dm/@smithy/fetch-http-handler.svg)](https://www.npmjs.com/package/@smithy/fetch-http-handler)
+
+This is the default `requestHandler` used for browser applications.
+Although some versions of Node.js support the web streams API, this implementation has
+not been extensively tested in Node.js. 
+
+For the Node.js default `requestHandler` implementation, see instead
+[`@smithy/node-http-handler`](https://www.npmjs.com/package/@smithy/node-http-handler). 

--- a/packages/fetch-http-handler/README.md
+++ b/packages/fetch-http-handler/README.md
@@ -4,8 +4,8 @@
 [![NPM downloads](https://img.shields.io/npm/dm/@smithy/fetch-http-handler.svg)](https://www.npmjs.com/package/@smithy/fetch-http-handler)
 
 This is the default `requestHandler` used for browser applications.
-Although some versions of Node.js support the web streams API, this implementation has
-not been extensively tested in Node.js.
+Since Node.js introduced experimental Web Streams API in v16.5.0 and made it stable in v21.0.0,
+you can consider using `fetch-http-handler` in Node.js, although it's not recommended.
 
 For the Node.js default `requestHandler` implementation, see instead
 [`@smithy/node-http-handler`](https://www.npmjs.com/package/@smithy/node-http-handler).

--- a/packages/fetch-http-handler/README.md
+++ b/packages/fetch-http-handler/README.md
@@ -5,7 +5,7 @@
 
 This is the default `requestHandler` used for browser applications.
 Although some versions of Node.js support the web streams API, this implementation has
-not been extensively tested in Node.js. 
+not been extensively tested in Node.js.
 
 For the Node.js default `requestHandler` implementation, see instead
-[`@smithy/node-http-handler`](https://www.npmjs.com/package/@smithy/node-http-handler). 
+[`@smithy/node-http-handler`](https://www.npmjs.com/package/@smithy/node-http-handler).

--- a/packages/node-http-handler/README.md
+++ b/packages/node-http-handler/README.md
@@ -2,3 +2,8 @@
 
 [![NPM version](https://img.shields.io/npm/v/@smithy/node-http-handler/latest.svg)](https://www.npmjs.com/package/@smithy/node-http-handler)
 [![NPM downloads](https://img.shields.io/npm/dm/@smithy/node-http-handler.svg)](https://www.npmjs.com/package/@smithy/node-http-handler)
+
+This package implements the default `requestHandler` for Node.js using `node:http`, `node:https`, and `node:http2`.
+
+For an example on how `requestHandler`s are used by Smithy generated SDK clients, refer to
+the [AWS SDK for JavaScript (v3) supplemental docs](https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md#request-handler-requesthandler).

--- a/packages/node-http-handler/src/stream-collector/index.spec.ts
+++ b/packages/node-http-handler/src/stream-collector/index.spec.ts
@@ -12,6 +12,21 @@ describe("streamCollector", () => {
     expect(collectedData).toEqual(expected);
   });
 
+  (typeof ReadableStream === "function" ? it : it.skip)(
+    "accepts ReadableStream if the global web stream implementation exists in Node.js",
+    async () => {
+      const data = await streamCollector(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(Buffer.from("abcd"));
+            controller.close();
+          },
+        })
+      );
+      expect(Buffer.from(data)).toEqual(Buffer.from("abcd"));
+    }
+  );
+
   it("will propagate errors from the stream", async () => {
     // stream should emit an error right away
     const mockReadStream = new ReadFromBuffers({

--- a/packages/node-http-handler/src/stream-collector/index.spec.ts
+++ b/packages/node-http-handler/src/stream-collector/index.spec.ts
@@ -12,9 +12,8 @@ describe("streamCollector", () => {
     expect(collectedData).toEqual(expected);
   });
 
-  (typeof ReadableStream === "function" ? it : it.skip)(
-    "accepts ReadableStream if the global web stream implementation exists in Node.js",
-    async () => {
+  it("accepts ReadableStream if the global web stream implementation exists in Node.js", async () => {
+    if (typeof ReadableStream === "function") {
       const data = await streamCollector(
         new ReadableStream({
           start(controller) {
@@ -25,7 +24,7 @@ describe("streamCollector", () => {
       );
       expect(Buffer.from(data)).toEqual(Buffer.from("abcd"));
     }
-  );
+  });
 
   it("will propagate errors from the stream", async () => {
     // stream should emit an error right away

--- a/packages/node-http-handler/src/stream-collector/index.ts
+++ b/packages/node-http-handler/src/stream-collector/index.ts
@@ -1,11 +1,12 @@
 import { StreamCollector } from "@smithy/types";
 import { Readable } from "stream";
+import type { ReadableStream as IReadableStream } from "stream/web";
 
 import { Collector } from "./collector";
 
-export const streamCollector: StreamCollector = (stream: Readable | ReadableStream): Promise<Uint8Array> => {
+export const streamCollector: StreamCollector = (stream: Readable | IReadableStream): Promise<Uint8Array> => {
   if (isReadableStreamInstance(stream)) {
-    // web stream in Node.js indicates user has overridden requestHandler with FetchHttpHandler.
+    // Web stream API in Node.js
     return collectReadableStream(stream);
   }
   return new Promise((resolve, reject) => {
@@ -24,10 +25,16 @@ export const streamCollector: StreamCollector = (stream: Readable | ReadableStre
   });
 };
 
-const isReadableStreamInstance = (stream: unknown): stream is ReadableStream =>
+/**
+ * Note: the global.ReadableStream object is marked experimental, and was added in v18.0.0 of Node.js.
+ * The importable version was added in v16.5.0. We only test for the global version so as not to
+ * enforce an import on a Node.js version that may not have it, and import
+ * only the type from stream/web.
+ */
+const isReadableStreamInstance = (stream: unknown): stream is IReadableStream =>
   typeof ReadableStream === "function" && stream instanceof ReadableStream;
 
-async function collectReadableStream(stream: ReadableStream): Promise<Uint8Array> {
+async function collectReadableStream(stream: IReadableStream): Promise<Uint8Array> {
   let res = new Uint8Array(0);
   const reader = stream.getReader();
   let isDone = false;

--- a/packages/util-stream/src/sdk-stream-mixin.browser.spec.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.browser.spec.ts
@@ -25,7 +25,7 @@ describe(sdkStreamMixin.name, () => {
     for (const method of transformMethods) {
       try {
         await sdkStream[method]();
-        fail(new Error("expect subsequent tranform to fail"));
+        fail(new Error("expect subsequent transform to fail"));
       } catch (error) {
         expect(error.message).toContain("The stream has already been transformed");
       }
@@ -64,7 +64,7 @@ describe(sdkStreamMixin.name, () => {
       sdkStreamMixin({});
       fail("expect unexpected stream to fail");
     } catch (e) {
-      expect(e.message).toContain("nexpected stream implementation");
+      expect(e.message).toContain("unexpected stream implementation");
       global.Blob = originalBlobCtr;
     }
   });
@@ -77,7 +77,7 @@ describe(sdkStreamMixin.name, () => {
       expect(byteArray).toEqual(mockStreamCollectorReturn);
     });
 
-    it("should fail any subsequent tranform calls", async () => {
+    it("should fail any subsequent transform calls", async () => {
       const sdkStream = sdkStreamMixin(payloadStream);
       await sdkStream.transformToByteArray();
       await expectAllTransformsToFail(sdkStream);
@@ -137,7 +137,7 @@ describe(sdkStreamMixin.name, () => {
       }
     });
 
-    it("should fail any subsequent tranform calls", async () => {
+    it("should fail any subsequent transform calls", async () => {
       const sdkStream = sdkStreamMixin(payloadStream);
       await sdkStream.transformToString();
       await expectAllTransformsToFail(sdkStream);
@@ -152,7 +152,7 @@ describe(sdkStreamMixin.name, () => {
       expect(transformed).toBe(payloadStream);
     });
 
-    it("should fail any subsequent tranform calls", async () => {
+    it("should fail any subsequent transform calls", async () => {
       const payloadStream = new ReadableStream();
       const sdkStream = sdkStreamMixin(payloadStream as any);
       sdkStream.transformToWebStream();
@@ -212,7 +212,7 @@ describe(sdkStreamMixin.name, () => {
       }
     });
 
-    it("should fail any subsequent tranform calls", async () => {
+    it("should fail any subsequent transform calls", async () => {
       const payloadStream = new Blob();
       const sdkStream = sdkStreamMixin(payloadStream as any);
       sdkStream.transformToWebStream();

--- a/packages/util-stream/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.spec.ts
@@ -39,10 +39,9 @@ describe(sdkStreamMixin.name, () => {
     passThrough = new PassThrough();
   });
 
-  (typeof ReadableStream !== "undefined" ? it : it.skip)(
-    "should attempt to use the ReadableStream version if the input is not a Readable",
-    async () => {
-      // node: ReadableStream is global only as of Node.js 18.
+  it("should attempt to use the ReadableStream version if the input is not a Readable", async () => {
+    if (typeof ReadableStream !== "undefined") {
+      // ReadableStream is global only as of Node.js 18.
       const sdkStream = sdkStreamMixin(
         new ReadableStream({
           start(controller) {
@@ -53,7 +52,7 @@ describe(sdkStreamMixin.name, () => {
       );
       expect(await sdkStream.transformToByteArray()).toEqual(new Uint8Array([97, 98, 99, 100]));
     }
-  );
+  });
 
   it("should throw if unexpected stream implementation is supplied", () => {
     try {

--- a/packages/util-stream/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.spec.ts
@@ -44,7 +44,15 @@ describe(sdkStreamMixin.name, () => {
     "should attempt to use the ReadableStream version if the input is not a Readable",
     async () => {
       // node: ReadableStream is global only as of Node.js 18.
-      sdkStreamMixin(new ReadableStream());
+      const sdkStream = sdkStreamMixin(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(Buffer.from("abcd"));
+            controller.close();
+          },
+        })
+      );
+      expect(await sdkStream.transformToByteArray()).toEqual(new Uint8Array([97, 98, 99, 100]));
     }
   );
 

--- a/packages/util-stream/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.spec.ts
@@ -1,7 +1,6 @@
 import { SdkStreamMixin } from "@smithy/types";
 import { fromArrayBuffer } from "@smithy/util-buffer-from";
 import { PassThrough, Readable, Writable } from "stream";
-
 import util from "util";
 
 import { sdkStreamMixin } from "./sdk-stream-mixin";


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/4619

*Description of changes:*
- `streamCollector` and `sdkStreamMixin` components that are part of the client config, specifically the SerdeContext subset, have been modified to allow web streams 