### PR TITLE
add default endpoint to protocol test stub

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -1,14 +1,14 @@
 import { HttpHandlerOptions, HeaderBag } from "@smithy/types";
 import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { Readable } from 'stream';
+import { Readable } from "stream";
 
 /**
  * Throws an expected exception that contains the serialized request.
  */
 class EXPECTED_REQUEST_SERIALIZATION_ERROR extends Error {
-    constructor(readonly request: HttpRequest) {
-      super();
-    }
+  constructor(readonly request: HttpRequest) {
+    super();
+  }
 }
 
 /**
@@ -16,62 +16,55 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR extends Error {
  * request. The thrown exception contains the serialized request.
  */
 class RequestSerializationTestHandler implements HttpHandler {
-    handle(
-        request: HttpRequest,
-        options?: HttpHandlerOptions
-    ): Promise<{ response: HttpResponse }> {
-        return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
-    }
-    updateHttpClientConfig(key: never, value: never): void {}
-    httpHandlerConfigs() { return {}; }
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+    return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
+  }
+  updateHttpClientConfig(key: never, value: never): void {}
+  httpHandlerConfigs() {
+    return {};
+  }
 }
 
 /**
  * Returns a resolved Promise of the specified response contents.
  */
 class ResponseDeserializationTestHandler implements HttpHandler {
-    isSuccess: boolean;
-    code: number;
-    headers: HeaderBag;
-    body: String;
+  isSuccess: boolean;
+  code: number;
+  headers: HeaderBag;
+  body: String;
 
-    constructor(
-        isSuccess: boolean,
-        code: number,
-        headers?: HeaderBag,
-        body?: String
-    ) {
-        this.isSuccess = isSuccess;
-        this.code = code;
-        if (headers === undefined) {
-            this.headers = {};
-        } else {
-            this.headers = headers;
-        }
-        if (body === undefined) {
-            body = "";
-        }
-        this.body = body;
+  constructor(isSuccess: boolean, code: number, headers?: HeaderBag, body?: String) {
+    this.isSuccess = isSuccess;
+    this.code = code;
+    if (headers === undefined) {
+      this.headers = {};
+    } else {
+      this.headers = headers;
     }
+    if (body === undefined) {
+      body = "";
+    }
+    this.body = body;
+  }
 
-    handle(
-        request: HttpRequest,
-        options?: HttpHandlerOptions
-    ): Promise<{ response: HttpResponse }> {
-        return Promise.resolve({
-            response: new HttpResponse({
-                statusCode: this.code,
-                headers: this.headers,
-                body: Readable.from([this.body])
-            })
-        });
-    }
-    updateHttpClientConfig(key: never, value: never): void {}
-    httpHandlerConfigs() { return {}; }
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+    return Promise.resolve({
+      response: new HttpResponse({
+        statusCode: this.code,
+        headers: this.headers,
+        body: Readable.from([this.body]),
+      }),
+    });
+  }
+  updateHttpClientConfig(key: never, value: never): void {}
+  httpHandlerConfigs() {
+    return {};
+  }
 }
 
 interface comparableParts {
-  [ key: string ]: string
+  [key: string]: string;
 }
 
 /**
@@ -79,7 +72,7 @@ interface comparableParts {
  */
 const compareParts = (expectedParts: comparableParts, generatedParts: comparableParts) => {
   const unequalParts: any = {};
-  Object.keys(expectedParts).forEach(key => {
+  Object.keys(expectedParts).forEach((key) => {
     if (generatedParts[key] === undefined) {
       unequalParts[key] = { exp: expectedParts[key], gen: undefined };
     } else if (!equivalentContents(expectedParts[key], generatedParts[key])) {
@@ -87,7 +80,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
     }
   });
 
-  Object.keys(generatedParts).forEach(key => {
+  Object.keys(generatedParts).forEach((key) => {
     if (expectedParts[key] === undefined) {
       unequalParts[key] = { exp: undefined, gen: generatedParts[key] };
     }
@@ -115,10 +108,10 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   // If a test fails with an issue in the below 6 lines, it's likely
   // due to an issue in the nestedness or existence of the property
   // being compared.
-  delete localExpected['$$metadata'];
-  delete generated['$$metadata'];
-  Object.keys(localExpected).forEach(key => localExpected[key] === undefined && delete localExpected[key])
-  Object.keys(generated).forEach(key => generated[key] === undefined && delete generated[key])
+  delete localExpected["$$metadata"];
+  delete generated["$$metadata"];
+  Object.keys(localExpected).forEach((key) => localExpected[key] === undefined && delete localExpected[key]);
+  Object.keys(generated).forEach((key) => generated[key] === undefined && delete generated[key]);
 
   const expectedProperties = Object.getOwnPropertyNames(localExpected);
   const generatedProperties = Object.getOwnPropertyNames(generated);
@@ -137,17 +130,18 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   }
 
   return true;
-}
+};
 
 const clientParams = {
   region: "us-west-2",
-  credentials: { accessKeyId: "key", secretAccessKey: "secret" }
-}
+  endpoint: "https://localhost/",
+  credentials: { accessKeyId: "key", secretAccessKey: "secret" },
+};
 
 /**
  * A wrapper function that shadows `fail` from jest-jasmine2
  * (jasmine2 was replaced with circus in > v27 as the default test runner)
  */
 const fail = (error?: any): never => {
-    throw new Error(error);
-}
+  throw new Error(error);
+};


### PR DESCRIPTION
Due to creating a set of default plugins in https://github.com/smithy-lang/smithy-typescript/pull/1321, an endpoint must be provided for non-Endpoints-RuleSet service models' clients. 

Providing a default endpoint in protocol tests is required for the non-Endpoints-RuleSet case, and also non-breaking otherwise.