### PR TITLE
Adding support for setting the fetch API credentials mode

### DIFF
--- a/.changeset/polite-fans-fly.md
+++ b/.changeset/polite-fans-fly.md
@@ -1,0 +1,6 @@
+---
+"@smithy/fetch-http-handler": minor
+"@smithy/types": minor
+---
+
+Adding support for setting the fetch API credentials mode

--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -353,32 +353,34 @@ describe(FetchHttpHandler.name, () => {
     expect(await blobToText(response.body)).toBe("FOO");
   });
 
-  it.each(["include", "omit", "same-origin"])
-  ("will pass credentials mode '%s' from a provider to a request", async (credentialsMode) => {
-    const mockResponse = {
-      headers: { entries: jest.fn().mockReturnValue([]) },
-      blob: jest.fn().mockResolvedValue(new Blob()),
-    };
-    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+  it.each(["include", "omit", "same-origin"])(
+    "will pass credentials mode '%s' from a provider to a request",
+    async (credentialsMode) => {
+      const mockResponse = {
+        headers: { entries: jest.fn().mockReturnValue([]) },
+        blob: jest.fn().mockResolvedValue(new Blob()),
+      };
+      const mockFetch = jest.fn().mockResolvedValue(mockResponse);
 
-    (global as any).fetch = mockFetch;
+      (global as any).fetch = mockFetch;
 
-    const httpRequest = new HttpRequest({
-      headers: {},
-      hostname: "foo.amazonaws.com",
-      method: "GET",
-      path: "/",
-      body: "will be omitted",
-    });
-    const fetchHttpHandler = new FetchHttpHandler();
-    fetchHttpHandler.updateHttpClientConfig("credentials", credentialsMode as RequestCredentials);
+      const httpRequest = new HttpRequest({
+        headers: {},
+        hostname: "foo.amazonaws.com",
+        method: "GET",
+        path: "/",
+        body: "will be omitted",
+      });
+      const fetchHttpHandler = new FetchHttpHandler();
+      fetchHttpHandler.updateHttpClientConfig("credentials", credentialsMode as RequestCredentials);
 
-    await fetchHttpHandler.handle(httpRequest, {});
+      await fetchHttpHandler.handle(httpRequest, {});
 
-    expect(mockFetch.mock.calls.length).toBe(1);
-    const requestCall = mockRequest.mock.calls[0];
-    expect(requestCall[1].credentials).toBe(credentialsMode);
-  });
+      expect(mockFetch.mock.calls.length).toBe(1);
+      const requestCall = mockRequest.mock.calls[0];
+      expect(requestCall[1].credentials).toBe(credentialsMode);
+    }
+  );
 
   describe("#destroy", () => {
     it("should be callable and return nothing", () => {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -77,7 +77,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
     }
     const requestTimeoutInMs = this.config!.requestTimeout;
     const keepAlive = this.config!.keepAlive === true;
-    const credentials = this.config!.credentials;
+    const credentials = this.config!.credentials as RequestCredentials;
 
     // if the request was already aborted, prevent doing extra work
     if (abortSignal?.aborted) {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -77,6 +77,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
     }
     const requestTimeoutInMs = this.config!.requestTimeout;
     const keepAlive = this.config!.keepAlive === true;
+    const credentials = this.config!.credentials;
 
     // if the request was already aborted, prevent doing extra work
     if (abortSignal?.aborted) {
@@ -110,6 +111,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
       body,
       headers: new Headers(request.headers),
       method: method,
+      credentials
     };
     if (body) {
       requestOptions.duplex = "half";

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -77,7 +77,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
     }
     const requestTimeoutInMs = this.config!.requestTimeout;
     const keepAlive = this.config!.keepAlive === true;
-    const credentials = this.config!.credentials as RequestCredentials;
+    const credentials = this.config!.credentials as RequestInit["credentials"];
 
     // if the request was already aborted, prevent doing extra work
     if (abortSignal?.aborted) {
@@ -111,7 +111,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
       body,
       headers: new Headers(request.headers),
       method: method,
-      credentials
+      credentials,
     };
     if (body) {
       requestOptions.duplex = "half";

--- a/packages/types/src/http/httpHandlerInitialization.ts
+++ b/packages/types/src/http/httpHandlerInitialization.ts
@@ -91,8 +91,8 @@ export interface FetchHttpHandlerOptions {
    */
   keepAlive?: boolean;
 
-    /** 
-     * A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials.
-     */
-  credentials?: RequestCredentials;
+  /** 
+   * A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials.
+   */
+  credentials?: "include" | "omit" | "same-origin" | undefined | string;
 }

--- a/packages/types/src/http/httpHandlerInitialization.ts
+++ b/packages/types/src/http/httpHandlerInitialization.ts
@@ -91,8 +91,10 @@ export interface FetchHttpHandlerOptions {
    */
   keepAlive?: boolean;
 
-  /** 
-   * A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials.
+  /**
+   * A string indicating whether credentials will be sent with the request always, never, or
+   * only when sent to a same-origin URL.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
    */
   credentials?: "include" | "omit" | "same-origin" | undefined | string;
 }

--- a/packages/types/src/http/httpHandlerInitialization.ts
+++ b/packages/types/src/http/httpHandlerInitialization.ts
@@ -90,4 +90,9 @@ export interface FetchHttpHandlerOptions {
    * these limitations before enabling keepalive.
    */
   keepAlive?: boolean;
+
+    /** 
+     * A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials.
+     */
+  credentials?: RequestCredentials;
 }


### PR DESCRIPTION
*Issue #, if available:* [1296](https://github.com/smithy-lang/smithy-typescript/issues/1296)

*Description of changes:* Adds support to set credentials in the fetch API to `include`, `same-origin`, or `omit`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
