### PR TITLE
Remove redundant getStaticContextParams function

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -74,31 +74,6 @@ public class RuleSetParameterFinder {
     }
 
     /**
-     * "The staticContextParams trait defines one or more context parameters that MUST
-     * be bound to the specified values. This trait MUST target an operation shape."
-     */
-    public Map<String, String> getStaticContextParams(Shape operationInput) {
-        Map<String, String> map = new HashMap<>();
-
-        if (operationInput.isStructureShape()) {
-            operationInput.getAllMembers().forEach((String memberName, MemberShape member) -> {
-                Optional<StaticContextParamsTrait> trait = member.getTrait(StaticContextParamsTrait.class);
-                if (trait.isPresent()) {
-                    StaticContextParamsTrait staticContextParamsTrait = trait.get();
-                    staticContextParamsTrait.getParameters().forEach((name, definition) -> {
-                        map.put(
-                            name,
-                            definition.getValue().getType().toString()
-                        );
-                    });
-                }
-            });
-        }
-
-        return map;
-    }
-
-    /**
      * Get map of params to actual values instead of the value type.
      */
     public Map<String, String> getStaticContextParamValues(OperationShape operation) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -30,7 +30,9 @@ import software.amazon.smithy.rulesengine.traits.ClientContextParamsTrait;
 import software.amazon.smithy.rulesengine.traits.ContextParamTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.rulesengine.traits.StaticContextParamsTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
+@SmithyInternalApi
 public class RuleSetParameterFinder {
     private final ServiceShape service;
     private final EndpointRuleSetTrait ruleset;


### PR DESCRIPTION
*Issue #, if available:*
Noticed while working on JS-5234

*Description of changes:*
Removes redundant `getStaticContextParams` function from RuleSetParameterFinder

It was originally added to get static context params, but later was replaced by fetching the values directly in `getStaticContextParamValues`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
