### PR TITLE
Do not take protocol and port from custom Endpoint

### DIFF
--- a/.changeset/good-cheetahs-press.md
+++ b/.changeset/good-cheetahs-press.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": patch
+---
+
+Do not take protocol and port from custom Endpoint

--- a/packages/util-endpoints/src/__mocks__/test-cases/parse-url.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/parse-url.json
@@ -72,7 +72,7 @@
       },
       "expect": {
         "endpoint": {
-          "url": "http://http-99_ab.com-nopath.example.com"
+          "url": "https://http-99_ab.com-nopath.example.com"
         }
       }
     },
@@ -83,7 +83,7 @@
       },
       "expect": {
         "endpoint": {
-          "url": "http://http-99_ab-.com-nopath.example.com"
+          "url": "https://http-99_ab-.com-nopath.example.com"
         }
       }
     },

--- a/packages/util-endpoints/src/resolveEndpoint.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.ts
@@ -36,18 +36,6 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
 
   const endpoint = evaluateRules(rules, { endpointParams, logger, referenceRecord: {} });
 
-  if (options.endpointParams?.Endpoint) {
-    // take protocol and port from custom Endpoint if present.
-    try {
-      const givenEndpoint = new URL(options.endpointParams.Endpoint as string);
-      const { protocol, port } = givenEndpoint;
-      endpoint.url.protocol = protocol;
-      endpoint.url.port = port;
-    } catch (e) {
-      // ignored
-    }
-  }
-
   options.logger?.debug?.(`${debugId} Resolved endpoint: ${toDebugString(endpoint)}`);
 
   return endpoint;


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/6410#issuecomment-2311320293

*Description of changes:*
Skips taking protocol and port from custom Endpoint.

The old tests added in https://github.com/aws/aws-sdk-js-v3/pull/4031 were likely incorrect.
Noticed while incorporating the endpoint tests at top-level in https://github.com/aws/aws-sdk-js-v3/pull/6410#issuecomment-2311320293

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
