### PR TITLE
fix(node-http-handler): call socket methods if socket is defined

### DIFF
--- a/.changeset/fresh-hairs-work.md
+++ b/.changeset/fresh-hairs-work.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+call socket operations if socket is present in deferred listeners

--- a/packages/node-http-handler/src/set-connection-timeout.spec.ts
+++ b/packages/node-http-handler/src/set-connection-timeout.spec.ts
@@ -74,6 +74,22 @@ describe("setConnectionTimeout", () => {
       );
     });
 
+    it("calls socket operations directly if socket is available", async () => {
+      const request = {
+        on: jest.fn(),
+        socket: {
+          on: jest.fn(),
+          connecting: true,
+        },
+        destroy() {},
+      } as any;
+      setConnectionTimeout(request, () => {}, 1);
+      jest.runAllTimers();
+
+      expect(request.socket.on).toHaveBeenCalled();
+      expect(request.on).not.toHaveBeenCalled();
+    });
+
     it("clears timeout if socket gets connected", () => {
       clientRequest.on.mock.calls[0][1](mockSocket);
 

--- a/packages/node-http-handler/src/set-connection-timeout.ts
+++ b/packages/node-http-handler/src/set-connection-timeout.ts
@@ -1,5 +1,4 @@
 import { ClientRequest } from "http";
-import { Socket } from "net";
 
 const DEFER_EVENT_LISTENER_TIME = 1000;
 
@@ -23,15 +22,21 @@ export const setConnectionTimeout = (
       );
     }, timeoutInMs - offset);
 
-    request.on("socket", (socket: Socket) => {
-      if (socket.connecting) {
+    const doWithSocket = (socket: typeof request.socket) => {
+      if (socket?.connecting) {
         socket.on("connect", () => {
           clearTimeout(timeoutId);
         });
       } else {
         clearTimeout(timeoutId);
       }
-    });
+    };
+
+    if (request.socket) {
+      doWithSocket(request.socket);
+    } else {
+      request.on("socket", doWithSocket);
+    }
   };
 
   if (timeoutInMs < 2000) {

--- a/packages/node-http-handler/src/set-socket-keep-alive.spec.ts
+++ b/packages/node-http-handler/src/set-socket-keep-alive.spec.ts
@@ -42,4 +42,17 @@ describe("setSocketKeepAlive", () => {
 
     expect(setKeepAliveSpy).not.toHaveBeenCalled();
   });
+
+  it("calls socket operations directly if socket is available", async () => {
+    const request = {
+      on: jest.fn(),
+      socket: {
+        setKeepAlive: jest.fn(),
+      },
+    } as any;
+    setSocketKeepAlive(request, { keepAlive: true, keepAliveMsecs: 1000 }, 0);
+
+    expect(request.socket.setKeepAlive).toHaveBeenCalled();
+    expect(request.on).not.toHaveBeenCalled();
+  });
 });

--- a/packages/node-http-handler/src/set-socket-keep-alive.ts
+++ b/packages/node-http-handler/src/set-socket-keep-alive.ts
@@ -17,9 +17,13 @@ export const setSocketKeepAlive = (
   }
 
   const registerListener = () => {
-    request.on("socket", (socket) => {
-      socket.setKeepAlive(keepAlive, keepAliveMsecs || 0);
-    });
+    if (request.socket) {
+      request.socket.setKeepAlive(keepAlive, keepAliveMsecs || 0);
+    } else {
+      request.on("socket", (socket) => {
+        socket.setKeepAlive(keepAlive, keepAliveMsecs || 0);
+      });
+    }
   };
 
   if (deferTimeMs === 0) {


### PR DESCRIPTION
followup to https://github.com/smithy-lang/smithy-typescript/pull/1384

if socket event listeners are deferred past the socket event (i.e. socket exists), call the socket methods directly.