### PR TITLE
fix(util-stream): avoid compilation of type parameter in global ReadableStream

### DIFF
--- a/.changeset/forty-candles-taste.md
+++ b/.changeset/forty-candles-taste.md
@@ -1,0 +1,6 @@
+---
+"@smithy/eventstream-serde-browser": patch
+"@smithy/util-stream": patch
+---
+
+avoid compilation of global ReadableStream with type parameter

--- a/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
@@ -68,5 +68,11 @@ export class EventStreamMarshaller {
   }
 }
 
+/**
+ * @internal
+ * Warning: do not export this without aliasing the reference to
+ * global ReadableStream.
+ * @see https://github.com/smithy-lang/smithy-typescript/issues/1341.
+ */
 const isReadableStream = (body: any): body is ReadableStream =>
   typeof ReadableStream === "function" && body instanceof ReadableStream;

--- a/packages/util-stream/src/stream-type-check.ts
+++ b/packages/util-stream/src/stream-type-check.ts
@@ -1,6 +1,14 @@
 /**
  * @internal
+ * Alias prevents compiler from turning
+ * ReadableStream into ReadableStream<any>, which is incompatible
+ * with the NodeJS.ReadableStream global type.
  */
-export const isReadableStream = (stream: unknown): stream is ReadableStream =>
+type ReadableStreamType = ReadableStream;
+
+/**
+ * @internal
+ */
+export const isReadableStream = (stream: unknown): stream is ReadableStreamType =>
   typeof ReadableStream === "function" &&
   (stream?.constructor?.name === ReadableStream.name || stream instanceof ReadableStream);


### PR DESCRIPTION
https://github.com/smithy-lang/smithy-typescript/issues/1341

If we export an interface involving a reference to the global `ReadableStream`, when compiled with the DOM lib present this becomes `ReadableStream<any>`. 

This is not compatible with `@types/node`, which declares a generic ReadableStream only in the stream/web module, and for some reason a different one globally. 