### PR TITLE
Bump @types/node to 16.x

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -45,7 +45,7 @@ public enum TypeScriptDependency implements Dependency {
     AWS_SMITHY_CLIENT("dependencies", "@smithy/smithy-client", true),
     INVALID_DEPENDENCY("dependencies", "@smithy/invalid-dependency", true),
     CONFIG_RESOLVER("dependencies", "@smithy/config-resolver", true),
-    TYPES_NODE("devDependencies", "@types/node", "^14.14.31", true),
+    TYPES_NODE("devDependencies", "@types/node", "^16.18.96", true),
 
     MIDDLEWARE_CONTENT_LENGTH("dependencies", "@smithy/middleware-content-length", true),
     MIDDLEWARE_SERDE("dependencies", "@smithy/middleware-serde", true),


### PR DESCRIPTION
*Issue #, if available:*
The codegen now supports Node.js 16.x as of https://github.com/smithy-lang/smithy-typescript/pull/1249

*Description of changes:*
Bump @types/node to 16.x

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
