### PR TITLE
chore: add logging for CredentialsProviderError

### DIFF
--- a/.changeset/late-glasses-jam.md
+++ b/.changeset/late-glasses-jam.md
@@ -1,0 +1,8 @@
+---
+"@smithy/credential-provider-imds": minor
+"@smithy/shared-ini-file-loader": minor
+"@smithy/node-config-provider": minor
+"@smithy/property-provider": minor
+---
+
+new logging-compatible signature for CredentialsProviderError

--- a/.changeset/two-weeks-provide.md
+++ b/.changeset/two-weeks-provide.md
@@ -1,6 +1,0 @@
----
-"@smithy/node-config-provider": patch
-"@smithy/property-provider": patch
----
-
-add logging capability for CredentialsProviderError

--- a/.changeset/two-weeks-provide.md
+++ b/.changeset/two-weeks-provide.md
@@ -1,0 +1,6 @@
+---
+"@smithy/node-config-provider": patch
+"@smithy/property-provider": patch
+---
+
+add logging capability for CredentialsProviderError

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -25,9 +25,12 @@ const X_AWS_EC2_METADATA_TOKEN = "x-aws-ec2-metadata-token";
  * Instance Metadata Service
  */
 export const fromInstanceMetadata = (init: RemoteProviderInit = {}): Provider<InstanceMetadataCredentials> =>
-  staticStabilityProvider(getInstanceImdsProvider(init), { logger: init.logger });
+  staticStabilityProvider(getInstanceMetadataProvider(init), { logger: init.logger });
 
-const getInstanceImdsProvider = (init: RemoteProviderInit) => {
+/**
+ * @internal
+ */
+const getInstanceMetadataProvider = (init: RemoteProviderInit = {}) => {
   // when set to true, metadata service will not fetch token
   let disableFetchToken = false;
   const { logger, profile } = init;
@@ -154,7 +157,7 @@ const getMetadataToken = async (options: RequestOptions) =>
 const getProfile = async (options: RequestOptions) => (await httpRequest({ ...options, path: IMDS_PATH })).toString();
 
 const getCredentialsFromProfile = async (profile: string, options: RequestOptions, init: RemoteProviderInit) => {
-  const credsResponse = JSON.parse(
+  const credentialsResponse = JSON.parse(
     (
       await httpRequest({
         ...options,
@@ -163,11 +166,11 @@ const getCredentialsFromProfile = async (profile: string, options: RequestOption
     ).toString()
   );
 
-  if (!isImdsCredentials(credsResponse)) {
+  if (!isImdsCredentials(credentialsResponse)) {
     throw new CredentialsProviderError("Invalid response received from instance metadata service.", {
       logger: init.logger,
     });
   }
 
-  return fromImdsCredentials(credsResponse);
+  return fromImdsCredentials(credentialsResponse);
 };

--- a/packages/node-config-provider/src/fromEnv.spec.ts
+++ b/packages/node-config-provider/src/fromEnv.spec.ts
@@ -4,26 +4,30 @@ import { fromEnv, GetterFromEnv } from "./fromEnv";
 
 describe("fromEnv", () => {
   describe("with env var getter", () => {
-    const envVarName = "ENV_VAR_NAME";
+    const ENV_VAR_NAME = "ENV_VAR_NAME";
 
     // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
-    const envVarGetter: GetterFromEnv<string> = (env: Record<string, string | undefined>) => env[envVarName]!;
-    const envVarValue = process.env[envVarName];
+    const envVarGetter: GetterFromEnv<string> = (env: Record<string, string | undefined>) => env[ENV_VAR_NAME]!;
+    const envVarValue = process.env[ENV_VAR_NAME];
     const mockEnvVarValue = "mockEnvVarValue";
 
-    const getCredentialsProviderError = (getter: GetterFromEnv<string>) =>
-      new CredentialsProviderError(`Cannot load config from environment variables with getter: ${getter}`);
-
     beforeEach(() => {
-      delete process.env[envVarName];
+      delete process.env[ENV_VAR_NAME];
     });
 
     afterAll(() => {
-      process.env[envVarName] = envVarValue;
+      process.env[ENV_VAR_NAME] = envVarValue;
     });
 
-    it(`returns string value in '${envVarName}' env var when set`, () => {
-      process.env[envVarName] = mockEnvVarValue;
+    describe("CredentialsProviderError", () => {
+      it("is behaving as expected cross-package in jest", () => {
+        expect(new CredentialsProviderError("msg", {}).message).toEqual("msg");
+        expect(new CredentialsProviderError("msg", {}).name).toEqual("CredentialsProviderError");
+      });
+    });
+
+    it(`returns string value in '${ENV_VAR_NAME}' env var when set`, () => {
+      process.env[ENV_VAR_NAME] = mockEnvVarValue;
       return expect(fromEnv(envVarGetter)()).resolves.toBe(mockEnvVarValue);
     });
 
@@ -35,9 +39,10 @@ describe("fromEnv", () => {
       return expect(fromEnv(getter)()).resolves.toEqual(value);
     });
 
-    it(`throws when '${envVarName}' env var is not set`, () => {
+    it(`throws when '${ENV_VAR_NAME}' env var is not set`, async () => {
       expect.assertions(1);
-      return expect(fromEnv(envVarGetter)()).rejects.toMatchObject(getCredentialsProviderError(envVarGetter));
+      const error = await fromEnv(envVarGetter)().catch((_) => _);
+      return expect(error).toEqual(new CredentialsProviderError(`Not found in ENV: ENV_VAR_NAME`, {}));
     });
 
     it("throws when the getter function throws", () => {

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,6 +1,8 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
 import { Provider } from "@smithy/types";
 
+import { getSelectorName } from "./getSelectorName";
+
 // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
 export type GetterFromEnv<T> = (env: Record<string, string | undefined>) => T | undefined;
 
@@ -19,7 +21,7 @@ export const fromEnv =
       return config as T;
     } catch (e) {
       throw new CredentialsProviderError(
-        e.message || `Cannot load config from environment variables with getter: ${envVarSelector}`
+        e.message || `Not found in ENV: ${getSelectorName(envVarSelector.toString())}`
       );
     }
   };

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,5 +1,5 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { Provider } from "@smithy/types";
+import { Logger, Provider } from "@smithy/types";
 
 import { getSelectorName } from "./getSelectorName";
 
@@ -11,7 +11,7 @@ export type GetterFromEnv<T> = (env: Record<string, string | undefined>) => T | 
  * environment variable.
  */
 export const fromEnv =
-  <T = string>(envVarSelector: GetterFromEnv<T>): Provider<T> =>
+  <T = string>(envVarSelector: GetterFromEnv<T>, logger?: Logger): Provider<T> =>
   async () => {
     try {
       const config = envVarSelector(process.env);
@@ -21,7 +21,8 @@ export const fromEnv =
       return config as T;
     } catch (e) {
       throw new CredentialsProviderError(
-        e.message || `Not found in ENV: ${getSelectorName(envVarSelector.toString())}`
+        e.message || `Not found in ENV: ${getSelectorName(envVarSelector.toString())}`,
+        { logger }
       );
     }
   };

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -2,6 +2,8 @@ import { CredentialsProviderError } from "@smithy/property-provider";
 import { getProfileName, loadSharedConfigFiles, SourceProfileInit } from "@smithy/shared-ini-file-loader";
 import { ParsedIniData, Profile, Provider } from "@smithy/types";
 
+import { getSelectorName } from "./getSelectorName";
+
 export interface SharedConfigInit extends SourceProfileInit {
   /**
    * The preferred shared ini file to load the config. "config" option refers to
@@ -41,8 +43,7 @@ export const fromSharedConfigFiles =
       return configValue;
     } catch (e) {
       throw new CredentialsProviderError(
-        e.message ||
-          `Cannot load config for profile ${profile} in SDK configuration files with getter: ${configSelector}`
+        e.message || `Not found in config files w/ profile [${profile}]: ${getSelectorName(configSelector.toString())}`
       );
     }
   };

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -43,7 +43,8 @@ export const fromSharedConfigFiles =
       return configValue;
     } catch (e) {
       throw new CredentialsProviderError(
-        e.message || `Not found in config files w/ profile [${profile}]: ${getSelectorName(configSelector.toString())}`
+        e.message || `Not found in config files w/ profile [${profile}]: ${getSelectorName(configSelector.toString())}`,
+        { logger: init.logger }
       );
     }
   };

--- a/packages/node-config-provider/src/getSelectorName.ts
+++ b/packages/node-config-provider/src/getSelectorName.ts
@@ -1,7 +1,7 @@
 /**
  * Attempts to extract the name of the variable that the functional selector is looking for.
  * Improves readability over the raw Function.toString() value.
- *
+ * @internal
  * @param functionString - function's string representation.
  *
  * @returns constant value used within the function.

--- a/packages/node-config-provider/src/getSelectorName.ts
+++ b/packages/node-config-provider/src/getSelectorName.ts
@@ -1,0 +1,15 @@
+/**
+ * Attempts to extract the name of the variable that the functional selector is looking for.
+ * Improves readability over the raw Function.toString() value.
+ *
+ * @param functionString - function's string representation.
+ *
+ * @returns constant value used within the function.
+ */
+export function getSelectorName(functionString: string): string {
+  const constants = new Set(Array.from(functionString.match(/([A-Z_]){3,}/g) ?? []));
+  constants.delete("CONFIG");
+  constants.delete("CONFIG_PREFIX_SEPARATOR");
+  constants.delete("ENV");
+  return [...constants].join(", ");
+}

--- a/packages/node-config-provider/src/getSelectorName.ts
+++ b/packages/node-config-provider/src/getSelectorName.ts
@@ -7,9 +7,13 @@
  * @returns constant value used within the function.
  */
 export function getSelectorName(functionString: string): string {
-  const constants = new Set(Array.from(functionString.match(/([A-Z_]){3,}/g) ?? []));
-  constants.delete("CONFIG");
-  constants.delete("CONFIG_PREFIX_SEPARATOR");
-  constants.delete("ENV");
-  return [...constants].join(", ");
+  try {
+    const constants = new Set(Array.from(functionString.match(/([A-Z_]){3,}/g) ?? []));
+    constants.delete("CONFIG");
+    constants.delete("CONFIG_PREFIX_SEPARATOR");
+    constants.delete("ENV");
+    return [...constants].join(", ");
+  } catch (e) {
+    return functionString;
+  }
 }

--- a/packages/property-provider/src/CredentialsProviderError.spec.ts
+++ b/packages/property-provider/src/CredentialsProviderError.spec.ts
@@ -2,22 +2,22 @@ import { CredentialsProviderError } from "./CredentialsProviderError";
 import { ProviderError } from "./ProviderError";
 
 describe(CredentialsProviderError.name, () => {
-  afterAll(() => {
-    CredentialsProviderError.logLimit = 100;
-  });
-
   it("should be named as CredentialsProviderError", () => {
     expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
   });
 
-  it("should log up to its logLimit", () => {
-    CredentialsProviderError.logLimit = 5;
+  it("should use logger.trace if provided", () => {
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+    };
+    new CredentialsProviderError("PANIC", { logger });
 
-    Array.from({ length: CredentialsProviderError.logLimit + 2 }).forEach(() => {
-      new CredentialsProviderError("PANIC");
-    });
-
-    expect(CredentialsProviderError.log.length).toEqual(CredentialsProviderError.logLimit);
+    expect(logger.debug).not.toHaveBeenCalled();
+    expect(logger.trace).toHaveBeenCalled();
   });
 
   describe.each([Error, ProviderError, CredentialsProviderError])("should be instanceof %p", (classConstructor) => {

--- a/packages/property-provider/src/CredentialsProviderError.spec.ts
+++ b/packages/property-provider/src/CredentialsProviderError.spec.ts
@@ -2,8 +2,22 @@ import { CredentialsProviderError } from "./CredentialsProviderError";
 import { ProviderError } from "./ProviderError";
 
 describe(CredentialsProviderError.name, () => {
+  afterAll(() => {
+    CredentialsProviderError.logLimit = 100;
+  });
+
   it("should be named as CredentialsProviderError", () => {
     expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
+  });
+
+  it("should log up to its logLimit", () => {
+    CredentialsProviderError.logLimit = 5;
+
+    Array.from({ length: CredentialsProviderError.logLimit + 2 }).forEach(() => {
+      new CredentialsProviderError("PANIC");
+    });
+
+    expect(CredentialsProviderError.log.length).toEqual(CredentialsProviderError.logLimit);
   });
 
   describe.each([Error, ProviderError, CredentialsProviderError])("should be instanceof %p", (classConstructor) => {

--- a/packages/property-provider/src/CredentialsProviderError.spec.ts
+++ b/packages/property-provider/src/CredentialsProviderError.spec.ts
@@ -2,11 +2,31 @@ import { CredentialsProviderError } from "./CredentialsProviderError";
 import { ProviderError } from "./ProviderError";
 
 describe(CredentialsProviderError.name, () => {
-  it("should be named as CredentialsProviderError", () => {
+  it("should be named CredentialsProviderError", () => {
     expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
   });
 
-  it("should use logger.trace if provided", () => {
+  it("should have a non-enumerable message like the base Error class", () => {
+    expect(new CredentialsProviderError("PANIC", {}).message).toBe("PANIC");
+
+    expect(
+      {
+        ...new CredentialsProviderError("PANIC", {}),
+      }.message
+    ).toBe(undefined);
+  });
+
+  it("should have an enumerable tryNextLink and logger like the base Error class", () => {
+    expect(new CredentialsProviderError("PANIC", {}).tryNextLink).toBe(true);
+
+    expect(
+      {
+        ...new CredentialsProviderError("PANIC", { tryNextLink: false }),
+      }.tryNextLink
+    ).toBe(false);
+  });
+
+  it("should use logger.debug if provided", () => {
     const logger = {
       info: jest.fn(),
       warn: jest.fn(),
@@ -16,8 +36,8 @@ describe(CredentialsProviderError.name, () => {
     };
     new CredentialsProviderError("PANIC", { logger });
 
-    expect(logger.debug).not.toHaveBeenCalled();
-    expect(logger.trace).toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalled();
+    expect(logger.trace).not.toHaveBeenCalled();
   });
 
   describe.each([Error, ProviderError, CredentialsProviderError])("should be instanceof %p", (classConstructor) => {

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -12,13 +12,18 @@ import { ProviderError } from "./ProviderError";
  * ensures the chain will stop if an entirely unexpected error is encountered.
  */
 export class CredentialsProviderError extends ProviderError {
-  name = "CredentialsProviderError";
-  constructor(
+  public static log: string[] = [];
+  public static logLimit = 100;
+  public name = "CredentialsProviderError";
+  public constructor(
     message: string,
     public readonly tryNextLink: boolean = true
   ) {
     super(message, tryNextLink);
-    // Remove once we stop targetting ES5.
     Object.setPrototypeOf(this, CredentialsProviderError.prototype);
+    CredentialsProviderError.log.push(`${new Date().toISOString()} ${tryNextLink ? "->" : "(!)"} ${message}`);
+    while (CredentialsProviderError.log.length > CredentialsProviderError.logLimit) {
+      CredentialsProviderError.log.shift();
+    }
   }
 }

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,14 +1,6 @@
 import { Logger } from "@smithy/types";
 
-import { ProviderError } from "./ProviderError";
-
-/**
- * @public
- */
-export type CredentialsProviderErrorOptionsType = {
-  tryNextLink?: boolean | undefined;
-  logger?: Logger;
-};
+import { ProviderError, ProviderErrorOptionsType } from "./ProviderError";
 
 /**
  * @public
@@ -22,8 +14,7 @@ export type CredentialsProviderErrorOptionsType = {
  * ensures the chain will stop if an entirely unexpected error is encountered.
  */
 export class CredentialsProviderError extends ProviderError {
-  public name = "CredentialsProviderError";
-  public readonly tryNextLink: boolean = true;
+  name = "CredentialsProviderError";
 
   /**
    * @deprecated constructor should be given a logger.
@@ -32,25 +23,13 @@ export class CredentialsProviderError extends ProviderError {
   /**
    * @deprecated constructor should be given a logger.
    */
-  public constructor(message: string, tryNextLink?: boolean | undefined);
+  public constructor(message: string, tryNextLink: boolean | undefined);
   /**
    * This signature is preferred for logging capability.
    */
-  public constructor(message: string, options: CredentialsProviderErrorOptionsType);
-  public constructor(message: string, options: boolean | CredentialsProviderErrorOptionsType = true) {
-    let logger: Logger | undefined;
-    let tryNextLink: boolean = true;
-
-    if (typeof options === "boolean") {
-      logger = undefined;
-      tryNextLink = options;
-    } else if (options != null && typeof options === "object") {
-      logger = options.logger;
-      tryNextLink = options.tryNextLink ?? true;
-    }
-    super(message, tryNextLink);
-
+  public constructor(message: string, options: ProviderErrorOptionsType);
+  public constructor(message: string, options: boolean | ProviderErrorOptionsType = true) {
+    super(message, options as ProviderErrorOptionsType);
     Object.setPrototypeOf(this, CredentialsProviderError.prototype);
-    logger?.trace?.(`${new Date().toISOString()} ${tryNextLink ? "->" : "(!)"} ${message}`);
   }
 }

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,5 +1,3 @@
-import { Logger } from "@smithy/types";
-
 import { ProviderError, ProviderErrorOptionsType } from "./ProviderError";
 
 /**
@@ -17,17 +15,23 @@ export class CredentialsProviderError extends ProviderError {
   name = "CredentialsProviderError";
 
   /**
+   * @override
    * @deprecated constructor should be given a logger.
    */
   public constructor(message: string);
   /**
+   * @override
    * @deprecated constructor should be given a logger.
    */
   public constructor(message: string, tryNextLink: boolean | undefined);
   /**
+   * @override
    * This signature is preferred for logging capability.
    */
   public constructor(message: string, options: ProviderErrorOptionsType);
+  /**
+   * @override
+   */
   public constructor(message: string, options: boolean | ProviderErrorOptionsType = true) {
     super(message, options as ProviderErrorOptionsType);
     Object.setPrototypeOf(this, CredentialsProviderError.prototype);

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -49,7 +49,7 @@ export class ProviderError extends Error {
     super(message);
     this.tryNextLink = tryNextLink;
     Object.setPrototypeOf(this, ProviderError.prototype);
-    logger?.debug?.(`${this.constructor?.name} ${tryNextLink ? "->" : "(!)"} ${message}`);
+    logger?.debug?.(`@smithy/property-provider ${tryNextLink ? "->" : "(!)"} ${message}`);
   }
 
   /**

--- a/packages/property-provider/src/TokenProviderError.ts
+++ b/packages/property-provider/src/TokenProviderError.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "./ProviderError";
+import { ProviderError, ProviderErrorOptionsType } from "./ProviderError";
 
 /**
  * @public
@@ -13,12 +13,20 @@ import { ProviderError } from "./ProviderError";
  */
 export class TokenProviderError extends ProviderError {
   name = "TokenProviderError";
-  constructor(
-    message: string,
-    public readonly tryNextLink: boolean = true
-  ) {
-    super(message, tryNextLink);
-    // Remove once we stop targetting ES5.
+  /**
+   * @deprecated constructor should be given a logger.
+   */
+  public constructor(message: string);
+  /**
+   * @deprecated constructor should be given a logger.
+   */
+  public constructor(message: string, tryNextLink: boolean | undefined);
+  /**
+   * This signature is preferred for logging capability.
+   */
+  public constructor(message: string, options: ProviderErrorOptionsType);
+  public constructor(message: string, options: boolean | ProviderErrorOptionsType = true) {
+    super(message, options as ProviderErrorOptionsType);
     Object.setPrototypeOf(this, TokenProviderError.prototype);
   }
 }

--- a/packages/property-provider/src/TokenProviderError.ts
+++ b/packages/property-provider/src/TokenProviderError.ts
@@ -13,18 +13,25 @@ import { ProviderError, ProviderErrorOptionsType } from "./ProviderError";
  */
 export class TokenProviderError extends ProviderError {
   name = "TokenProviderError";
+
   /**
+   * @override
    * @deprecated constructor should be given a logger.
    */
   public constructor(message: string);
   /**
+   * @override
    * @deprecated constructor should be given a logger.
    */
   public constructor(message: string, tryNextLink: boolean | undefined);
   /**
+   * @override
    * This signature is preferred for logging capability.
    */
   public constructor(message: string, options: ProviderErrorOptionsType);
+  /**
+   * @override
+   */
   public constructor(message: string, options: boolean | ProviderErrorOptionsType = true) {
     super(message, options as ProviderErrorOptionsType);
     Object.setPrototypeOf(this, TokenProviderError.prototype);

--- a/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
@@ -1,4 +1,4 @@
-import { SharedConfigFiles } from "@smithy/types";
+import { Logger, SharedConfigFiles } from "@smithy/types";
 
 import { getConfigData } from "./getConfigData";
 import { getConfigFilepath } from "./getConfigFilepath";
@@ -26,6 +26,11 @@ export interface SharedConfigInit {
    * property is set, the provider will always reload any configuration files loaded before.
    */
   ignoreCache?: boolean;
+
+  /**
+   * For credential resolution trace logging.
+   */
+  logger?: Logger;
 }
 
 const swallowError = () => ({});


### PR DESCRIPTION
Enable access to the log of instantiated `CredentialsProviderError`s.

In the AWS SDK with its many credential sources (default chain), the sequence through which you may end up with a certain provider in the chain is unclear, and seeing the history of thrown `CredentialProviderError`s helps with both maintainer and user debugging.

Example log:
```
2024-05-23T20:17:57.283Z -> Not found in ENV: UA_APP_ID_ENV_NAME
2024-05-23T20:17:57.283Z -> Not found in ENV: AWS_DEFAULTS_MODE_ENV
2024-05-23T20:17:57.289Z -> Unable to find environment variable credentials.
2024-05-23T20:17:57.289Z -> Skipping SSO provider in default chain (inputs do not include SSO fields).
2024-05-23T20:17:57.296Z -> Not found in config files w/ profile [default]: UA_APP_ID_INI_NAME
2024-05-23T20:17:57.296Z -> Not found in config files w/ profile [default]: AWS_DEFAULTS_MODE_CONFIG
2024-05-23T20:17:57.297Z -> Profile some_profile could not be found or parsed in shared credentials file.
2024-05-23T20:17:57.299Z -> Profile default did not contain credential_process.
2024-05-23T20:17:57.301Z -> Web identity configuration not specified
2024-05-23T20:17:57.318Z -> Not found in ENV: ENV_ENDPOINT_URL
2024-05-23T20:17:57.318Z -> Not found in config files w/ profile [default]: CONFIG_ENDPOINT_URL
2024-05-23T20:17:57.318Z -> Not found in ENV: ENV_USE_FIPS_ENDPOINT, ENV
2024-05-23T20:17:57.318Z -> Not found in config files w/ profile [default]: CONFIG_USE_FIPS_ENDPOINT
2024-05-23T20:17:57.319Z -> Not found in ENV: ENV_USE_DUALSTACK_ENDPOINT, ENV
2024-05-23T20:17:57.319Z -> Not found in config files w/ profile [default]: CONFIG_USE_DUALSTACK_ENDPOINT
2024-05-23T20:17:57.321Z -> Not found in ENV: ENV_RETRY_MODE
2024-05-23T20:17:57.321Z -> Not found in config files w/ profile [default]: CONFIG_RETRY_MODE
2024-05-23T20:17:57.321Z -> Not found in ENV: ENV_MAX_ATTEMPTS
2024-05-23T20:17:57.321Z -> Not found in config files w/ profile [default]: CONFIG_MAX_ATTEMPTS
```

Example 2, debugging credential chain:
```
@aws-sdk/credential-provider-node defaultProvider::fromEnv
@aws-sdk/credential-provider-env - fromEnv
@smithy/property-provider -> Unable to find environment variable credentials.
@aws-sdk/credential-provider-node defaultProvider::fromSSO
@smithy/property-provider -> Skipping SSO provider in default chain (inputs do not include SSO fields).
@aws-sdk/credential-provider-node defaultProvider::fromIni
@aws-sdk/credential-provider-ini - fromIni
    default isAssumeRoleWithSourceProfile source_profile=cluster_role
@aws-sdk/credential-provider-ini - resolveAssumeRoleCredentials (STS)
@aws-sdk/credential-provider-ini - finding credential resolver using source_profile=[cluster_role]
    cluster_role isCredentialSourceProfile credential_source=EcsContainer
@aws-sdk/credential-provider-ini - resolveAssumeRoleCredentials (STS)
@aws-sdk/credential-provider-ini - finding credential resolver using profile=[cluster_role]
@aws-sdk/credential-provider-ini - credential_source is EcsContainer
@aws-sdk/credential-provider-http - fromHttp
@aws-sdk/client-sts::resolveRegion accepting first of: undefined (provider) undefined (parent client) us-east-1 (STS default)
```