### PR TITLE
fix: exclude CustomEndpoints plugin from Endpoints 2.0 services

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBuiltinPlugins.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBuiltinPlugins.java
@@ -9,7 +9,6 @@ import static software.amazon.smithy.typescript.codegen.integration.RuntimeClien
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
 import java.util.List;
-
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBuiltinPlugins.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBuiltinPlugins.java
@@ -9,6 +9,9 @@ import static software.amazon.smithy.typescript.codegen.integration.RuntimeClien
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
 import java.util.List;
+
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -25,6 +28,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
             RuntimeClientPlugin.builder()
                 .withConventions(
                     TypeScriptDependency.CONFIG_RESOLVER.dependency, "CustomEndpoints", HAS_CONFIG)
+                .servicePredicate((m, s) -> !isEndpointsV2Service(s))
                 .build(),
             RuntimeClientPlugin.builder()
                 .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "Retry")
@@ -33,5 +37,9 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                 .withConventions(TypeScriptDependency.MIDDLEWARE_CONTENT_LENGTH.dependency, "ContentLength",
                     HAS_MIDDLEWARE)
                 .build());
+    }
+
+    private static boolean isEndpointsV2Service(ServiceShape serviceShape) {
+        return serviceShape.hasTrait(EndpointRuleSetTrait.class);
     }
 }


### PR DESCRIPTION
followup fix for https://github.com/smithy-lang/smithy-typescript/pull/1321.

The `CustomEndpoints` plugin is only needed for non-endpoints-ruleset services.