### PR TITLE
Add docs to use updated TypeScript Codegen Plugins

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
@@ -19,6 +19,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Plugin to trigger TypeScript code generation.
+ * @deprecated Use {@link TypeScriptClientCodegenPlugin} instead.
  */
 @SmithyInternalApi
 @Deprecated

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSSDKCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSSDKCodegenPlugin.java
@@ -9,6 +9,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Plugin to trigger TypeScript SSDK code generation.
+ * @deprecated Use {@link TypeScriptServerCodegenPlugin} instead.
  */
 @SmithyInternalApi
 @Deprecated


### PR DESCRIPTION
*Issue #, if available:*
The deprecation messages were noticed in https://github.com/smithy-lang/smithy-typescript/pull/1387, but I'd to dig into the history/parent class to find out which class to use.

*Description of changes:*
Add docs to use updated TypeScript Codegen Plugins

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
