### PR TITLE
Verify that removeSignalEventListener is a function before calling

### DIFF
--- a/.changeset/unlucky-glasses-nail.md
+++ b/.changeset/unlucky-glasses-nail.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": patch
+---
+
+Verify that removeSignalEventListener is a function before calling

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -185,7 +185,11 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
         })
       );
     }
-    return Promise.race(raceOfPromises).finally(removeSignalEventListener);
+    return Promise.race(raceOfPromises).finally(() => {
+      if (typeof removeSignalEventListener === "function") {
+        removeSignalEventListener();
+      }
+    });
   }
 
   updateHttpClientConfig(key: keyof FetchHttpHandlerConfig, value: FetchHttpHandlerConfig[typeof key]): void {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/6269

*Description of changes:*
Verifies that removeSignalEventListener is a function before calling

Testing done while debugging in react-native environment in https://github.com/aws/aws-sdk-js-v3/issues/6269#issuecomment-2252850763

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
