### PR TITLE
Fix logic for deciding when to write a default input body and content-type

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1096,7 +1096,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             optionalContentType = bindingIndex.determineResponseContentType(operationOrError, getDocumentContentType());
         }
         // If we need to write a default body then it needs a content type.
-        if (!optionalContentType.isPresent() && shouldWriteDefaultBody(context, operationOrError, isInput)) {
+        if (optionalContentType.isEmpty() && shouldWriteDefaultBody(context, operationOrError, isInput)) {
             optionalContentType = Optional.of(getDocumentContentType());
         }
         optionalContentType.ifPresent(contentType -> {
@@ -1143,8 +1143,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     /**
-     * Given a context and operation, should a default input body be written. By default no body will be written
-     * if there are no members bound to the input.
+     * Given a context and operation, should a default input body be written. By default, a body
+     * will be written if and only if there are payload members bound to the input.
      *
      * @param context The generation context.
      * @param operation The operation whose input is being serialized.
@@ -1152,7 +1152,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * @return True if a default body should be generated.
      */
     protected boolean shouldWriteDefaultInputBody(GenerationContext context, OperationShape operation) {
-        return HttpBindingIndex.of(context.getModel()).getRequestBindings(operation).isEmpty();
+        return HttpBindingIndex.of(context.getModel()).hasRequestBody(operation);
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
- Fixes a bug where an operation with no input shape is treated with a default payload and therefore has the content-type header added to the request object:
```
// Serialized request object
HttpRequest {
  method: 'GET',
  ...
  headers: {
    'content-type': 'application/json',   <---- ** Should NOT be set **
    host: 'localhost:3001',
    'x-amz-user-agent': 'aws-sdk-js/0.0.1',
    'user-agent': 'aws-sdk-js/0.0.1 ua/2.0 os/darwin#23.4.0 lang/js md/nodejs#18.20.2',
    'amz-sdk-invocation-id': '32c12c5c-6d20-407b-bfec-b78c6b00a0cd',
    'amz-sdk-request': 'attempt=1; max=3'
  },
  body: '',
  ...
}
```
- This leads to a 415, `UnsupportedMediaTypeException`, when calling a server with said operation
- Fixes #613

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
