### PR TITLE
Include ./dist/es in published ssdk package files to fix ESM entrypoint

### DIFF
--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -42,6 +42,7 @@
   },
   "files": [
     "dist/cjs/**/*.js",
+    "dist/es/**/*.js",
     "dist/types/**/*.d.ts",
     "!**/*.spec.*"
   ],

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -42,6 +42,7 @@
   },
   "files": [
     "dist/cjs/**/*.js",
+    "dist/es/**/*.js",
     "dist/types/**/*.d.ts",
     "!**/*.spec.*"
   ],

--- a/smithy-typescript-ssdk-libs/server-node/package.json
+++ b/smithy-typescript-ssdk-libs/server-node/package.json
@@ -41,6 +41,7 @@
   },
   "files": [
     "dist/cjs/**/*.js",
+    "dist/es/**/*.js",
     "dist/types/**/*.d.ts",
     "!**/*.spec.*"
   ],


### PR DESCRIPTION
*Issue #, if available:*
N/a

*Description of changes:*

The ssdk packages have `"module": "./dist/es/index.js",` in package.json, but did not include `./dist/es` in their published files to npm. I noticed this when using vite's bundler, which was looking for the ESM entrypoint via the `module` field, but it was unable to find the file because it was not included in the files published to npm. This PR addes the files inside of `./dist/es` to the list of files published to npm to fix this issue.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
