### PR TITLE
Add ecs and eks imds ip adresses to greengrass list

### DIFF
--- a/.changeset/soft-pans-enjoy.md
+++ b/.changeset/soft-pans-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@smithy/credential-provider-imds": minor
+---
+
+Support for ECS and EKS credential URI overrides, enabling the use of EKS Pod Identities on EKS

--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -59,6 +59,9 @@ const CMDS_IP = "169.254.170.2";
 const GREENGRASS_HOSTS = {
   localhost: true,
   "127.0.0.1": true,
+  "169.254.170.2": true, // IPv4 address for ECS
+  "169.254.170.23": true, // IPv4 address for EKS
+  "fd00:ec2::23": true, // IPv6 address for EKS
 };
 const GREENGRASS_PROTOCOLS = {
   "http:": true,


### PR DESCRIPTION
The AWS Profile EcsContainer credential provider is broken for application code running within the EKS environment using the AWS Pod Identity Service for credentials. This is because the AWS JSv3 SDK (using this library) configures itself using the fromContainerMetadata method which has an allow-list to only the ECS service (or localhost).
The EcsContainer credential provider is intended to be used with either ECS or EKS credential services (see https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html). This library restricts this provider to usage only with the ECS credential service.
This PR allow-lists the EKS credential service in addition to the ECS service to match the supported use-cases when configuring from the AWS profile config. This brings the AWS JSv3 SDK (which is [supported](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html)) which uses this library back into feature-parity with the other SDKs supporting the EKS Pod Identity Service such as the [Go SDK](https://github.com/aws/aws-sdk-go-v2/blob/a7db10670faedd542dc92cec6d0c602e5315a3a9/config/resolve_credentials.go#L33-L52).
It’s been noted in other PRs/issues around this issue that the fromHttp method can be used for the EKS Pod Identity Service. This is correct however this is for programmatic configuration whereas this PR fix is about fixing the supported use-case of configuring the SDK via the AWS Profile Config.

Note1: [Equivalent PR](https://github.com/aws/aws-sdk-go-v2/pull/2259) from November 2023 in the Go SDK

Note2: this is effectively reopening https://github.com/smithy-lang/smithy-typescript/pull/1144
