### PR TITLE
fix(endpoints): resolve service-specific endpoint once per client

### DIFF
--- a/.changeset/hot-items-sing.md
+++ b/.changeset/hot-items-sing.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+resolve service-specific endpoint once per client

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromConfig.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromConfig.ts
@@ -2,4 +2,7 @@ import { loadConfig } from "@smithy/node-config-provider";
 
 import { getEndpointUrlConfig } from "./getEndpointUrlConfig";
 
-export const getEndpointFromConfig = async (serviceId: string) => loadConfig(getEndpointUrlConfig(serviceId))();
+/**
+ * @internal
+ */
+export const getEndpointFromConfig = async (serviceId?: string) => loadConfig(getEndpointUrlConfig(serviceId ?? ""))();

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
@@ -39,9 +39,19 @@ export const getEndpointFromInstructions = async <
   context?: HandlerExecutionContext
 ): Promise<EndpointV2> => {
   if (!clientConfig.endpoint) {
-    const endpointFromConfig = await getEndpointFromConfig(clientConfig.serviceId || "");
+    let endpointFromConfig: string | undefined;
+
+    // This field is guaranteed by the type indicated by the config resolver, but is new
+    // and some existing standalone calls to this function may not provide the function, so
+    // this check should remain here.
+    if (clientConfig.serviceConfiguredEndpoint) {
+      endpointFromConfig = await clientConfig.serviceConfiguredEndpoint();
+    } else {
+      endpointFromConfig = await getEndpointFromConfig(clientConfig.serviceId);
+    }
+
     if (endpointFromConfig) {
-      clientConfig.endpoint = () => Promise.resolve(toEndpointV1(endpointFromConfig));
+      clientConfig.endpoint = () => Promise.resolve(toEndpointV1(endpointFromConfig!));
     }
   }
 


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/6423

- resolve service specific endpoint once per config (client instance)
- this avoids the ENV and file system read from `loadConfig`