### PR TITLE
fix(util-waiter): return stringified result object in case of failure

### DIFF
--- a/.changeset/giant-swans-trade.md
+++ b/.changeset/giant-swans-trade.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-waiter": patch
+---
+
+Return stringified result object in case of failure

--- a/packages/util-waiter/src/waiter.spec.ts
+++ b/packages/util-waiter/src/waiter.spec.ts
@@ -23,7 +23,7 @@ describe(checkExceptions.name, () => {
     const result = { state: WaiterState.RETRY, reason };
     expect(() => checkExceptions(result)).toThrow({
       name: "Error",
-      message: JSON.stringify({ result }),
+      message: JSON.stringify(result),
     });
   });
 
@@ -31,7 +31,7 @@ describe(checkExceptions.name, () => {
     const result = { state: WaiterState.FAILURE, reason };
     expect(() => checkExceptions(result)).toThrow({
       name: "Error",
-      message: JSON.stringify({ result }),
+      message: JSON.stringify(result),
     });
   });
 

--- a/packages/util-waiter/src/waiter.spec.ts
+++ b/packages/util-waiter/src/waiter.spec.ts
@@ -1,0 +1,42 @@
+import { checkExceptions, WaiterState } from "./waiter";
+
+describe(checkExceptions.name, () => {
+  const reason = "generic reason";
+
+  it(`throw AbortError if state is ${WaiterState.ABORTED}`, () => {
+    const result = { state: WaiterState.ABORTED, reason };
+    expect(() => checkExceptions(result)).toThrow({
+      name: "AbortError",
+      message: JSON.stringify({ ...result, reason: "Request was aborted" }),
+    });
+  });
+
+  it(`throw TimeoutError if state is ${WaiterState.TIMEOUT}`, () => {
+    const result = { state: WaiterState.TIMEOUT, reason };
+    expect(() => checkExceptions(result)).toThrow({
+      name: "TimeoutError",
+      message: JSON.stringify({ ...result, reason: "Waiter has timed out" }),
+    });
+  });
+
+  it(`throw generic Error if state is ${WaiterState.RETRY}`, () => {
+    const result = { state: WaiterState.RETRY, reason };
+    expect(() => checkExceptions(result)).toThrow({
+      name: "Error",
+      message: JSON.stringify({ result }),
+    });
+  });
+
+  it(`throw generic Error if state is ${WaiterState.FAILURE}`, () => {
+    const result = { state: WaiterState.FAILURE, reason };
+    expect(() => checkExceptions(result)).toThrow({
+      name: "Error",
+      message: JSON.stringify({ result }),
+    });
+  });
+
+  it(`return result if state is ${WaiterState.SUCCESS}`, () => {
+    const result = { state: WaiterState.SUCCESS };
+    expect(checkExceptions(result)).toEqual(result);
+  });
+});

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -68,7 +68,7 @@ export const checkExceptions = (result: WaiterResult): WaiterResult => {
     timeoutError.name = "TimeoutError";
     throw timeoutError;
   } else if (result.state !== WaiterState.SUCCESS) {
-    throw new Error(`${JSON.stringify({ result })}`);
+    throw new Error(`${JSON.stringify(result)}`);
   }
   return result;
 };


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5250

*Description of changes:*
Returns stringified result object in case of failure

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
