### PR TITLE
fix(maxAttempts): Add new configuration maxAttempts in RemoteProvider…

### DIFF
--- a/.changeset/red-coats-visit.md
+++ b/.changeset/red-coats-visit.md
@@ -1,0 +1,5 @@
+---
+"@smithy/credential-provider-imds": minor
+---
+
+The configuration maxRetries was changed to maxAttempts in middleware-retry to be compliant with other SDKs and retry strategy #1244. This change adds new configuration maxAttempts in RemoteProviderConfig and deprecates maxRetries.

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.spec.ts
@@ -17,4 +17,48 @@ describe("providerConfigFromInit", () => {
       maxRetries,
     });
   });
+
+  it("should return maxAttempts with the same value as the deprecated maxRetries if maxAttempts is NOT provided", () => {
+    const timeout = 123456789;
+    const maxRetries = 987654321;
+
+    expect(providerConfigFromInit({ timeout, maxRetries })).toEqual({
+      timeout,
+      maxRetries,
+      maxAttempts: maxRetries,
+    });
+  });
+
+  it("should return maxAttempts with the same value as maxAttempts option if it is provided", () => {
+    const timeout = 123456789;
+    const maxRetries = 987654321;
+    const maxAttempts = 987654322;
+
+    expect(providerConfigFromInit({ timeout, maxRetries, maxAttempts })).toEqual({
+      timeout,
+      maxRetries,
+      maxAttempts,
+    });
+  });
+
+  it("should return maxAttempts with DEFAULT_MAX_RETRIES as value if both maxAttempts and maxRetries are NOT provided", () => {
+    const timeout = 123456789;
+
+    expect(providerConfigFromInit({ timeout })).toEqual({
+      timeout,
+      maxRetries: 0,
+      maxAttempts: 0,
+    });
+  });
+
+  it("should return maxRetries with the same value as the new maxRetries maxAttempts if maxAttempts is provided with any value", () => {
+    const timeout = 123456789;
+    const maxAttempts = 987654321;
+
+    expect(providerConfigFromInit({ timeout, maxAttempts })).toEqual({
+      timeout,
+      maxRetries: maxAttempts,
+      maxAttempts,
+    });
+  });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -22,9 +22,15 @@ export interface RemoteProviderConfig {
   timeout: number;
 
   /**
+   * @deprecated The configuration maxRetries was changed to maxAttempts in middleware-retry to be compliant with other SDKs and retry strategy [#1244](https://github.com/aws/aws-sdk-js-v3/pull/1244). Use maxAttempts instead.
    * The maximum number of times the HTTP connection should be retried
    */
-  maxRetries: number;
+  maxRetries?: number;
+
+  /**
+   * The maximum number of times the HTTP connection should be retried
+   */
+  maxAttempts?: number;
 }
 
 /**
@@ -47,5 +53,14 @@ export interface RemoteProviderInit extends Partial<RemoteProviderConfig> {
  */
 export const providerConfigFromInit = ({
   maxRetries = DEFAULT_MAX_RETRIES,
+  maxAttempts,
   timeout = DEFAULT_TIMEOUT,
-}: RemoteProviderInit): RemoteProviderConfig => ({ maxRetries, timeout });
+}: RemoteProviderInit): RemoteProviderConfig => {
+  const effectiveMaxAttempts = maxAttempts || maxRetries;
+
+  return { 
+    maxRetries: effectiveMaxAttempts, 
+    maxAttempts: effectiveMaxAttempts,
+    timeout
+  };
+}


### PR DESCRIPTION
*Issue #, if available:*

Replace unused maxRetries with maxAttempts #2709

*Description of changes:*

- Add new configuration maxAttempts in RemoteProviderConfig, so that it reuses the value from retry while fetching credentials.
- Instead of deleting existing maxRetries, call it deprecated in favor of maxAttempts.


If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

Changeset updated.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
