### PR TITLE
fix: type transforms account for no-args operation methods

### DIFF
--- a/.changeset/cold-ligers-punch.md
+++ b/.changeset/cold-ligers-punch.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": minor
+---
+
+fix type transforms for method signatures with no arguments

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -54,6 +54,19 @@ export interface InvokeMethod<InputType extends object, OutputType extends Metad
 }
 
 /**
+ * @public
+ *
+ * Signature that appears on aggregated clients' methods when argument is optional.
+ */
+export interface InvokeMethodOptionalArgs<InputType extends object, OutputType extends MetadataBearer> {
+  (): Promise<OutputType>;
+  (input: InputType, options?: any): Promise<OutputType>;
+  (input: InputType, cb: (err: any, data?: OutputType) => void): void;
+  (input: InputType, options: any, cb: (err: any, data?: OutputType) => void): void;
+  (input: InputType, options?: any, cb?: (err: any, data?: OutputType) => void): Promise<OutputType> | void;
+}
+
+/**
  * A general interface for service clients, idempotent to browser or node clients
  * This type corresponds to SmithyClient(https://github.com/aws/aws-sdk-js-v3/blob/main/packages/smithy-client/src/client.ts).
  * It's provided for using without importing the SmithyClient class.

--- a/packages/types/src/transform/no-undefined.spec.ts
+++ b/packages/types/src/transform/no-undefined.spec.ts
@@ -49,6 +49,11 @@ type A = {
     putObject(args: MyInput, options?: HttpHandlerOptions): Promise<MyOutput>;
     putObject(args: MyInput, cb: (err: any, data?: MyOutput) => void): void;
     putObject(args: MyInput, options: HttpHandlerOptions, cb: (err: any, data?: MyOutput) => void): void;
+
+    listObjects(): Promise<MyOutput>;
+    listObjects(args: MyInput, options?: HttpHandlerOptions): Promise<MyOutput>;
+    listObjects(args: MyInput, cb: (err: any, data?: MyOutput) => void): void;
+    listObjects(args: MyInput, options: HttpHandlerOptions, cb: (err: any, data?: MyOutput) => void): void;
   }
 
   {
@@ -91,5 +96,21 @@ type A = {
     const assert4: Exact<typeof output.r.a, string> = true as const;
     const assert5: Exact<typeof output.r.b, number> = true as const;
     const assert6: Exact<typeof output.r.c, string | number> = true as const;
+  }
+
+  {
+    // Handles methods with optionally zero args.
+    const c = (null as unknown) as AssertiveClient<MyClient>;
+    const list = c.listObjects();
+    const output = (null as unknown) as Awaited<typeof list>;
+
+    const assert1: Exact<typeof output.a, string | undefined> = true as const;
+    const assert2: Exact<typeof output.b, number | undefined> = true as const;
+    const assert3: Exact<typeof output.c, string | number | undefined> = true as const;
+    if (output.r) {
+      const assert4: Exact<typeof output.r.a, string | undefined> = true as const;
+      const assert5: Exact<typeof output.r.b, number | undefined> = true as const;
+      const assert6: Exact<typeof output.r.c, string | number | undefined> = true as const;
+    }
   }
 }

--- a/packages/types/src/transform/no-undefined.ts
+++ b/packages/types/src/transform/no-undefined.ts
@@ -1,4 +1,4 @@
-import type { InvokeFunction, InvokeMethod } from "../client";
+import type { InvokeFunction, InvokeMethod, InvokeMethodOptionalArgs } from "../client";
 
 /**
  * @public
@@ -59,8 +59,10 @@ export type RecursiveRequired<T> = T extends Function
  */
 type NarrowClientIOTypes<ClientType extends object> = {
   [key in keyof ClientType]: [ClientType[key]] extends [
-    InvokeFunction<infer InputTypes, infer OutputTypes, infer ConfigType>
+    InvokeMethodOptionalArgs<infer FunctionInputTypes, infer FunctionOutputTypes>
   ]
+    ? InvokeMethodOptionalArgs<NoUndefined<FunctionInputTypes>, NoUndefined<FunctionOutputTypes>>
+    : [ClientType[key]] extends [InvokeFunction<infer InputTypes, infer OutputTypes, infer ConfigType>]
     ? InvokeFunction<NoUndefined<InputTypes>, NoUndefined<OutputTypes>, ConfigType>
     : [ClientType[key]] extends [InvokeMethod<infer FunctionInputTypes, infer FunctionOutputTypes>]
     ? InvokeMethod<NoUndefined<FunctionInputTypes>, NoUndefined<FunctionOutputTypes>>
@@ -74,8 +76,10 @@ type NarrowClientIOTypes<ClientType extends object> = {
  */
 type UncheckedClientOutputTypes<ClientType extends object> = {
   [key in keyof ClientType]: [ClientType[key]] extends [
-    InvokeFunction<infer InputTypes, infer OutputTypes, infer ConfigType>
+    InvokeMethodOptionalArgs<infer FunctionInputTypes, infer FunctionOutputTypes>
   ]
+    ? InvokeMethodOptionalArgs<NoUndefined<FunctionInputTypes>, RecursiveRequired<FunctionOutputTypes>>
+    : [ClientType[key]] extends [InvokeFunction<infer InputTypes, infer OutputTypes, infer ConfigType>]
     ? InvokeFunction<NoUndefined<InputTypes>, RecursiveRequired<OutputTypes>, ConfigType>
     : [ClientType[key]] extends [InvokeMethod<infer FunctionInputTypes, infer FunctionOutputTypes>]
     ? InvokeMethod<NoUndefined<FunctionInputTypes>, RecursiveRequired<FunctionOutputTypes>>


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/6065

fix type transforms for Clients to handle the case where a method has an additional no-args signature. 

- no-args signature was a feature added after the addition of the AssertiveClient/UncheckedClient type transforms.
