### PR TITLE
feat: IDE type navigation assistance for command classes

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -210,6 +210,37 @@ final class CommandGenerator implements Runnable {
             .protocolGenerator(protocolGenerator)
             .applicationProtocol(applicationProtocol)
             .build());
+
+        {
+            // This block places the most commonly sought type definitions
+            // closer to the command definition, for navigation assistance
+            // in IDEs.
+            Shape operationInputShape = model.expectShape(operation.getInputShape());
+            Symbol baseInput = symbolProvider.toSymbol(operationInputShape);
+            Shape operationOutputShape = model.expectShape(operation.getOutputShape());
+            Symbol baseOutput = symbolProvider.toSymbol(operationOutputShape);
+
+            writer.write("/** @internal type navigation helper, not in runtime. */");
+            writer.openBlock("declare protected static __types: {", "};", () -> {
+                String baseInputStr = operationInputShape.getAllMembers().isEmpty()
+                    ? "{}"
+                    : baseInput.getName();
+                String baseOutputStr = operationOutputShape.getAllMembers().isEmpty()
+                    ? "{}"
+                    : baseOutput.getName();
+                writer.write("""
+                api: {
+                    input: $L;
+                    output: $L;
+                };""", baseInputStr, baseOutputStr);
+                writer.write("""
+                sdk: {
+                    input: $T;
+                    output: $T;
+                };""", inputType, outputType);
+            });
+        }
+
         writer.write("}"); // class close bracket.
     }
 


### PR DESCRIPTION
closes https://github.com/smithy-lang/smithy-typescript/issues/1366

This PR creates `declare protected static` fields on classes pointing to commonly sought after associated type declarations.

This is needed because the type declaration position of commands can be distant from the type declaration of the operation's input and output.

In the future, the list of modeled Exception classes could also be listed here. 

### Reasoning

- `declare` this allows the field to have a type annotation without assigning any runtime value. In the runtime JavaScript code, these types do not appear at all. This avoids wasting runtime artifact size on what is essentially documentation.
- `static` avoids autocomplete proposing this field on instances of the Command class.
- `protected` avoids autocomplete proposing this field on the Command class constructor.

### Source code
```ts
export class ListBucketsCommand extends $Command
  .classBuilder<
    ListBucketsCommandInput,
    ListBucketsCommandOutput,
    S3ClientResolvedConfig,
    ServiceInputTypes,
    ServiceOutputTypes
  >()
  .ep({
    ...commonParams,
  })
  .m(function (this: any, Command: any, cs: any, config: S3ClientResolvedConfig, o: any) {
    return [
      getSerdePlugin(config, this.serialize, this.deserialize),
      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
      getThrow200ExceptionsPlugin(config),
    ];
  })
  .s("AmazonS3", "ListBuckets", {})
  .n("S3Client", "ListBucketsCommand")
  .f(void 0, void 0)
  .ser(se_ListBucketsCommand)
  .de(de_ListBucketsCommand)
  .build() {
  /** @internal type navigation helper, not in runtime. */
  protected declare static inputTypeRef: [ListBucketsCommandInput, ListBucketsRequest];
  /** @internal type navigation helper, not in runtime. */
  protected declare static outputTypeRef: [ListBucketsCommandOutput, ListBucketsOutput];
}
```

### `.d.ts` dist-types

Type references now appear very close to the Command type declaration for easier navigation.

```ts
export declare class ListBucketsCommand extends ListBucketsCommand_base {
    /** @internal type navigation helper, not in runtime. */
    protected static inputTypeRef: [ListBucketsCommandInput, ListBucketsRequest];
    /** @internal type navigation helper, not in runtime. */
    protected static outputTypeRef: [ListBucketsCommandOutput, ListBucketsOutput];
}
```

### `.js` dist-es

Invisible to the runtime.

```js
export class ListBucketsCommand extends $Command
  .classBuilder()
  .ep({
    ...commonParams,
  })
  .m(function (Command, cs, config, o) {
    return [
      getSerdePlugin(config, this.serialize, this.deserialize),
      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
      getThrow200ExceptionsPlugin(config),
    ];
  })
  .s("AmazonS3", "ListBuckets", {})
  .n("S3Client", "ListBucketsCommand")
  .f(void 0, void 0)
  .ser(se_ListBucketsCommand)
  .de(de_ListBucketsCommand)
  .build() {}
```