### PR TITLE
Populate memberName as contextParams value

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -291,11 +291,11 @@ final class CommandGenerator implements Runnable {
             });
 
             Shape operationInput = model.getShape(operation.getInputShape()).get();
-            parameterFinder.getContextParams(operationInput).forEach((name, type) -> {
+            parameterFinder.getContextParams(operationInput).forEach((name, memberName) -> {
                 if (!paramNames.contains(name)) {
                     writer.write(
                         "$L: { type: \"contextParams\", name: \"$L\" },",
-                        name, name);
+                        name, memberName);
                 }
                 paramNames.add(name);
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -122,7 +122,7 @@ public class RuleSetParameterFinder {
                     String name = contextParamTrait.getName();
                     map.put(
                         name,
-                        "unknown"
+                        member.getMemberName()
                     );
                 }
             });


### PR DESCRIPTION
*Issue #, if available:*
Fixes failing endpoint tests in https://github.com/aws/aws-sdk-js-v3/pull/6373#issuecomment-2278753422

*Description of changes:*
Populates memberName as contextParams value, so that it can be consumed correctly when populating endpoints.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
