### PR TITLE
Execute AbortSignal listeners once to avoid memory leaks

### DIFF
--- a/.changeset/hip-rats-report.md
+++ b/.changeset/hip-rats-report.md
@@ -1,0 +1,6 @@
+---
+"@smithy/fetch-http-handler": patch
+"@smithy/node-http-handler": patch
+---
+
+Ensure abort signal event listeners are only called once

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -173,7 +173,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
           };
           if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
             // preferred.
-            (abortSignal as AbortSignal).addEventListener("abort", onAbort);
+            (abortSignal as AbortSignal).addEventListener("abort", onAbort, { once: true });
           } else {
             // backwards compatibility
             abortSignal.onabort = onAbort;

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -252,7 +252,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         };
         if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
           // preferred.
-          (abortSignal as AbortSignal).addEventListener("abort", onAbort);
+          (abortSignal as AbortSignal).addEventListener("abort", onAbort, { once: true });
         } else {
           // backwards compatibility
           abortSignal.onabort = onAbort;

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -189,7 +189,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
         };
         if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
           // preferred.
-          (abortSignal as AbortSignal).addEventListener("abort", onAbort);
+          (abortSignal as AbortSignal).addEventListener("abort", onAbort, { once: true });
         } else {
           // backwards compatibility
           abortSignal.onabort = onAbort;


### PR DESCRIPTION
*Issue #, if available:* #1330

*Description of changes:*

- Add `{ once: true }` when adding event listeners to `AbortSignal`s as recommended in the NodeJS documentation (see linked issue)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
