### PR TITLE
chore(id-auth-sra): set command instance ref on smithy context

### DIFF
--- a/.changeset/hip-cycles-buy.md
+++ b/.changeset/hip-cycles-buy.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+add command instance ref to smithy context

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -82,6 +82,7 @@ export abstract class Command<
       inputFilterSensitiveLog,
       outputFilterSensitiveLog,
       [SMITHY_CONTEXT_KEY]: {
+        commandInstance: this,
         ...smithyContext,
       },
       ...additionalContext,


### PR DESCRIPTION
related to `experimentalIdentityAndAuth` (no longer experimental), 

this PR adds a reference to the calling command within the smithy-context, a data object that exists for the lifecycle of a request and is naturally subordinated to the command. 

having this reference will allow the middleware using the smithy-context object to fetch the command's static contextual endpoint parameters.