### PR TITLE
fix(shared-ini-file-loader): read config files from paths relative to homedir

### DIFF
--- a/.changeset/eight-beans-visit.md
+++ b/.changeset/eight-beans-visit.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+read config files from paths relative to homedir

--- a/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
@@ -1,8 +1,10 @@
 import { Logger, SharedConfigFiles } from "@smithy/types";
+import { join } from "path";
 
 import { getConfigData } from "./getConfigData";
 import { getConfigFilepath } from "./getConfigFilepath";
 import { getCredentialsFilepath } from "./getCredentialsFilepath";
+import { getHomeDir } from "./getHomeDir";
 import { parseIni } from "./parseIni";
 import { slurpFile } from "./slurpFile";
 
@@ -39,15 +41,27 @@ export const CONFIG_PREFIX_SEPARATOR = ".";
 
 export const loadSharedConfigFiles = async (init: SharedConfigInit = {}): Promise<SharedConfigFiles> => {
   const { filepath = getCredentialsFilepath(), configFilepath = getConfigFilepath() } = init;
+  const homeDir = getHomeDir();
+  const relativeHomeDirPrefix = "~/";
+
+  let resolvedFilepath = filepath;
+  if (filepath.startsWith(relativeHomeDirPrefix)) {
+    resolvedFilepath = join(homeDir, filepath.slice(2));
+  }
+
+  let resolvedConfigFilepath = configFilepath;
+  if (configFilepath.startsWith(relativeHomeDirPrefix)) {
+    resolvedConfigFilepath = join(homeDir, configFilepath.slice(2));
+  }
 
   const parsedFiles = await Promise.all([
-    slurpFile(configFilepath, {
+    slurpFile(resolvedConfigFilepath, {
       ignoreCache: init.ignoreCache,
     })
       .then(parseIni)
       .then(getConfigData)
       .catch(swallowError),
-    slurpFile(filepath, {
+    slurpFile(resolvedFilepath, {
       ignoreCache: init.ignoreCache,
     })
       .then(parseIni)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/5876

*Description of changes:*
If a config path relative to *homedir* is provided, `shared-ini-file-loader` now expands `~` to its absolute path and reads the config file successfully.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
