### PR TITLE
feat(util-endpoint): add endpoint ruleset cache

### DIFF
--- a/.changeset/moody-fishes-buy.md
+++ b/.changeset/moody-fishes-buy.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": minor
+---
+
+add endpoint ruleset cache

--- a/packages/util-endpoints/src/cache/EndpointCache.spec.ts
+++ b/packages/util-endpoints/src/cache/EndpointCache.spec.ts
@@ -1,0 +1,53 @@
+import { EndpointCache } from "./EndpointCache";
+
+describe(EndpointCache.name, () => {
+  const endpoint1: any = {};
+  const endpoint2: any = {};
+
+  it("should store and retrieve items", () => {
+    const cache = new EndpointCache({
+      size: 50,
+    });
+
+    expect(cache.get({ A: "b", B: "b" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.get({ A: "b", B: "b" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.get({ A: "b", B: "b", C: "c" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.get({ A: "b", B: "b", C: "c" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.get({ A: "b", B: "b", C: "cc" }, () => endpoint2)).toBe(endpoint2);
+    expect(cache.get({ A: "b", B: "b", C: "cc" }, () => endpoint2)).toBe(endpoint2);
+
+    expect(cache.size()).toEqual(3);
+  });
+
+  it("should accept a custom parameter list", () => {
+    const cache = new EndpointCache({
+      size: 50,
+      params: ["A", "B"],
+    });
+
+    expect(cache.get({ A: "b", B: "b" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.get({ A: "b", B: "b", C: "c" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.get({ A: "b", B: "b", C: "cc" }, () => endpoint2)).toBe(endpoint1);
+
+    expect(cache.size()).toEqual(1);
+  });
+
+  it("should be an LRU cache", () => {
+    const cache = new EndpointCache({
+      size: 5,
+      params: ["A", "B"],
+    });
+
+    for (let i = 0; i < 50; ++i) {
+      cache.get({ A: "b", B: "b" + i }, () => endpoint1);
+    }
+
+    const size = cache.size();
+    expect(size).toBeLessThan(16);
+    expect(cache.get({ A: "b", B: "b49" }, () => endpoint2)).toBe(endpoint1);
+    expect(cache.size()).toEqual(size);
+
+    expect(cache.get({ A: "b", B: "b1" }, () => endpoint2)).toBe(endpoint2);
+    expect(cache.size()).toEqual(size + 1);
+  });
+});

--- a/packages/util-endpoints/src/cache/EndpointCache.spec.ts
+++ b/packages/util-endpoints/src/cache/EndpointCache.spec.ts
@@ -7,6 +7,7 @@ describe(EndpointCache.name, () => {
   it("should store and retrieve items", () => {
     const cache = new EndpointCache({
       size: 50,
+      params: ["A", "B", "C"],
     });
 
     expect(cache.get({ A: "b", B: "b" }, () => endpoint1)).toBe(endpoint1);
@@ -30,6 +31,35 @@ describe(EndpointCache.name, () => {
     expect(cache.get({ A: "b", B: "b", C: "cc" }, () => endpoint2)).toBe(endpoint1);
 
     expect(cache.size()).toEqual(1);
+  });
+
+  it("bypasses caching if param values include the cache key delimiter", () => {
+    const cache = new EndpointCache({
+      size: 50,
+      params: ["A", "B"],
+    });
+
+    expect(cache.get({ A: "b", B: "aaa|;aaa" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.size()).toEqual(0);
+  });
+
+  it("bypasses caching if param list is empty", () => {
+    const cache = new EndpointCache({
+      size: 50,
+      params: [],
+    });
+
+    expect(cache.get({ A: "b", B: "b" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.size()).toEqual(0);
+  });
+
+  it("bypasses caching if no param list is supplied", () => {
+    const cache = new EndpointCache({
+      size: 50,
+    });
+
+    expect(cache.get({ A: "b", B: "b" }, () => endpoint1)).toBe(endpoint1);
+    expect(cache.size()).toEqual(0);
   });
 
   it("should be an LRU cache", () => {

--- a/packages/util-endpoints/src/cache/EndpointCache.ts
+++ b/packages/util-endpoints/src/cache/EndpointCache.ts
@@ -15,7 +15,7 @@ export class EndpointCache {
    *                 before keys are dropped.
    * @param [params] - list of params to consider as part of the cache key.
    *
-   * If the params list is not populated, all object keys will be considered.
+   * If the params list is not populated, no caching will happen.
    * This may be out of order depending on how the object is created and arrives to this class.
    */
   public constructor({ size, params }: { size?: number; params?: string[] }) {
@@ -57,10 +57,16 @@ export class EndpointCache {
     return this.data.size;
   }
 
+  /**
+   * @returns cache key or false if not cachable.
+   */
   private hash(endpointParams: EndpointParams): string | false {
     let buffer = "";
-    const params = this.parameters.length ? this.parameters : Object.keys(endpointParams);
-    for (const param of params) {
+    const { parameters } = this;
+    if (parameters.length === 0) {
+      return false;
+    }
+    for (const param of parameters) {
       const val = String(endpointParams[param] ?? "");
       if (val.includes("|;")) {
         return false;

--- a/packages/util-endpoints/src/cache/EndpointCache.ts
+++ b/packages/util-endpoints/src/cache/EndpointCache.ts
@@ -1,0 +1,62 @@
+import type { EndpointParams, EndpointV2 } from "@smithy/types";
+
+/**
+ * @internal
+ *
+ * Cache for endpoint ruleSet resolution.
+ */
+export class EndpointCache {
+  private capacity: number;
+  private data = new Map<string, EndpointV2>();
+  private parameters: string[] = [];
+
+  /**
+   * @param [params] - list of params to consider as part of the cache key.
+   *
+   * If the params list is not populated, all object keys will be considered.
+   * This may be out of order depending on how the object is created and arrives to this class.
+   */
+  public constructor({ size, params }: { size?: number; params?: string[] }) {
+    this.capacity = size ?? 50;
+    if (params) {
+      this.parameters = params;
+    }
+  }
+
+  /**
+   * @param endpointParams - query for endpoint.
+   * @param resolver - provider of the value if not present.
+   * @returns endpoint corresponding to the query.
+   */
+  public get(endpointParams: EndpointParams, resolver: () => EndpointV2): EndpointV2 {
+    const key = this.hash(endpointParams);
+    if (!this.data.has(key)) {
+      if (this.data.size > this.capacity + 10) {
+        const keys = this.data.keys();
+        let i = 0;
+        while (true) {
+          const { value, done } = keys.next();
+          this.data.delete(value);
+          if (done || ++i > 10) {
+            break;
+          }
+        }
+      }
+      this.data.set(key, resolver());
+    }
+    return this.data.get(key)!;
+  }
+
+  public size() {
+    return this.data.size;
+  }
+
+  private hash(endpointParams: EndpointParams): string {
+    let buffer = "";
+    const params = this.parameters.length ? this.parameters : Object.keys(endpointParams);
+    for (const param of params) {
+      buffer += endpointParams[param] ?? "" + "|";
+    }
+    return buffer;
+  }
+}

--- a/packages/util-endpoints/src/index.ts
+++ b/packages/util-endpoints/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./cache/EndpointCache";
 export * from "./lib/isIpAddress";
 export * from "./lib/isValidHostLabel";
 export * from "./utils/customEndpointFunctions";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -79,6 +80,7 @@ public final class EndpointsV2Generator implements Runnable {
     private final EndpointRuleSetTrait endpointRuleSetTrait;
     private final ServiceShape service;
     private final TypeScriptSettings settings;
+    private final RuleSetParameterFinder ruleSetParameterFinder;
 
     public EndpointsV2Generator(
             TypeScriptDelegator delegator,
@@ -90,6 +92,7 @@ public final class EndpointsV2Generator implements Runnable {
         this.settings = settings;
         endpointRuleSetTrait = service.getTrait(EndpointRuleSetTrait.class)
             .orElseThrow(() -> new RuntimeException("service missing EndpointRuleSetTrait"));
+        ruleSetParameterFinder = new RuleSetParameterFinder(service);
     }
 
     @Override
@@ -114,8 +117,6 @@ public final class EndpointsV2Generator implements Runnable {
                     "export interface ClientInputEndpointParameters {",
                     "}",
                     () -> {
-                        RuleSetParameterFinder ruleSetParameterFinder = new RuleSetParameterFinder(service);
-
                         Map<String, String> clientInputParams = ruleSetParameterFinder.getClientContextParams();
                         //Omit Endpoint params that should not be a part of the ClientInputEndpointParameters interface
                         Map<String, String> builtInParams = ruleSetParameterFinder.getBuiltInParams();
@@ -164,10 +165,9 @@ public final class EndpointsV2Generator implements Runnable {
                 writer.openBlock(
                     "export const commonParams = {", "} as const",
                     () -> {
-                        RuleSetParameterFinder parameterFinder = new RuleSetParameterFinder(service);
                         Set<String> paramNames = new HashSet<>();
 
-                        parameterFinder.getClientContextParams().forEach((name, type) -> {
+                        ruleSetParameterFinder.getClientContextParams().forEach((name, type) -> {
                             if (!paramNames.contains(name)) {
                                 writer.write(
                                     "$L: { type: \"clientContextParams\", name: \"$L\" },",
@@ -176,7 +176,7 @@ public final class EndpointsV2Generator implements Runnable {
                             paramNames.add(name);
                         });
 
-                        parameterFinder.getBuiltInParams().forEach((name, type) -> {
+                        ruleSetParameterFinder.getBuiltInParams().forEach((name, type) -> {
                             if (!paramNames.contains(name)) {
                                 writer.write(
                                     "$L: { type: \"builtInParams\", name: \"$L\" },",
@@ -222,25 +222,29 @@ public final class EndpointsV2Generator implements Runnable {
                     Paths.get(".", CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER,
                         ENDPOINT_RULESET_FILE.replace(".ts", "")));
 
-                writer.openBlock(
-                    "export const defaultEndpointResolver = ",
-                    "",
-                    () -> {
-                        writer.openBlock(
-                            "(endpointParams: EndpointParameters, context: { logger?: Logger } = {}): EndpointV2 => {",
-                            "};",
-                            () -> {
-                                writer.openBlock(
-                                    "return resolveEndpoint(ruleSet, {",
-                                    "});",
-                                    () -> {
-                                        writer.write("endpointParams: endpointParams as EndpointParams,");
-                                        writer.write("logger: context.logger,");
-                                    }
-                                );
-                            }
-                        );
-                    }
+                writer.addImport("EndpointCache", null, TypeScriptDependency.UTIL_ENDPOINTS);
+                writer.write("""
+                    const cache = new EndpointCache({
+                        size: 50,
+                        params: [$L]
+                    });
+                    """,
+                    ruleSetParameterFinder.getEffectiveParams()
+                        .stream().collect(Collectors.joining("\",\n \"", "\"", "\""))
+                );
+
+                writer.write(
+                """
+                    export const defaultEndpointResolver = (
+                        endpointParams: EndpointParameters,
+                        context: { logger?: Logger } = {}
+                    ): EndpointV2 => {
+                        return cache.get(endpointParams as EndpointParams, () => resolveEndpoint(ruleSet, {
+                            endpointParams: endpointParams as EndpointParams,
+                            logger: context.logger,
+                        }));
+                    };
+                    """
                 );
             }
         );

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinderTest.java
@@ -40,6 +40,11 @@ class RuleSetParameterFinderTest {
                   "required": false,
                   "documentation": "...",
                   "type": "String"
+                },
+                "ShorthandParameter": {
+                  "required": true,
+                  "documentation": "...",
+                  "type": "String"
                 }
               },
               "rules": [
@@ -83,6 +88,13 @@ class RuleSetParameterFinderTest {
                             },
                             true
                           ]
+                        },
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            "literal",
+                            "{ShorthandParameter}"
+                          ]
                         }
                       ],
                       "endpoint": {
@@ -109,6 +121,6 @@ class RuleSetParameterFinderTest {
 
         List<String> effectiveParams = subject.getEffectiveParams();
 
-        assertEquals(List.of("BasicParameter", "NestedParameter", "UrlOnlyParameter"), effectiveParams);
+        assertEquals(List.of("BasicParameter", "NestedParameter", "ShorthandParameter", "UrlOnlyParameter"), effectiveParams);
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinderTest.java
@@ -1,0 +1,114 @@
+package software.amazon.smithy.typescript.codegen.endpointsV2;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RuleSetParameterFinderTest {
+
+    Node ruleSet = Node.parse("""
+            {
+              "version": "1.0",
+              "parameters": {
+                "BasicParameter": {
+                  "required": false,
+                  "documentation": "...",
+                  "type": "String"
+                },
+                "NestedParameter": {
+                  "required": true,
+                  "documentation": "...",
+                  "type": "Boolean"
+                },
+                "UrlOnlyParameter": {
+                  "required": true,
+                  "documentation": "...",
+                  "type": "String"
+                },
+                "UnusedParameter": {
+                  "required": false,
+                  "documentation": "...",
+                  "type": "String"
+                }
+              },
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "BasicParameter"
+                        }
+                      ]
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "booleanEquals",
+                                      "argv": [
+                                        {
+                                          "ref": "NestedParameter"
+                                        },
+                                        true
+                                      ]
+                                    },
+                                    true
+                                  ]
+                                },
+                                true
+                              ]
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://www.{BasicParameter}.{UrlOnlyParameter}.com",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ]
+            }
+            """);
+
+    @Test
+    void getEffectiveParams(@Mock ServiceShape serviceShape, @Mock EndpointRuleSetTrait endpointRuleSetTrait) {
+        EndpointRuleSet endpointRuleSet = EndpointRuleSet.fromNode(ruleSet);
+        when(serviceShape.getTrait(EndpointRuleSetTrait.class)).thenReturn(Optional.of(endpointRuleSetTrait));
+        when(endpointRuleSetTrait.getEndpointRuleSet()).thenReturn(endpointRuleSet);
+
+        RuleSetParameterFinder subject = new RuleSetParameterFinder(serviceShape);
+
+        List<String> effectiveParams = subject.getEffectiveParams();
+
+        assertEquals(List.of("BasicParameter", "NestedParameter", "UrlOnlyParameter"), effectiveParams);
+    }
+}


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/6423

This PR creates a cache for endpoint ruleset resolution.

As one would expect, the input and cache key are the endpoint params and the output and cache value is the endpoint.

Some services declare endpoint parameters in excess of what is actually evaluated in the ruleset, so codegen provides the explicit pared param list to the cache instance.

- [x] codegen to connect EndpointCache to the service's endpointResolver.ts file contents.
- [x] codegen to determine what the pared parameter list is to avoid cache pollution from irrelevant params