### PR TITLE
fix(core): set module export fields

### DIFF
--- a/.changeset/rare-bulldogs-battle.md
+++ b/.changeset/rare-bulldogs-battle.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+adds a module exports field in core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,12 +18,14 @@
   "types": "./dist-types/index.d.ts",
   "exports": {
     ".": {
+      "module": "./dist-es/index.js",
       "node": "./dist-cjs/index.js",
       "import": "./dist-es/index.js",
       "require": "./dist-cjs/index.js",
       "types": "./dist-types/index.d.ts"
     },
     "./package.json": {
+      "module": "./package.json",
       "node": "./package.json",
       "import": "./package.json",
       "require": "./package.json"

--- a/packages/core/scripts/lint.js
+++ b/packages/core/scripts/lint.js
@@ -20,6 +20,7 @@ for (const submodule of submodules) {
     if (!pkgJson.exports[`./${submodule}`]) {
       errors.push(`${submodule} submodule is missing exports statement in package.json`);
       pkgJson.exports[`./${submodule}`] = {
+        module: `./dist-es/submodules/${submodule}/index.js`,
         node: `./dist-cjs/submodules/${submodule}/index.js`,
         import: `./dist-es/submodules/${submodule}/index.js`,
         require: `./dist-cjs/submodules/${submodule}/index.js`,


### PR DESCRIPTION
*Issue #, if available:*
Partner PR with https://github.com/aws/aws-sdk-js-v3/pull/6149

*Description of changes:*
adds a module field to (conditional) exports in core. 
no other entry points in submodules in `/core` yet


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
