### PR TITLE
fix(event-streams): use member name as :event-type header value

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -103,12 +104,15 @@ public class EventStreamGenerator {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
         TreeSet<UnionShape> eventUnionsToSerialize = new TreeSet<>();
-        TreeSet<Pair<String, StructureShape>> eventShapesToMarshall = new TreeSet<>();
+        TreeSet<Pair<String, StructureShape>> eventShapesToMarshall = new TreeSet<>(
+            (a, b) -> Objects.compare(a.getRight(), b.getRight(), StructureShape::compareTo)
+        );
+
         for (OperationShape operation : operations) {
             if (hasEventStreamInput(context, operation)) {
                 UnionShape eventsUnion = getEventStreamInputShape(context, operation);
                 eventUnionsToSerialize.add(eventsUnion);
-                eventsUnion.members().stream()
+                eventsUnion.members()
                     .forEach(member -> {
                         eventShapesToMarshall.add(Pair.of(
                             member.getMemberName(),
@@ -161,6 +165,7 @@ public class EventStreamGenerator {
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
         TreeSet<UnionShape> eventUnionsToDeserialize = new TreeSet<>();
         TreeSet<StructureShape> eventShapesToUnmarshall = new TreeSet<>();
+
         for (OperationShape operation : operations) {
             if (hasEventStreamOutput(context, operation)) {
                 UnionShape eventsUnion = getEventStreamOutputShape(context, operation);


### PR DESCRIPTION
When serializing the headers for an event stream event, the `:event-type` should take on the member name and not the member target id.

```ts
  const headers: __MessageHeaders = {
    ":event-type": { type: "string", value: "textEvent" }, // <-- here, for example
    ":message-type": { type: "string", value: "event" },
    ":content-type": { type: "string", value: "application/json" },
  };
```

This had not manifested until a recent AWS service in which the two values were not identical for apparently the first time.