### PR TITLE
Update CI to be more resilient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
   test-typescript:
     runs-on: smithy-typescript_ubuntu-latest_8-core
     name: TypeScript Test ${{ matrix.node }}
+    needs: ['ensure-typescript-packages-have-changesets', 'lint-typescript', 'ensure-typescript-formatted']
     strategy:
+      fail-fast: false
       matrix:
         node: [16, 18, 20, 22]
 


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Update CI to be more resilient.

For TypeScript Test, don't allow it to fail fast to prevent having to rerun failed jobs all the time, costing more billing.

This will allow contributors to rerun singular Node versions to test on.

Also, don't run any TypeScript Test until the CI for linting, formatting, and changesets have succeeded.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
