### PR TITLE
feat(node-http-handler): defer socket event listener attachment

### DIFF
--- a/.changeset/empty-feet-shop.md
+++ b/.changeset/empty-feet-shop.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": minor
+---
+
+defer socket event listeners for node:http

--- a/packages/node-http-handler/src/set-connection-timeout.ts
+++ b/packages/node-http-handler/src/set-connection-timeout.ts
@@ -1,28 +1,43 @@
 import { ClientRequest } from "http";
 import { Socket } from "net";
 
-export const setConnectionTimeout = (request: ClientRequest, reject: (err: Error) => void, timeoutInMs = 0) => {
+const DEFER_EVENT_LISTENER_TIME = 1000;
+
+export const setConnectionTimeout = (
+  request: ClientRequest,
+  reject: (err: Error) => void,
+  timeoutInMs = 0
+): NodeJS.Timeout | number => {
   if (!timeoutInMs) {
-    return;
+    return -1;
   }
 
-  // Throw a connecting timeout error unless a connection is made within time.
-  const timeoutId = setTimeout(() => {
-    request.destroy();
-    reject(
-      Object.assign(new Error(`Socket timed out without establishing a connection within ${timeoutInMs} ms`), {
-        name: "TimeoutError",
-      })
-    );
-  }, timeoutInMs);
+  const registerTimeout = (offset: number) => {
+    // Throw a connecting timeout error unless a connection is made within time.
+    const timeoutId = setTimeout(() => {
+      request.destroy();
+      reject(
+        Object.assign(new Error(`Socket timed out without establishing a connection within ${timeoutInMs} ms`), {
+          name: "TimeoutError",
+        })
+      );
+    }, timeoutInMs - offset);
 
-  request.on("socket", (socket: Socket) => {
-    if (socket.connecting) {
-      socket.on("connect", () => {
+    request.on("socket", (socket: Socket) => {
+      if (socket.connecting) {
+        socket.on("connect", () => {
+          clearTimeout(timeoutId);
+        });
+      } else {
         clearTimeout(timeoutId);
-      });
-    } else {
-      clearTimeout(timeoutId);
-    }
-  });
+      }
+    });
+  };
+
+  if (timeoutInMs < 2000) {
+    registerTimeout(0);
+    return 0;
+  }
+
+  return setTimeout(registerTimeout.bind(null, DEFER_EVENT_LISTENER_TIME), DEFER_EVENT_LISTENER_TIME);
 };

--- a/packages/node-http-handler/src/set-socket-keep-alive.spec.ts
+++ b/packages/node-http-handler/src/set-socket-keep-alive.spec.ts
@@ -14,7 +14,7 @@ describe("setSocketKeepAlive", () => {
   });
 
   it("should set keepAlive to true", () => {
-    setSocketKeepAlive(request, { keepAlive: true });
+    setSocketKeepAlive(request, { keepAlive: true }, 0);
 
     const setKeepAliveSpy = jest.spyOn(socket, "setKeepAlive");
     request.emit("socket", socket);
@@ -25,7 +25,7 @@ describe("setSocketKeepAlive", () => {
 
   it("should set keepAlive to true with custom initialDelay", () => {
     const initialDelay = 5 * 1000;
-    setSocketKeepAlive(request, { keepAlive: true, keepAliveMsecs: initialDelay });
+    setSocketKeepAlive(request, { keepAlive: true, keepAliveMsecs: initialDelay }, 0);
 
     const setKeepAliveSpy = jest.spyOn(socket, "setKeepAlive");
     request.emit("socket", socket);
@@ -35,7 +35,7 @@ describe("setSocketKeepAlive", () => {
   });
 
   it("should not set keepAlive at all when keepAlive is false", () => {
-    setSocketKeepAlive(request, { keepAlive: false });
+    setSocketKeepAlive(request, { keepAlive: false }, 0);
 
     const setKeepAliveSpy = jest.spyOn(socket, "setKeepAlive");
     request.emit("socket", socket);

--- a/packages/node-http-handler/src/set-socket-keep-alive.ts
+++ b/packages/node-http-handler/src/set-socket-keep-alive.ts
@@ -1,16 +1,31 @@
 import { ClientRequest } from "http";
 
+const DEFER_EVENT_LISTENER_TIME = 3000;
+
 export interface SocketKeepAliveOptions {
   keepAlive: boolean;
   keepAliveMsecs?: number;
 }
 
-export const setSocketKeepAlive = (request: ClientRequest, { keepAlive, keepAliveMsecs }: SocketKeepAliveOptions) => {
+export const setSocketKeepAlive = (
+  request: ClientRequest,
+  { keepAlive, keepAliveMsecs }: SocketKeepAliveOptions,
+  deferTimeMs = DEFER_EVENT_LISTENER_TIME
+): NodeJS.Timeout | number => {
   if (keepAlive !== true) {
-    return;
+    return -1;
   }
 
-  request.on("socket", (socket) => {
-    socket.setKeepAlive(keepAlive, keepAliveMsecs || 0);
-  });
+  const registerListener = () => {
+    request.on("socket", (socket) => {
+      socket.setKeepAlive(keepAlive, keepAliveMsecs || 0);
+    });
+  };
+
+  if (deferTimeMs === 0) {
+    registerListener();
+    return 0;
+  }
+
+  return setTimeout(registerListener, deferTimeMs);
 };

--- a/packages/node-http-handler/src/set-socket-timeout.spec.ts
+++ b/packages/node-http-handler/src/set-socket-timeout.spec.ts
@@ -8,6 +8,12 @@ describe("setSocketTimeout", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
   it(`sets the request's timeout if provided`, () => {
@@ -17,15 +23,17 @@ describe("setSocketTimeout", () => {
     expect(clientRequest.setTimeout).toHaveBeenLastCalledWith(100, expect.any(Function));
   });
 
-  it(`sets the request's timeout to 0 if not provided`, () => {
+  it(`sets the request's timeout to 0 if not provided`, async () => {
     setSocketTimeout(clientRequest, jest.fn());
+
+    jest.runAllTimers();
 
     expect(clientRequest.setTimeout).toHaveBeenCalledTimes(1);
     expect(clientRequest.setTimeout).toHaveBeenLastCalledWith(0, expect.any(Function));
   });
 
   it(`destroys the request on timeout`, () => {
-    setSocketTimeout(clientRequest, jest.fn());
+    setSocketTimeout(clientRequest, jest.fn(), 1);
     expect(clientRequest.destroy).not.toHaveBeenCalled();
 
     // call setTimeout callback

--- a/packages/node-http-handler/src/set-socket-timeout.ts
+++ b/packages/node-http-handler/src/set-socket-timeout.ts
@@ -1,9 +1,27 @@
 import { ClientRequest } from "http";
 
-export const setSocketTimeout = (request: ClientRequest, reject: (err: Error) => void, timeoutInMs = 0) => {
-  request.setTimeout(timeoutInMs, () => {
-    // destroy the request
-    request.destroy();
-    reject(Object.assign(new Error(`Connection timed out after ${timeoutInMs} ms`), { name: "TimeoutError" }));
-  });
+const DEFER_EVENT_LISTENER_TIME = 3000;
+
+export const setSocketTimeout = (
+  request: ClientRequest,
+  reject: (err: Error) => void,
+  timeoutInMs = 0
+): NodeJS.Timeout | number => {
+  const registerTimeout = (offset: number) => {
+    request.setTimeout(timeoutInMs - offset, () => {
+      // destroy the request
+      request.destroy();
+      reject(Object.assign(new Error(`Connection timed out after ${timeoutInMs} ms`), { name: "TimeoutError" }));
+    });
+  };
+
+  if (0 < timeoutInMs && timeoutInMs < 6000) {
+    registerTimeout(0);
+    return 0;
+  }
+
+  return setTimeout(
+    registerTimeout.bind(null, timeoutInMs === 0 ? 0 : DEFER_EVENT_LISTENER_TIME),
+    DEFER_EVENT_LISTENER_TIME
+  );
 };


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/6423

This PR defers the registration of `socket` event listeners on individual requests outgoing from `node:http(s)` requests.

Attaching events creates a small performance overhead (0-2ms) and I believe they are unnecessary for requests that resolve in under 3 seconds for timeouts of greater than 6 seconds.

Here is a comparison of the use-case of a request before and after this PR:

### Before PR

- request is created
- socket event listeners are attached
- request is submitted
- socket event triggers event listeners 
  - some don't do anything because the timeouts involved are far higher than the request duration
  - sending a keepalive probe is useless if the request completes in e.g. under a second
- request completes, event listeners are cleaned up

### After PR
- request is created
- no event listeners register until the request duration exceeds 3 seconds or the configured timeout is less than 6 seconds, in which case they are still immediately registered.
  - avoids sending keepalive probe too early for short duration request
  - avoids adding other socket event listeners until needed
- request is submitted
- request completes, event listeners are cleaned up, or event listener deferment timeouts are cleared