### PR TITLE
feat(codegen): add `mutateClientPlugins()` integration hook

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -102,6 +102,11 @@ final class DirectedTypeScriptCodegen
             });
         });
 
+        directive.integrations().forEach(integration -> {
+            LOGGER.info(() -> "Mutating plugins from TypeScriptIntegration: " + integration.getClass().getName());
+            integration.mutateClientPlugins(runtimePlugins);
+        });
+
         ProtocolGenerator protocolGenerator = resolveProtocolGenerator(
                 directive.integrations(),
                 directive.model(),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -65,6 +65,13 @@ public interface TypeScriptIntegration
     }
 
     /**
+     * Mutates in place the loaded list of plugins to apply to the generated client.
+     */
+    default void mutateClientPlugins(List<RuntimeClientPlugin> plugins) {
+        // defaults to no mutation
+    }
+
+    /**
      * Gets a list of protocol generators to register.
      *
      * @return Returns the list of protocol generators to register.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Add `mutateClientPlugins()` integration hook, useful for modifying the client plugins (e.g. builtin plugins).

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
