### PR TITLE
Make sha256 required parameter for SigV4 constructor

### DIFF
--- a/.changeset/real-teachers-sort.md
+++ b/.changeset/real-teachers-sort.md
@@ -1,0 +1,5 @@
+---
+"@smithy/signature-v4": major
+---
+
+Make sha256 required parameter for SigV4 constructor

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -72,7 +72,7 @@ export interface SignatureV4Init {
    * A constructor function for a hash object that will calculate SHA-256 HMAC
    * checksums.
    */
-  sha256?: ChecksumConstructor | HashConstructor;
+  sha256: ChecksumConstructor | HashConstructor;
 
   /**
    * Whether to uri-escape the request URI path as part of computing the


### PR DESCRIPTION
*Issue #, if available:*

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3590

*Description of changes:*

The SignatureV4 implementation was originally added in https://github.com/aws/aws-sdk-js-v3/pull/36 seven years ago, where `sha256` was not optional. It was incorrectly made optional in https://github.com/aws/aws-sdk-js-v3/pull/58.

This issue was not noticed during development of AWS SDK for JavaScript packages, since we always passed `sha256` as linked in https://github.com/aws/aws-sdk-js-v3/issues/3590#issuecomment-2223511779. However, it was an issue for some customers who called it directly. As described in the issue, those customers provided `sha256` implementation as a workaround.

This PR makes `sha256` a required parameter, as required by the implementation.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
