### PR TITLE
fix(types): fix client type transforms

### DIFF
--- a/.changeset/wise-fans-fold.md
+++ b/.changeset/wise-fans-fold.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+fix type transforms

--- a/packages/types/src/command.ts
+++ b/packages/types/src/command.ts
@@ -10,7 +10,7 @@ export interface Command<
   ClientOutput extends MetadataBearer,
   OutputType extends ClientOutput,
   ResolvedConfiguration,
-> {
+> extends CommandIO<InputType, OutputType> {
   readonly input: InputType;
   readonly middlewareStack: MiddlewareStack<InputType, OutputType>;
   resolveMiddleware(
@@ -19,3 +19,18 @@ export interface Command<
     options: any
   ): Handler<InputType, OutputType>;
 }
+
+/**
+ * @internal
+ *
+ * This is a subset of the Command type used only to detect the i/o types.
+ */
+export interface CommandIO<InputType extends object, OutputType extends MetadataBearer> {
+  readonly input: InputType;
+  resolveMiddleware(stack: any, configuration: any, options: any): Handler<InputType, OutputType>;
+}
+
+/**
+ * @internal
+ */
+export type GetOutputType<Command> = Command extends CommandIO<any, infer O> ? O : never;

--- a/packages/types/src/transform/client-method-transforms.ts
+++ b/packages/types/src/transform/client-method-transforms.ts
@@ -1,4 +1,4 @@
-import type { Command } from "../command";
+import type { CommandIO } from "../command";
 import type { MetadataBearer } from "../response";
 import type { StreamingBlobPayloadOutputTypes } from "../streaming-payload/streaming-blob-payload-output-types";
 import type { Transform } from "./type-transform";
@@ -13,23 +13,22 @@ export interface NarrowedInvokeFunction<
   HttpHandlerOptions,
   InputTypes extends object,
   OutputTypes extends MetadataBearer,
-  ResolvedClientConfiguration,
 > {
   <InputType extends InputTypes, OutputType extends OutputTypes>(
-    command: Command<InputTypes, InputType, OutputTypes, OutputType, ResolvedClientConfiguration>,
+    command: CommandIO<InputType, OutputType>,
     options?: HttpHandlerOptions
   ): Promise<Transform<OutputType, StreamingBlobPayloadOutputTypes | undefined, NarrowType>>;
   <InputType extends InputTypes, OutputType extends OutputTypes>(
-    command: Command<InputTypes, InputType, OutputTypes, OutputType, ResolvedClientConfiguration>,
+    command: CommandIO<InputType, OutputType>,
     cb: (err: unknown, data?: Transform<OutputType, StreamingBlobPayloadOutputTypes | undefined, NarrowType>) => void
   ): void;
   <InputType extends InputTypes, OutputType extends OutputTypes>(
-    command: Command<InputTypes, InputType, OutputTypes, OutputType, ResolvedClientConfiguration>,
+    command: CommandIO<InputType, OutputType>,
     options: HttpHandlerOptions,
     cb: (err: unknown, data?: Transform<OutputType, StreamingBlobPayloadOutputTypes | undefined, NarrowType>) => void
   ): void;
   <InputType extends InputTypes, OutputType extends OutputTypes>(
-    command: Command<InputTypes, InputType, OutputTypes, OutputType, ResolvedClientConfiguration>,
+    command: CommandIO<InputType, OutputType>,
     options?: HttpHandlerOptions,
     cb?: (err: unknown, data?: Transform<OutputType, StreamingBlobPayloadOutputTypes | undefined, NarrowType>) => void
   ): Promise<Transform<OutputType, StreamingBlobPayloadOutputTypes | undefined, NarrowType>> | void;

--- a/packages/types/src/transform/client-payload-blob-type-narrow.spec.ts
+++ b/packages/types/src/transform/client-payload-blob-type-narrow.spec.ts
@@ -2,6 +2,7 @@
 import type { IncomingMessage } from "node:http";
 
 import type { Client } from "../client";
+import type { CommandIO } from "../command";
 import type { HttpHandlerOptions } from "../http";
 import type { MetadataBearer } from "../response";
 import type { SdkStream } from "../serde";
@@ -87,7 +88,7 @@ interface MyClient extends Client<MyInput, MyOutput, MyConfig> {
 {
   interface NodeJsMyClient extends NodeJsClient<MyClient> {}
   const mockClient = null as unknown as NodeJsMyClient;
-  const sendCall = () => mockClient.send(null as any, { abortSignal: null as any });
+  const sendCall = () => mockClient.send(null as unknown as CommandIO<MyInput, MyOutput>, { abortSignal: null as any });
 
   type A = Awaited<ReturnType<typeof sendCall>>;
   type B = Omit<MyOutput, "body"> & { body?: SdkStream<IncomingMessage> };

--- a/packages/types/src/transform/no-undefined.spec.ts
+++ b/packages/types/src/transform/no-undefined.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { Client } from "../client";
+import { CommandIO } from "../command";
 import type { HttpHandlerOptions } from "../http";
 import type { MetadataBearer } from "../response";
 import type { Exact } from "./exact";
@@ -103,6 +104,22 @@ type A = {
     // Handles methods with optionally zero args.
     const c = null as unknown as AssertiveClient<MyClient>;
     const list = c.listObjects();
+    const output = null as unknown as Awaited<typeof list>;
+
+    const assert1: Exact<typeof output.a, string | undefined> = true as const;
+    const assert2: Exact<typeof output.b, number | undefined> = true as const;
+    const assert3: Exact<typeof output.c, string | number | undefined> = true as const;
+    if (output.r) {
+      const assert4: Exact<typeof output.r.a, string | undefined> = true as const;
+      const assert5: Exact<typeof output.r.b, number | undefined> = true as const;
+      const assert6: Exact<typeof output.r.c, string | number | undefined> = true as const;
+    }
+  }
+
+  {
+    // Works with outputs of the "send" method.
+    const c = null as unknown as AssertiveClient<MyClient>;
+    const list = c.send(null as unknown as CommandIO<MyInput, MyOutput>);
     const output = null as unknown as Awaited<typeof list>;
 
     const assert1: Exact<typeof output.a, string | undefined> = true as const;

--- a/packages/types/src/transform/no-undefined.ts
+++ b/packages/types/src/transform/no-undefined.ts
@@ -1,4 +1,5 @@
-import type { InvokeFunction, InvokeMethod, InvokeMethodOptionalArgs } from "../client";
+import type { InvokeMethod, InvokeMethodOptionalArgs } from "../client";
+import type { GetOutputType } from "../command";
 
 /**
  * @public
@@ -62,11 +63,11 @@ type NarrowClientIOTypes<ClientType extends object> = {
     InvokeMethodOptionalArgs<infer FunctionInputTypes, infer FunctionOutputTypes>,
   ]
     ? InvokeMethodOptionalArgs<NoUndefined<FunctionInputTypes>, NoUndefined<FunctionOutputTypes>>
-    : [ClientType[key]] extends [InvokeFunction<infer InputTypes, infer OutputTypes, infer ConfigType>]
-      ? InvokeFunction<NoUndefined<InputTypes>, NoUndefined<OutputTypes>, ConfigType>
-      : [ClientType[key]] extends [InvokeMethod<infer FunctionInputTypes, infer FunctionOutputTypes>]
-        ? InvokeMethod<NoUndefined<FunctionInputTypes>, NoUndefined<FunctionOutputTypes>>
-        : ClientType[key];
+    : [ClientType[key]] extends [InvokeMethod<infer FunctionInputTypes, infer FunctionOutputTypes>]
+      ? InvokeMethod<NoUndefined<FunctionInputTypes>, NoUndefined<FunctionOutputTypes>>
+      : ClientType[key];
+} & {
+  send<Command>(command: Command, options?: any): Promise<NoUndefined<GetOutputType<Command>>>;
 };
 
 /**
@@ -79,9 +80,9 @@ type UncheckedClientOutputTypes<ClientType extends object> = {
     InvokeMethodOptionalArgs<infer FunctionInputTypes, infer FunctionOutputTypes>,
   ]
     ? InvokeMethodOptionalArgs<NoUndefined<FunctionInputTypes>, RecursiveRequired<FunctionOutputTypes>>
-    : [ClientType[key]] extends [InvokeFunction<infer InputTypes, infer OutputTypes, infer ConfigType>]
-      ? InvokeFunction<NoUndefined<InputTypes>, RecursiveRequired<OutputTypes>, ConfigType>
-      : [ClientType[key]] extends [InvokeMethod<infer FunctionInputTypes, infer FunctionOutputTypes>]
-        ? InvokeMethod<NoUndefined<FunctionInputTypes>, RecursiveRequired<FunctionOutputTypes>>
-        : ClientType[key];
+    : [ClientType[key]] extends [InvokeMethod<infer FunctionInputTypes, infer FunctionOutputTypes>]
+      ? InvokeMethod<NoUndefined<FunctionInputTypes>, RecursiveRequired<FunctionOutputTypes>>
+      : ClientType[key];
+} & {
+  send<Command>(command: Command, options?: any): Promise<RecursiveRequired<NoUndefined<GetOutputType<Command>>>>;
 };

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -66,7 +66,7 @@ public class CommandGeneratorTest {
                 .build())
             .build();
 
-        new TypeScriptClientCodegenPlugin().execute(context);
+        new TypeScriptCodegenPlugin().execute(context);
         String contents = manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "//commands/GetFooCommand.ts").get();
 
         assertThat(contents, containsString("as __MetadataBearer"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -489,7 +489,7 @@ public class StructureGeneratorTest {
                         .build())
                 .build();
 
-        new TypeScriptClientCodegenPlugin().execute(context);
+        new TypeScriptCodegenPlugin().execute(context);
         String contents = manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "//models/models_0.ts").get();
 
         if (assertContains) {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPluginTest.java
@@ -31,7 +31,7 @@ public class TypeScriptCodegenPluginTest {
                                   .build())
                 .build();
 
-        new TypeScriptClientCodegenPlugin().execute(context);
+        new TypeScriptCodegenPlugin().execute(context);
 
         // Did we generate the runtime config files?
         // note that asserting the contents of runtime config files is handled in its own unit tests.
@@ -66,7 +66,7 @@ public class TypeScriptCodegenPluginTest {
                         .build())
                 .build();
 
-        new TypeScriptClientCodegenPlugin().execute(context);
+        new TypeScriptCodegenPlugin().execute(context);
 
         assertTrue(manifest.hasFile("Foo.ts"));
         assertThat(manifest.getFileString("Foo.ts").get(), containsString("export class Foo"));
@@ -88,7 +88,7 @@ public class TypeScriptCodegenPluginTest {
                         .withMember("packageVersion", Node.from("1.0.0"))
                         .build())
                 .build();
-        new TypeScriptClientCodegenPlugin().execute(context);
+        new TypeScriptCodegenPlugin().execute(context);
 
         assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/Example.ts"));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/Example.ts").get(),

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2GeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2GeneratorTest.java
@@ -10,7 +10,7 @@ import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
-import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
 public class EndpointsV2GeneratorTest {
     @Test
@@ -79,7 +79,7 @@ public class EndpointsV2GeneratorTest {
                         .build())
                 .build();
 
-        new TypeScriptClientCodegenPlugin().execute(context);
+        new TypeScriptCodegenPlugin().execute(context);
 
         assertThat(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/endpoint/EndpointParameters.ts"),
                 is(true));


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/4720

This PR fixes typechecking for aggregated client usage in the optional type transforms from changes to the Command shapes using Command.classBuilder. 

preview of the integration test I'll add to AWS SDK:

```ts
import { GetObjectCommand, S3, S3Client } from "@aws-sdk/client-s3";
import type { AssertiveClient, BrowserClient, NodeJsClient, UncheckedClient } from "@smithy/types";

{
  // default, no validation for undefined values
  const s3 = new S3({});

  await s3.listBuckets();
  await s3.listBuckets({});

  // @ts-expect-error (missing Bucket)
  s3.getObject({
    Key: undefined,
  });

  s3.getObject({
    // @ts-expect-error (unrecognized field)
    UnknownProperty: undefined,
  });

  const get = await s3.getObject({
    Bucket: undefined,
    Key: undefined,
  });

  // @ts-expect-error (Body may be undefined)
  await get.Body.transformToString();

  await get.Body?.transformToString();
  await get.Body!.transformToString();
}

{
  // the assertive client requires that inputs/outputs are of the right type
  // excluding '| undefined'.
  const s3_assertive = new S3() as AssertiveClient<S3>;
  const s3Client_assertive = new S3Client() as AssertiveClient<S3Client>;

  await s3_assertive.listBuckets();
  await s3_assertive.listBuckets({});

  s3_assertive.getObject({
    Bucket: "undefined",
    // @ts-expect-error (undefined not assignable to string)
    Key: undefined,
  });
  s3Client_assertive.send(
    new GetObjectCommand({
      Bucket: "undefined",
      // type transform is unable to validate within Command ctor.
      Key: undefined,
    })
  );

  // @ts-expect-error (missing Key)
  s3_assertive.getObject({
    Bucket: "undefined",
  });

  {
    const get = await s3_assertive.getObject({
      Bucket: "undefined",
      Key: "undefined",
    });

    // @ts-expect-error (Body is optional)
    await get.Body.transformToString();

    await get.Body?.transformToString();
    await get.Body!.transformToString();
  }

  {
    const get = await s3Client_assertive.send(
      new GetObjectCommand({
        Bucket: "undefined",
        Key: "undefined",
      })
    );

    // @ts-expect-error (Body is optional)
    await get.Body.transformToString();

    await get.Body?.transformToString();
    await get.Body!.transformToString();
  }
}

{
  // unchecked client also removes the possibility
  // of optionality '?' in addition to '| undefined'.
  const s3_unchecked = new S3({}) as UncheckedClient<S3>;
  const s3Client_unchecked = new S3Client() as UncheckedClient<S3Client>;

  await s3_unchecked.listBuckets();
  await s3_unchecked.listBuckets({});

  s3_unchecked.getObject({
    Bucket: "undefined",
    // @ts-expect-error (undefined not assignable to string)
    Key: undefined,
  });
  s3_unchecked.send(
    new GetObjectCommand({
      Bucket: "undefined",
      // type transform is unable to validate within Command ctor.
      Key: undefined,
    })
  );

  // @ts-expect-error (missing Key)
  s3_unchecked.getObject({
    Bucket: "undefined",
  });

  {
    const get = await s3_unchecked.getObject({
      Bucket: "undefined",
      Key: "undefined",
    });

    await get.Body.transformToString();
  }

  {
    const get = await s3Client_unchecked.send(
      new GetObjectCommand({
        Bucket: "undefined",
        Key: "undefined",
      })
    );

    await get.Body.transformToString();
  }
}

{
  // platform specific clients.
  const s3_browser = new S3({}) as BrowserClient<S3>;
  const s3Client_browser = new S3Client() as BrowserClient<S3Client>;
  const s3_node = new S3() as NodeJsClient<S3>;
  const s3Client_node = new S3() as NodeJsClient<S3>;

  {
    const get = await s3Client_browser.send(
      new GetObjectCommand({
        Bucket: "undefined",
        Key: "undefined",
      })
    );
    get.Body!.tee();
  }
  {
    const get = await s3_browser.getObject({ Bucket: "undefined", Key: "undefined" });
    get.Body!.tee();
  }

  {
    const get = await s3Client_node.send(
      new GetObjectCommand({
        Bucket: "undefined",
        Key: "undefined",
      })
    );
    get.Body!.pause();
  }
  {
    const get = await s3_node.getObject({ Bucket: "undefined", Key: "undefined" });
    get.Body!.pause();
  }
}

```