### PR TITLE
feat(node-http-handler): improve stream collection performance

### DIFF
--- a/.changeset/fluffy-crabs-watch.md
+++ b/.changeset/fluffy-crabs-watch.md
@@ -1,0 +1,6 @@
+---
+"@smithy/fetch-http-handler": patch
+"@smithy/node-http-handler": patch
+---
+
+improve stream collection speed

--- a/packages/fetch-http-handler/src/stream-collector.ts
+++ b/packages/fetch-http-handler/src/stream-collector.ts
@@ -17,20 +17,17 @@ async function collectBlob(blob: Blob): Promise<Uint8Array> {
 }
 
 async function collectStream(stream: ReadableStream): Promise<Uint8Array> {
-  let res = new Uint8Array(0);
+  const buffer = [];
   const reader = stream.getReader();
   let isDone = false;
   while (!isDone) {
     const { done, value } = await reader.read();
     if (value) {
-      const prior = res;
-      res = new Uint8Array(prior.length + value.length);
-      res.set(prior);
-      res.set(value, prior.length);
+      buffer.push(...value);
     }
     isDone = done;
   }
-  return res;
+  return new Uint8Array(buffer);
 }
 
 function readToBase64(blob: Blob): Promise<string> {

--- a/packages/fetch-http-handler/src/stream-collector.ts
+++ b/packages/fetch-http-handler/src/stream-collector.ts
@@ -17,17 +17,28 @@ async function collectBlob(blob: Blob): Promise<Uint8Array> {
 }
 
 async function collectStream(stream: ReadableStream): Promise<Uint8Array> {
-  const buffer = [];
+  const chunks = [];
   const reader = stream.getReader();
   let isDone = false;
+  let length = 0;
+
   while (!isDone) {
     const { done, value } = await reader.read();
     if (value) {
-      buffer.push(...value);
+      chunks.push(value);
+      length += value.length;
     }
     isDone = done;
   }
-  return new Uint8Array(buffer);
+
+  const collected = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    collected.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return collected;
 }
 
 function readToBase64(blob: Blob): Promise<string> {

--- a/packages/node-http-handler/src/stream-collector/index.ts
+++ b/packages/node-http-handler/src/stream-collector/index.ts
@@ -35,15 +35,26 @@ const isReadableStreamInstance = (stream: unknown): stream is IReadableStream =>
   typeof ReadableStream === "function" && stream instanceof ReadableStream;
 
 async function collectReadableStream(stream: IReadableStream): Promise<Uint8Array> {
-  const buffer = [];
+  const chunks = [];
   const reader = stream.getReader();
   let isDone = false;
+  let length = 0;
+
   while (!isDone) {
     const { done, value } = await reader.read();
     if (value) {
-      buffer.push(...value);
+      chunks.push(value);
+      length += value.length;
     }
     isDone = done;
   }
-  return new Uint8Array(buffer);
+
+  const collected = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    collected.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return collected;
 }

--- a/packages/node-http-handler/src/stream-collector/index.ts
+++ b/packages/node-http-handler/src/stream-collector/index.ts
@@ -35,18 +35,15 @@ const isReadableStreamInstance = (stream: unknown): stream is IReadableStream =>
   typeof ReadableStream === "function" && stream instanceof ReadableStream;
 
 async function collectReadableStream(stream: IReadableStream): Promise<Uint8Array> {
-  let res = new Uint8Array(0);
+  const buffer = [];
   const reader = stream.getReader();
   let isDone = false;
   while (!isDone) {
     const { done, value } = await reader.read();
     if (value) {
-      const prior = res;
-      res = new Uint8Array(prior.length + value.length);
-      res.set(prior);
-      res.set(value, prior.length);
+      buffer.push(...value);
     }
     isDone = done;
   }
-  return res;
+  return new Uint8Array(buffer);
 }


### PR DESCRIPTION
I noticed stream collectors were doing iffy copy operations during the stream -> Uint8Array process.
