### PR TITLE
fix(fetch-http-handler): set duplex on request when body present

### DIFF
--- a/.changeset/tiny-eyes-argue.md
+++ b/.changeset/tiny-eyes-argue.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": patch
+---
+
+set duplex on fetch options

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -20,6 +20,14 @@ export const keepAliveSupport = {
 };
 
 /**
+ * @internal
+ */
+type AdditionalRequestParameters = {
+  // This is required in Node.js when Request has a body, and does nothing in the browser.
+  duplex?: "half";
+};
+
+/**
  * @public
  *
  * HttpHandler implementation using browsers' `fetch` global function.
@@ -91,16 +99,23 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
     // Request constructor doesn't allow GET/HEAD request with body
     // ref: https://github.com/whatwg/fetch/issues/551
     const body = method === "GET" || method === "HEAD" ? undefined : request.body;
-    const requestOptions: RequestInit = { body, headers: new Headers(request.headers), method: method };
+    const requestOptions: RequestInit & AdditionalRequestParameters = {
+      body,
+      headers: new Headers(request.headers),
+      method: method,
+    };
+    if (body) {
+      requestOptions.duplex = "half";
+    }
 
     // some browsers support abort signal
     if (typeof AbortController !== "undefined") {
-      (requestOptions as any)["signal"] = abortSignal;
+      requestOptions.signal = abortSignal as AbortSignal;
     }
 
     // some browsers support keepalive
     if (keepAliveSupport.supported) {
-      (requestOptions as any)["keepalive"] = keepAlive;
+      requestOptions.keepalive = keepAlive;
     }
 
     const fetchRequest = new Request(url, requestOptions);

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -24,6 +24,8 @@ export const keepAliveSupport = {
  */
 type AdditionalRequestParameters = {
   // This is required in Node.js when Request has a body, and does nothing in the browser.
+  // Duplex: half means the request is fully transmitted before attempting to process the response.
+  // As of writing this is the only accepted value in https://fetch.spec.whatwg.org/.
   duplex?: "half";
 };
 


### PR DESCRIPTION
Followup to https://github.com/aws/aws-sdk-js-v3/issues/4619 as part of `fetch` in Node.js compatibility.

- Set `duplex: "half"` on `Request` init when body is present. This is required in Node.js and ignored in the browser.
