### PR TITLE
chore: switch to platform AbortController & Signal implementations after dropping Node.js 14

### DIFF
--- a/.changeset/spotty-cars-do.md
+++ b/.changeset/spotty-cars-do.md
@@ -1,0 +1,9 @@
+---
+"@smithy/fetch-http-handler": minor
+"@smithy/node-http-handler": minor
+"@smithy/abort-controller": minor
+"@smithy/util-waiter": minor
+"@smithy/types": minor
+---
+
+use platform AbortController|AbortSignal implementations

--- a/packages/abort-controller/src/AbortController.ts
+++ b/packages/abort-controller/src/AbortController.ts
@@ -5,7 +5,7 @@ import { AbortSignal } from "./AbortSignal";
 export { IAbortController };
 
 /**
- * This implementation was added as Node.js didn't support AbortController prior to 15.x
+ * @deprecated This implementation was added as Node.js didn't support AbortController prior to 15.x
  * Use native implementation in browsers or Node.js \>=15.4.0.
  *
  * @public

--- a/packages/abort-controller/src/AbortController.ts
+++ b/packages/abort-controller/src/AbortController.ts
@@ -1,8 +1,8 @@
-import { AbortController as IAbortController } from "@smithy/types";
+import { AbortController as DeprecatedAbortController } from "@smithy/types";
 
 import { AbortSignal } from "./AbortSignal";
 
-export { IAbortController };
+export { DeprecatedAbortController };
 
 /**
  * @deprecated This implementation was added as Node.js didn't support AbortController prior to 15.x
@@ -10,7 +10,7 @@ export { IAbortController };
  *
  * @public
  */
-export class AbortController implements IAbortController {
+export class AbortController implements DeprecatedAbortController {
   public readonly signal: AbortSignal = new AbortSignal();
 
   abort(): void {

--- a/packages/abort-controller/src/AbortController.ts
+++ b/packages/abort-controller/src/AbortController.ts
@@ -2,7 +2,10 @@ import { AbortController as DeprecatedAbortController } from "@smithy/types";
 
 import { AbortSignal } from "./AbortSignal";
 
-export { DeprecatedAbortController };
+/**
+ * @public
+ */
+export { DeprecatedAbortController as IAbortController };
 
 /**
  * @deprecated This implementation was added as Node.js didn't support AbortController prior to 15.x

--- a/packages/abort-controller/src/AbortSignal.ts
+++ b/packages/abort-controller/src/AbortSignal.ts
@@ -1,11 +1,14 @@
-import { AbortHandler, AbortSignal as IAbortSignal } from "@smithy/types";
-
-export { AbortHandler, IAbortSignal };
+import { AbortHandler, AbortSignal as DeprecatedAbortSignal } from "@smithy/types";
 
 /**
  * @public
  */
-export class AbortSignal implements IAbortSignal {
+export { AbortHandler, DeprecatedAbortSignal as IAbortSignal };
+
+/**
+ * @public
+ */
+export class AbortSignal implements DeprecatedAbortSignal {
   public onabort: AbortHandler | null = null;
   private _aborted = false;
 

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -165,8 +165,10 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
             reject(abortError);
           };
           if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+            // preferred.
             (abortSignal as AbortSignal).addEventListener("abort", onAbort);
           } else {
+            // backwards compatibility
             abortSignal.onabort = onAbort;
           }
         })

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -159,11 +159,16 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
     if (abortSignal) {
       raceOfPromises.push(
         new Promise<never>((resolve, reject) => {
-          abortSignal.onabort = () => {
+          const onAbort = () => {
             const abortError = new Error("Request aborted");
             abortError.name = "AbortError";
             reject(abortError);
           };
+          if (typeof abortSignal.addEventListener === "function") {
+            abortSignal.addEventListener("abort", onAbort);
+          } else {
+            abortSignal.onabort = onAbort;
+          }
         })
       );
     }

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -164,8 +164,8 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
             abortError.name = "AbortError";
             reject(abortError);
           };
-          if (typeof abortSignal.addEventListener === "function") {
-            abortSignal.addEventListener("abort", onAbort);
+          if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+            (abortSignal as AbortSignal).addEventListener("abort", onAbort);
           } else {
             abortSignal.onabort = onAbort;
           }

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -611,7 +611,7 @@ describe("NodeHttpHandler", () => {
       ).rejects.toHaveProperty("name", "TypeError");
     });
 
-    fit("will destroy the request when aborted", async () => {
+    it("will destroy the request when aborted", async () => {
       const mockResponse = {
         statusCode: 200,
         headers: {},

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -611,7 +611,7 @@ describe("NodeHttpHandler", () => {
       ).rejects.toHaveProperty("name", "TypeError");
     });
 
-    it("will destroy the request when aborted", async () => {
+    fit("will destroy the request when aborted", async () => {
       const mockResponse = {
         statusCode: 200,
         headers: {},
@@ -619,12 +619,12 @@ describe("NodeHttpHandler", () => {
       };
       mockHttpsServer.addListener("request", createResponseFunction(mockResponse));
       let httpRequest: http.ClientRequest;
-      let reqAbortSpy: any;
+      let reqDestroySpy: any;
       const spy = jest.spyOn(https, "request").mockImplementationOnce(() => {
         const calls = spy.mock.calls;
         const currentIndex = calls.length - 1;
         httpRequest = https.request(calls[currentIndex][0], calls[currentIndex][1]);
-        reqAbortSpy = jest.spyOn(httpRequest, "abort");
+        reqDestroySpy = jest.spyOn(httpRequest, "destroy");
         return httpRequest;
       });
       const nodeHttpHandler = new NodeHttpHandler();
@@ -650,7 +650,7 @@ describe("NodeHttpHandler", () => {
         )
       ).rejects.toHaveProperty("name", "AbortError");
 
-      expect(reqAbortSpy.mock.calls.length).toBe(1);
+      expect(reqDestroySpy.mock.calls.length).toBe(1);
     });
   });
 

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -239,8 +239,8 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
           abortError.name = "AbortError";
           reject(abortError);
         };
-        if (typeof abortSignal.addEventListener === "function") {
-          abortSignal.addEventListener("abort", onAbort);
+        if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+          (abortSignal as AbortSignal).addEventListener("abort", onAbort);
         } else {
           abortSignal.onabort = onAbort;
         }

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -232,13 +232,18 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
 
       // wire-up abort logic
       if (abortSignal) {
-        abortSignal.onabort = () => {
+        const onAbort = () => {
           // ensure request is destroyed
-          req.abort();
+          req.destroy();
           const abortError = new Error("Request aborted");
           abortError.name = "AbortError";
           reject(abortError);
         };
+        if (typeof abortSignal.addEventListener === "function") {
+          abortSignal.addEventListener("abort", onAbort);
+        } else {
+          abortSignal.onabort = onAbort;
+        }
       }
 
       // Workaround for bug report in Node.js https://github.com/nodejs/node/issues/47137

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -240,8 +240,10 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
           reject(abortError);
         };
         if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+          // preferred.
           (abortSignal as AbortSignal).addEventListener("abort", onAbort);
         } else {
+          // backwards compatibility
           abortSignal.onabort = onAbort;
         }
       }

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -187,8 +187,8 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
           abortError.name = "AbortError";
           rejectWithDestroy(abortError);
         };
-        if (typeof abortSignal.addEventListener === "function") {
-          abortSignal.addEventListener("abort", onAbort);
+        if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+          (abortSignal as AbortSignal).addEventListener("abort", onAbort);
         } else {
           abortSignal.onabort = onAbort;
         }

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -188,8 +188,10 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
           rejectWithDestroy(abortError);
         };
         if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+          // preferred.
           (abortSignal as AbortSignal).addEventListener("abort", onAbort);
         } else {
+          // backwards compatibility
           abortSignal.onabort = onAbort;
         }
       }

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -181,12 +181,17 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
       }
 
       if (abortSignal) {
-        abortSignal.onabort = () => {
+        const onAbort = () => {
           req.close();
           const abortError = new Error("Request aborted");
           abortError.name = "AbortError";
           rejectWithDestroy(abortError);
         };
+        if (typeof abortSignal.addEventListener === "function") {
+          abortSignal.addEventListener("abort", onAbort);
+        } else {
+          abortSignal.onabort = onAbort;
+        }
       }
 
       // Set up handlers for errors

--- a/packages/types/src/abort-handler.ts
+++ b/packages/types/src/abort-handler.ts
@@ -1,8 +1,8 @@
-import type { AbortSignal as CustomAbortSignal } from "./abort";
+import type { AbortSignal as DeprecatedAbortSignal } from "./abort";
 
 /**
  * @public
  */
 export interface AbortHandler {
-  (this: AbortSignal | CustomAbortSignal, ev: any): any;
+  (this: AbortSignal | DeprecatedAbortSignal, ev: any): any;
 }

--- a/packages/types/src/abort-handler.ts
+++ b/packages/types/src/abort-handler.ts
@@ -1,0 +1,8 @@
+import type { AbortSignal as CustomAbortSignal } from "./abort";
+
+/**
+ * @public
+ */
+export interface AbortHandler {
+  (this: AbortSignal | CustomAbortSignal, ev: any): any;
+}

--- a/packages/types/src/abort.ts
+++ b/packages/types/src/abort.ts
@@ -7,7 +7,7 @@ export { AbortHandler };
 
 /**
  * @public
- * @deprecated use platform (global) type for AbortController | AbortSignal.
+ * @deprecated use platform (global) type for AbortSignal.
  *
  * Holders of an AbortSignal object may query if the associated operation has
  * been aborted and register an onabort handler.

--- a/packages/types/src/abort.ts
+++ b/packages/types/src/abort.ts
@@ -1,12 +1,13 @@
-/**
- * @public
- */
-export interface AbortHandler {
-  (this: AbortSignal, ev: any): any;
-}
+import type { AbortHandler } from "./abort-handler";
 
 /**
  * @public
+ */
+export { AbortHandler };
+
+/**
+ * @public
+ * @deprecated use platform (global) type for AbortController | AbortSignal.
  *
  * Holders of an AbortSignal object may query if the associated operation has
  * been aborted and register an onabort handler.
@@ -28,6 +29,7 @@ export interface AbortSignal {
 
 /**
  * @public
+ * @deprecated use platform (global) type for AbortController | AbortSignal.
  *
  * The AWS SDK uses a Controller/Signal model to allow for cooperative
  * cancellation of asynchronous operations. When initiating such an operation,

--- a/packages/types/src/abort.ts
+++ b/packages/types/src/abort.ts
@@ -29,7 +29,7 @@ export interface AbortSignal {
 
 /**
  * @public
- * @deprecated use platform (global) type for AbortController | AbortSignal.
+ * @deprecated use platform (global) type for AbortController.
  *
  * The AWS SDK uses a Controller/Signal model to allow for cooperative
  * cancellation of asynchronous operations. When initiating such an operation,

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -1,3 +1,4 @@
+import { AbortSignal as DeprecatedAbortSignal } from "./abort";
 import { URI } from "./uri";
 
 /**
@@ -105,7 +106,7 @@ export interface HttpMessage {
  * Represents the options that may be passed to an Http Handler.
  */
 export interface HttpHandlerOptions {
-  abortSignal?: AbortSignal;
+  abortSignal?: AbortSignal | DeprecatedAbortSignal;
 
   /**
    * The maximum time in milliseconds that the connection phase of a request

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -1,4 +1,3 @@
-import { AbortSignal } from "./abort";
 import { URI } from "./uri";
 
 /**

--- a/packages/types/src/waiter.ts
+++ b/packages/types/src/waiter.ts
@@ -1,3 +1,5 @@
+import { AbortController as IAbortController } from "./abort";
+
 /**
  * @public
  */
@@ -16,12 +18,12 @@ export interface WaiterConfiguration<Client> {
    * @deprecated Use abortSignal
    * Abort controller. Used for ending the waiter early.
    */
-  abortController?: AbortController;
+  abortController?: AbortController | IAbortController;
 
   /**
    * Abort Signal. Used for ending the waiter early.
    */
-  abortSignal?: AbortController["signal"];
+  abortSignal?: AbortController["signal"] | IAbortController["signal"];
 
   /**
    * The minimum amount of time to delay between retries in seconds. This is the

--- a/packages/types/src/waiter.ts
+++ b/packages/types/src/waiter.ts
@@ -1,4 +1,4 @@
-import { AbortController as IAbortController } from "./abort";
+import { AbortController as DeprecatedAbortController } from "./abort";
 
 /**
  * @public
@@ -18,12 +18,12 @@ export interface WaiterConfiguration<Client> {
    * @deprecated Use abortSignal
    * Abort controller. Used for ending the waiter early.
    */
-  abortController?: AbortController | IAbortController;
+  abortController?: AbortController | DeprecatedAbortController;
 
   /**
    * Abort Signal. Used for ending the waiter early.
    */
-  abortSignal?: AbortController["signal"] | IAbortController["signal"];
+  abortSignal?: AbortController["signal"] | DeprecatedAbortController["signal"];
 
   /**
    * The minimum amount of time to delay between retries in seconds. This is the

--- a/packages/types/src/waiter.ts
+++ b/packages/types/src/waiter.ts
@@ -1,5 +1,3 @@
-import { AbortController } from "./abort";
-
 /**
  * @public
  */

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -1,12 +1,14 @@
+import { AbortSignal as DeprecatedAbortSignal } from "@smithy/types";
+
 import { runPolling } from "./poller";
 import { validateWaiterOptions } from "./utils";
 import { WaiterOptions, WaiterResult, waiterServiceDefaults, WaiterState } from "./waiter";
 
-const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => {
+const abortTimeout = async (abortSignal: AbortSignal | DeprecatedAbortSignal): Promise<WaiterResult> => {
   return new Promise((resolve) => {
     const onAbort = () => resolve({ state: WaiterState.ABORTED });
-    if (typeof abortSignal.addEventListener === "function") {
-      abortSignal.addEventListener("abort", onAbort);
+    if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+      (abortSignal as AbortSignal).addEventListener("abort", onAbort);
     } else {
       abortSignal.onabort = onAbort;
     }

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -1,12 +1,15 @@
-import { AbortSignal } from "@smithy/types";
-
 import { runPolling } from "./poller";
 import { validateWaiterOptions } from "./utils";
 import { WaiterOptions, WaiterResult, waiterServiceDefaults, WaiterState } from "./waiter";
 
 const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => {
   return new Promise((resolve) => {
-    abortSignal.onabort = () => resolve({ state: WaiterState.ABORTED });
+    const onAbort = () => resolve({ state: WaiterState.ABORTED });
+    if (typeof abortSignal.addEventListener === "function") {
+      abortSignal.addEventListener("abort", onAbort);
+    } else {
+      abortSignal.onabort = onAbort;
+    }
   });
 };
 

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -8,8 +8,10 @@ const abortTimeout = async (abortSignal: AbortSignal | DeprecatedAbortSignal): P
   return new Promise((resolve) => {
     const onAbort = () => resolve({ state: WaiterState.ABORTED });
     if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
+      // preferred.
       (abortSignal as AbortSignal).addEventListener("abort", onAbort);
     } else {
+      // backwards compatibility
       abortSignal.onabort = onAbort;
     }
   });


### PR DESCRIPTION
fixes https://github.com/aws/aws-sdk-js-v3/issues/4872
fixes https://github.com/smithy-lang/smithy-typescript/issues/974

this deprecates our own Abort types and implementation and switches to the platform types where available.

AbortController / AbortSignal are available in Node.js 16+.