### PR TITLE
fix: serialize milliseconds for DateTime and EpochSeconds timestamp formats

### DIFF
--- a/.changeset/sweet-years-compete.md
+++ b/.changeset/sweet-years-compete.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": minor
+---
+
+add dateTime serializer function

--- a/packages/smithy-client/src/ser-utils.spec.ts
+++ b/packages/smithy-client/src/ser-utils.spec.ts
@@ -1,4 +1,4 @@
-import { serializeFloat } from "./ser-utils";
+import { serializeDateTime, serializeFloat } from "./ser-utils";
 
 describe("serializeFloat", () => {
   it("handles non-numerics", () => {
@@ -10,5 +10,18 @@ describe("serializeFloat", () => {
   it("handles normal numbers", () => {
     expect(serializeFloat(1)).toEqual(1);
     expect(serializeFloat(1.1)).toEqual(1.1);
+  });
+});
+
+describe("serializeDateTime", () => {
+  it("should truncate at the top of the second", () => {
+    const date = new Date(1716476757761);
+    date.setMilliseconds(0);
+    expect(serializeDateTime(date)).toEqual("2024-05-23T15:05:57Z");
+  });
+
+  it("should not truncate otherwise", () => {
+    const date = new Date(1716476757761);
+    expect(serializeDateTime(date)).toEqual("2024-05-23T15:05:57.761Z");
   });
 });

--- a/packages/smithy-client/src/ser-utils.spec.ts
+++ b/packages/smithy-client/src/ser-utils.spec.ts
@@ -14,13 +14,13 @@ describe("serializeFloat", () => {
 });
 
 describe("serializeDateTime", () => {
-  it("should truncate at the top of the second", () => {
+  it("should not truncate at the top of the second", () => {
     const date = new Date(1716476757761);
     date.setMilliseconds(0);
-    expect(serializeDateTime(date)).toEqual("2024-05-23T15:05:57Z");
+    expect(serializeDateTime(date)).toEqual("2024-05-23T15:05:57.000Z");
   });
 
-  it("should not truncate otherwise", () => {
+  it("should not truncate in general", () => {
     const date = new Date(1716476757761);
     expect(serializeDateTime(date)).toEqual("2024-05-23T15:05:57.761Z");
   });

--- a/packages/smithy-client/src/ser-utils.ts
+++ b/packages/smithy-client/src/ser-utils.ts
@@ -22,7 +22,7 @@ export const serializeFloat = (value: number): string | number => {
 };
 
 /**
- * @param date - to be serialized
+ * @param date - to be serialized.
  * @returns https://smithy.io/1.0/spec/core/protocol-traits.html#timestampformat-trait date-time format.
  */
 export const serializeDateTime = (date: Date): string => {

--- a/packages/smithy-client/src/ser-utils.ts
+++ b/packages/smithy-client/src/ser-utils.ts
@@ -26,10 +26,5 @@ export const serializeFloat = (value: number): string | number => {
  * @returns https://smithy.io/1.0/spec/core/protocol-traits.html#timestampformat-trait date-time format.
  */
 export const serializeDateTime = (date: Date): string => {
-  const iso = date.toISOString();
-  const [prefix, milliseconds] = iso.split(".");
-  if (milliseconds === "000Z") {
-    return prefix + "Z";
-  }
-  return iso;
+  return date.toISOString();
 };

--- a/packages/smithy-client/src/ser-utils.ts
+++ b/packages/smithy-client/src/ser-utils.ts
@@ -23,6 +23,6 @@ export const serializeFloat = (value: number): string | number => {
 
 /**
  * @param date - to be serialized.
- * @returns https://smithy.io/1.0/spec/core/protocol-traits.html#timestampformat-trait date-time format.
+ * @returns https://smithy.io/2.0/spec/protocol-traits.html#timestampformat-trait date-time format.
  */
 export const serializeDateTime = (date: Date): string => date.toISOString();

--- a/packages/smithy-client/src/ser-utils.ts
+++ b/packages/smithy-client/src/ser-utils.ts
@@ -25,6 +25,4 @@ export const serializeFloat = (value: number): string | number => {
  * @param date - to be serialized.
  * @returns https://smithy.io/1.0/spec/core/protocol-traits.html#timestampformat-trait date-time format.
  */
-export const serializeDateTime = (date: Date): string => {
-  return date.toISOString();
-};
+export const serializeDateTime = (date: Date): string => date.toISOString();

--- a/packages/smithy-client/src/ser-utils.ts
+++ b/packages/smithy-client/src/ser-utils.ts
@@ -20,3 +20,16 @@ export const serializeFloat = (value: number): string | number => {
       return value;
   }
 };
+
+/**
+ * @param date - to be serialized
+ * @returns https://smithy.io/1.0/spec/core/protocol-traits.html#timestampformat-trait date-time format.
+ */
+export const serializeDateTime = (date: Date): string => {
+  const iso = date.toISOString();
+  const [prefix, milliseconds] = iso.split(".");
+  if (milliseconds === "000Z") {
+    return prefix + "Z";
+  }
+  return iso;
+};

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -79,16 +79,15 @@ public final class HttpProtocolGeneratorUtils {
     ) {
         switch (format) {
             case DATE_TIME:
-                // Use the split to not serialize milliseconds.
-                return "(" + dataSource + ".toISOString().split('.')[0]+\"Z\")";
+                return dataSource + ".toISOString()";
             case EPOCH_SECONDS:
-                return "Math.round(" + dataSource + ".getTime() / 1000)";
+                return "(" + dataSource + ".getTime() / 1_000)";
             case HTTP_DATE:
                 context.getWriter().addImport("dateToUtcString", "__dateToUtcString",
                     TypeScriptDependency.AWS_SMITHY_CLIENT);
                 return "__dateToUtcString(" + dataSource + ")";
             default:
-                throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
+                throw new CodegenException("Unexpected timestamp format `" + format + "` on " + shape);
         }
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -79,12 +79,20 @@ public final class HttpProtocolGeneratorUtils {
     ) {
         switch (format) {
             case DATE_TIME:
-                return dataSource + ".toISOString()";
+                context.getWriter().addImport(
+                    "serializeDateTime",
+                    "__serializeDateTime",
+                    TypeScriptDependency.AWS_SMITHY_CLIENT
+                );
+                return "__serializeDateTime(" + dataSource + ")";
             case EPOCH_SECONDS:
                 return "(" + dataSource + ".getTime() / 1_000)";
             case HTTP_DATE:
-                context.getWriter().addImport("dateToUtcString", "__dateToUtcString",
-                    TypeScriptDependency.AWS_SMITHY_CLIENT);
+                context.getWriter().addImport(
+                    "dateToUtcString",
+                    "__dateToUtcString",
+                    TypeScriptDependency.AWS_SMITHY_CLIENT
+                );
                 return "__dateToUtcString(" + dataSource + ")";
             default:
                 throw new CodegenException("Unexpected timestamp format `" + format + "` on " + shape);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -28,7 +28,7 @@ public class HttpProtocolGeneratorUtilsTest {
         mockContext.setWriter(writer);
         TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
 
-        assertThat(DATA_SOURCE + ".toISOString()",
+        assertThat("__serializeDateTime(" + DATA_SOURCE + ")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.DATE_TIME)));
         assertThat("(" + DATA_SOURCE + ".getTime() / 1_000)",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.EPOCH_SECONDS)));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -28,9 +28,9 @@ public class HttpProtocolGeneratorUtilsTest {
         mockContext.setWriter(writer);
         TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
 
-        assertThat("(" + DATA_SOURCE + ".toISOString().split('.')[0]+\"Z\")",
+        assertThat(DATA_SOURCE + ".toISOString()",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.DATE_TIME)));
-        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000)",
+        assertThat("(" + DATA_SOURCE + ".getTime() / 1_000)",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
         assertThat("__dateToUtcString(" + DATA_SOURCE + ")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.HTTP_DATE)));


### PR DESCRIPTION
fixes https://github.com/smithy-lang/smithy-typescript/issues/1278