### PR TITLE
feat(smithy-client): add handler cache

### DIFF
--- a/.changeset/tall-cameras-reply.md
+++ b/.changeset/tall-cameras-reply.md
@@ -1,5 +1,4 @@
 ---
-"@smithy/middleware-stack": minor
 "@smithy/smithy-client": minor
 ---
 

--- a/.changeset/tall-cameras-reply.md
+++ b/.changeset/tall-cameras-reply.md
@@ -1,0 +1,6 @@
+---
+"@smithy/middleware-stack": minor
+"@smithy/smithy-client": minor
+---
+
+add client handler caching

--- a/packages/middleware-stack/src/MiddlewareStack.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.ts
@@ -32,14 +32,7 @@ const getMiddlewareNameWithAliases = (name: string | undefined, aliases: Array<s
   return `${name || "anonymous"}${aliases && aliases.length > 0 ? ` (a.k.a. ${aliases.join(",")})` : ""}`;
 };
 
-export const constructStack = <Input extends object, Output extends object>(
-  stackOptions: {
-    /**
-     * Optional change listener, called with stack instance when middleware added/removed.
-     */
-    onChange?: (middlewareStack: MiddlewareStack<any, any>) => void;
-  } = {}
-): MiddlewareStack<Input, Output> => {
+export const constructStack = <Input extends object, Output extends object>(): MiddlewareStack<Input, Output> => {
   let absoluteEntries: AbsoluteMiddlewareEntry<Input, Output>[] = [];
   let relativeEntries: RelativeMiddlewareEntry<Input, Output>[] = [];
   let identifyOnResolve = false;
@@ -229,7 +222,6 @@ export const constructStack = <Input extends object, Output extends object>(
         }
       }
       absoluteEntries.push(entry);
-      stackOptions.onChange?.(stack);
     },
 
     addRelativeTo: (middleware: MiddlewareType<Input, Output>, options: HandlerOptions & RelativeLocation) => {
@@ -266,7 +258,6 @@ export const constructStack = <Input extends object, Output extends object>(
         }
       }
       relativeEntries.push(entry);
-      stackOptions.onChange?.(stack);
     },
 
     clone: () => cloneTo(constructStack<Input, Output>()),
@@ -276,14 +267,8 @@ export const constructStack = <Input extends object, Output extends object>(
     },
 
     remove: (toRemove: MiddlewareType<Input, Output> | string): boolean => {
-      let isRemoved: boolean;
-      if (typeof toRemove === "string") {
-        isRemoved = removeByName(toRemove);
-      } else {
-        isRemoved = removeByReference(toRemove);
-      }
-      stackOptions.onChange?.(stack);
-      return isRemoved;
+      if (typeof toRemove === "string") return removeByName(toRemove);
+      else return removeByReference(toRemove);
     },
 
     removeByTag: (toRemove: string): boolean => {
@@ -302,7 +287,6 @@ export const constructStack = <Input extends object, Output extends object>(
       };
       absoluteEntries = absoluteEntries.filter(filterCb);
       relativeEntries = relativeEntries.filter(filterCb);
-      stackOptions?.onChange?.(stack);
       return isRemoved;
     },
 

--- a/packages/smithy-client/src/client.spec.ts
+++ b/packages/smithy-client/src/client.spec.ts
@@ -67,5 +67,11 @@ describe("SmithyClient", () => {
       await expect(client.send(getCommandWithOutput("foo") as any, {})).resolves.toEqual("foo");
       expect(privateAccess()).toBeUndefined();
     });
+
+    it("unsets the cache if client.destroy() is called.", async () => {
+      await expect(client.send(getCommandWithOutput("foo") as any)).resolves.toEqual("foo");
+      client.destroy();
+      expect(privateAccess()).toBeUndefined();
+    });
   });
 });

--- a/packages/smithy-client/src/client.spec.ts
+++ b/packages/smithy-client/src/client.spec.ts
@@ -50,4 +50,28 @@ describe("SmithyClient", () => {
     };
     client.send(getCommandWithOutput("foo") as any, options, callback);
   });
+
+  describe("handler caching", () => {
+    beforeEach(() => {
+      delete (client as any).handlers;
+    });
+
+    const privateAccess = () => (client as any).handlers;
+
+    it("should cache the resolved handler", async () => {
+      await expect(client.send(getCommandWithOutput("foo") as any)).resolves.toEqual("foo");
+      expect(privateAccess().get({}.constructor)).toBeDefined();
+    });
+
+    it("should not cache the resolved handler if called with request options", async () => {
+      await expect(client.send(getCommandWithOutput("foo") as any, {})).resolves.toEqual("foo");
+      expect(privateAccess()).toBeUndefined();
+    });
+
+    it("should clear the handler cache when the middleareStack is modified", async () => {
+      await expect(client.send(getCommandWithOutput("foo") as any)).resolves.toEqual("foo");
+      client.middlewareStack.add((n) => (a) => n(a));
+      expect(privateAccess()).toBeUndefined();
+    });
+  });
 });

--- a/packages/smithy-client/src/client.spec.ts
+++ b/packages/smithy-client/src/client.spec.ts
@@ -9,7 +9,7 @@ describe("SmithyClient", () => {
   const getCommandWithOutput = (output: string) => ({
     resolveMiddleware: mockResolveMiddleware,
   });
-  const client = new Client({} as any);
+  const client = new Client({ cacheMiddleware: true } as any);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -65,12 +65,6 @@ describe("SmithyClient", () => {
 
     it("should not cache the resolved handler if called with request options", async () => {
       await expect(client.send(getCommandWithOutput("foo") as any, {})).resolves.toEqual("foo");
-      expect(privateAccess()).toBeUndefined();
-    });
-
-    it("should clear the handler cache when the middleareStack is modified", async () => {
-      await expect(client.send(getCommandWithOutput("foo") as any)).resolves.toEqual("foo");
-      client.middlewareStack.add((n) => (a) => n(a));
       expect(privateAccess()).toBeUndefined();
     });
   });

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -129,7 +129,7 @@ export class Client<
   }
 
   destroy() {
-    this.config.requestHandler.destroy?.();
+    this.config?.requestHandler?.destroy?.();
     delete this.handlers;
   }
 }


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/6423

This adds a cache for the handler functions resolved from calls to 

```ts
command.resolveMiddleware(client.middlewareStack, client.config, (request) options)
```

when options is undefined. This occurs in the request path and can take 1-2ms, but is redundant for any client/command pair in most cases. 

Despite being cached, the handler functions has a reference to the client config, so any changes there will still be visible to the middleware within the resolved handler. ~Modifying a client's middlewareStack invalidates the cache.~

The cache is opt-in and also unique per client, so users retain control that way.