### PR TITLE
fix(smithy-client): truncate timestamp at 000 millis

### DIFF
--- a/.changeset/lucky-hats-doubt.md
+++ b/.changeset/lucky-hats-doubt.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+truncate timestamp ending in 000 milliseconds

--- a/packages/smithy-client/src/ser-utils.spec.ts
+++ b/packages/smithy-client/src/ser-utils.spec.ts
@@ -14,10 +14,10 @@ describe("serializeFloat", () => {
 });
 
 describe("serializeDateTime", () => {
-  it("should not truncate at the top of the second", () => {
+  it("should truncate at the top of the second", () => {
     const date = new Date(1716476757761);
     date.setMilliseconds(0);
-    expect(serializeDateTime(date)).toEqual("2024-05-23T15:05:57.000Z");
+    expect(serializeDateTime(date)).toEqual("2024-05-23T15:05:57Z");
   });
 
   it("should not truncate in general", () => {

--- a/packages/smithy-client/src/ser-utils.ts
+++ b/packages/smithy-client/src/ser-utils.ts
@@ -25,4 +25,4 @@ export const serializeFloat = (value: number): string | number => {
  * @param date - to be serialized.
  * @returns https://smithy.io/2.0/spec/protocol-traits.html#timestampformat-trait date-time format.
  */
-export const serializeDateTime = (date: Date): string => date.toISOString();
+export const serializeDateTime = (date: Date): string => date.toISOString().replace(".000Z", "Z");


### PR DESCRIPTION
I thought the test cases had more control over what was asserted downstream in the test generator (aws-sdk-js-v3), but the literal test case body strings are upstream (Smithy), so to pass the tests _and_ remain compliant with the spec I'd like to truncate the timestamps when millis are `000`.