### PR TITLE
fix: enforce consistent plugin additional parameter ordering

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.BiPredicate;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
@@ -798,7 +799,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * Enables access to the writer for adding imports/dependencies.
          */
         public Builder withAdditionalClientParams(Map<String, ClientWriterConsumer> writeAdditionalClientParams) {
-            this.writeAdditionalClientParams = writeAdditionalClientParams;
+            // enforce consistent sorting during codegen.
+            this.writeAdditionalClientParams = new TreeMap<>(writeAdditionalClientParams);
             return this;
         }
 
@@ -808,7 +810,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         public Builder withAdditionalOperationParams(
             Map<String, CommandWriterConsumer> writeAdditionalOperationParams
         ) {
-            this.writeAdditionalOperationParams = writeAdditionalOperationParams;
+            // enforce consistent sorting during codegen.
+            this.writeAdditionalOperationParams = new TreeMap<>(writeAdditionalOperationParams);
             return this;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
