### PR TITLE
Initialize removeSignalEventListener as an empty function

### DIFF
--- a/.changeset/unlucky-glasses-nail.md
+++ b/.changeset/unlucky-glasses-nail.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": patch
+---
+
+Verify that removeSignalEventListener is a function before calling

--- a/.changeset/unlucky-glasses-nail.md
+++ b/.changeset/unlucky-glasses-nail.md
@@ -2,4 +2,4 @@
 "@smithy/fetch-http-handler": patch
 ---
 
-Verify that removeSignalEventListener is a function before calling
+Initialize removeSignalEventListener as an empty function

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -185,7 +185,11 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
         })
       );
     }
-    return Promise.race(raceOfPromises).finally(removeSignalEventListener);
+    return Promise.race(raceOfPromises).finally(() => {
+      if (typeof removeSignalEventListener === "function") {
+        removeSignalEventListener();
+      }
+    });
   }
 
   updateHttpClientConfig(key: keyof FetchHttpHandlerConfig, value: FetchHttpHandlerConfig[typeof key]): void {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -127,7 +127,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
       requestOptions.keepalive = keepAlive;
     }
 
-    let removeSignalEventListener = null as null | (() => void);
+    let removeSignalEventListener = () => {};
 
     const fetchRequest = new Request(url, requestOptions);
     const raceOfPromises = [
@@ -185,11 +185,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
         })
       );
     }
-    return Promise.race(raceOfPromises).finally(() => {
-      if (typeof removeSignalEventListener === "function") {
-        removeSignalEventListener();
-      }
-    });
+    return Promise.race(raceOfPromises).finally(removeSignalEventListener);
   }
 
   updateHttpClientConfig(key: keyof FetchHttpHandlerConfig, value: FetchHttpHandlerConfig[typeof key]): void {


### PR DESCRIPTION
*Issue #, if available:*
* Fixes: https://github.com/aws/aws-sdk-js-v3/issues/6269
* A cleaner alternative to https://github.com/smithy-lang/smithy-typescript/pull/1350

*Description of changes:*
Initialize removeSignalEventListener as an empty function

Testing done in https://github.com/aws/aws-sdk-js-v3/issues/6269#issuecomment-2253018138

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
