### PR TITLE
fix: use string join instead of templates

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -493,11 +493,11 @@ final class CommandGenerator implements Runnable {
                         return;
                     }
                     writer.openBlock(", { ", " }", () -> {
-                        writer
-                            .pushState()
-                            .putContext("params", additionalParameters)
-                            .writeInline("${#params}${value:L}, ${/params}")
-                            .popState();
+                        // caution: using String.join instead of templating
+                        // because additionalParameters may contain Smithy syntax.
+                        if (!additionalParameters.isEmpty()) {
+                            writer.writeInline(String.join(", ", additionalParameters) + ", ");
+                        }
                         clientAddParamsWriterConsumers.forEach((key, consumer) -> {
                             writer.writeInline("$L: $C,", key, (Consumer<TypeScriptWriter>) (w -> {
                                 consumer.accept(w, CommandConstructorCodeSection.builder()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -460,11 +460,11 @@ public final class ServiceBareBonesClientGenerator implements Runnable {
                         }
 
                         writer.openBlock(", {", " }", () -> {
-                            writer
-                                .pushState()
-                                .putContext("params", additionalParameters)
-                                .writeInline("${#params}${value:L}, ${/params}")
-                                .popState();
+                            // caution: using String.join instead of templating
+                            // because additionalParameters may contain Smithy syntax.
+                            if (!additionalParameters.isEmpty()) {
+                                writer.writeInline(String.join(", ", additionalParameters) + ", ");
+                            }
                             clientAddParamsWriterConsumers.forEach((key, consumer) -> {
                                 writer.writeInline("$L: $C,", key, (Consumer<TypeScriptWriter>) (w -> {
                                     consumer.accept(w, ClientBodyExtraCodeSection.builder()


### PR DESCRIPTION
switches back to using string join because templating escapes the string which may include smithy syntax