### PR TITLE
Remove AbortSignal event listeners when requests complete

### DIFF
--- a/.changeset/four-carrots-tap.md
+++ b/.changeset/four-carrots-tap.md
@@ -1,0 +1,6 @@
+---
+"@smithy/fetch-http-handler": patch
+"@smithy/node-http-handler": patch
+---
+
+remove abort signal event listeners after request completion

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -127,7 +127,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
       requestOptions.keepalive = keepAlive;
     }
 
-    let cleanupFunction = null as null | (() => void);
+    let removeSignalEventListener = null as null | (() => void);
 
     const fetchRequest = new Request(url, requestOptions);
     const raceOfPromises = [
@@ -177,7 +177,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
             // preferred.
             const signal = abortSignal as AbortSignal;
             signal.addEventListener("abort", onAbort, { once: true });
-            cleanupFunction = () => signal.removeEventListener("abort", onAbort);
+            removeSignalEventListener = () => signal.removeEventListener("abort", onAbort);
           } else {
             // backwards compatibility
             abortSignal.onabort = onAbort;
@@ -185,7 +185,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
         })
       );
     }
-    return Promise.race(raceOfPromises).finally(() => cleanupFunction && cleanupFunction());
+    return Promise.race(raceOfPromises).finally(removeSignalEventListener);
   }
 
   updateHttpClientConfig(key: keyof FetchHttpHandlerConfig, value: FetchHttpHandlerConfig[typeof key]): void {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -127,6 +127,8 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
       requestOptions.keepalive = keepAlive;
     }
 
+    let cleanupFunction = null as null | (() => void);
+
     const fetchRequest = new Request(url, requestOptions);
     const raceOfPromises = [
       fetch(fetchRequest).then((response) => {
@@ -173,7 +175,9 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
           };
           if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
             // preferred.
-            (abortSignal as AbortSignal).addEventListener("abort", onAbort);
+            const signal = abortSignal as AbortSignal;
+            signal.addEventListener("abort", onAbort, { once: true });
+            cleanupFunction = () => signal.removeEventListener("abort", onAbort);
           } else {
             // backwards compatibility
             abortSignal.onabort = onAbort;
@@ -181,7 +185,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
         })
       );
     }
-    return Promise.race(raceOfPromises);
+    return Promise.race(raceOfPromises).finally(() => cleanupFunction && cleanupFunction());
   }
 
   updateHttpClientConfig(key: keyof FetchHttpHandlerConfig, value: FetchHttpHandlerConfig[typeof key]): void {

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -252,7 +252,9 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         };
         if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
           // preferred.
-          (abortSignal as AbortSignal).addEventListener("abort", onAbort);
+          const signal = abortSignal as AbortSignal;
+          signal.addEventListener("abort", onAbort, { once: true });
+          req.once("close", () => signal.removeEventListener("abort", onAbort));
         } else {
           // backwards compatibility
           abortSignal.onabort = onAbort;

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -189,7 +189,9 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
         };
         if (typeof (abortSignal as AbortSignal).addEventListener === "function") {
           // preferred.
-          (abortSignal as AbortSignal).addEventListener("abort", onAbort);
+          const signal = abortSignal as AbortSignal;
+          signal.addEventListener("abort", onAbort, { once: true });
+          req.once("close", () => signal.removeEventListener("abort", onAbort));
         } else {
           // backwards compatibility
           abortSignal.onabort = onAbort;


### PR DESCRIPTION
*Issue #1318, if available:*

*Description of changes:*

Currently if an `AbortSignal` is re-used across multiple requests, more and more listeners will accumulate, leading to memory leaks. In order to mitigate this, we should remove any event listeners we add to the `AbortSignal` when the request completes.

## Notes on the code changes

- Should we be more defensive and check that `removeEventListener` is a function before using it?
- I don't really like the code changes in the `fetch-http-handler` so if anyone has any suggestions, please do chime in. It's somewhat tricky because `fetch` doesn't provide an event-driven API (that I know of).

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
