### PR TITLE
Validate resolvedHost from httpRequestTests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -448,6 +448,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
 
         writeHttpHeaderAssertions(testCase);
         writeHttpQueryAssertions(testCase);
+        writeHttpHostAssertion(testCase);
         testCase.getBody().ifPresent(body -> {
             writeHttpBodyAssertions(body, testCase.getBodyMediaType().orElse("UNKNOWN"), true);
         });
@@ -519,6 +520,14 @@ public final class HttpProtocolTestGenerator implements Runnable {
             writer.write("expect(r.headers[$S]).toBe($S);", header, value);
         });
         writer.write("");
+    }
+
+    private void writeHttpHostAssertion(HttpRequestTestCase testCase) {
+        testCase.getResolvedHost().ifPresent(resolvedHost -> {
+            writer.write("expect(r.headers[\"host\"]).toBeDefined();");
+            writer.write("expect(r.headers[\"host\"]).toBe($S);", resolvedHost);
+            writer.write("");
+        });
     }
 
     private void writeHttpBodyAssertions(String body, String mediaType, boolean isClientTest) {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/smithy-lang/smithy-typescript/issues/1298

*Description of changes:*
Validates resolvedHost from httpRequestTests

Tested with MachineLearning in commit [aws/aws-sdk-js-v3@`1d6f814` (#6161)](https://github.com/aws/aws-sdk-js-v3/pull/6161/commits/1d6f814504c8540bd9a71915439b8da31010e757)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
