### PR TITLE
fix(types): add interface stub for RequestInit

### DIFF
--- a/.changeset/forty-cooks-deny.md
+++ b/.changeset/forty-cooks-deny.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+add interface stub for browser RequestInit type

--- a/packages/types/src/http/httpHandlerInitialization.ts
+++ b/packages/types/src/http/httpHandlerInitialization.ts
@@ -125,3 +125,10 @@ export interface FetchHttpHandlerOptions {
    */
   requestInit?: (httpRequest: IHttpRequest) => RequestInit;
 }
+
+declare global {
+  /**
+   * interface merging stub.
+   */
+  interface RequestInit {}
+}


### PR DESCRIPTION
- adds interface stub for `RequestInit` global

`RequestInit` was already used in the fetch-http-handler, but that is only conditionally compiled if the user imports it or bundles web-based code that imports the browser runtimeConfig files. 

The usage of `RequestInit` in the types package, which is not conditionally loaded, must be accompanied by the interface merging stub.