### PR TITLE
fix(signature-v4): sort query parameter keys after encoding

### DIFF
--- a/.changeset/ninety-hairs-obey.md
+++ b/.changeset/ninety-hairs-obey.md
@@ -1,0 +1,5 @@
+---
+"@smithy/signature-v4": patch
+---
+
+fix: sort query parameter keys after encoding

--- a/packages/signature-v4/src/getCanonicalQuery.spec.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.spec.ts
@@ -37,6 +37,17 @@ describe("getCanonicalQuery", () => {
     ).toBe("baz=quux&fizz=buzz&foo=bar");
   });
 
+  it("should sort query keys alphabetically after URI-encode", () => {
+    expect(
+      getCanonicalQuery(
+        new HttpRequest({
+          ...httpRequestOptions,
+          query: { A: "65", "[": "91", a: "97", "{": "123" },
+        })
+      )
+    ).toBe("%5B=91&%7B=123&A=65&a=97");
+  });
+
   it("should URI-encode keys and values", () => {
     expect(
       getCanonicalQuery(

--- a/packages/signature-v4/src/getCanonicalQuery.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.ts
@@ -9,28 +9,27 @@ import { SIGNATURE_HEADER } from "./constants";
 export const getCanonicalQuery = ({ query = {} }: HttpRequest): string => {
   const keys: Array<string> = [];
   const serialized: Record<string, string> = {};
-  for (const key of Object.keys(query).sort()) {
+  for (const key of Object.keys(query)) {
     if (key.toLowerCase() === SIGNATURE_HEADER) {
       continue;
     }
 
-    keys.push(key);
+    const encodedKey = escapeUri(key);
+    keys.push(encodedKey);
     const value = query[key];
     if (typeof value === "string") {
-      serialized[key] = `${escapeUri(key)}=${escapeUri(value)}`;
+      serialized[encodedKey] = `${encodedKey}=${escapeUri(value)}`;
     } else if (Array.isArray(value)) {
-      serialized[key] = value
+      serialized[encodedKey] = value
         .slice(0)
-        .reduce(
-          (encoded: Array<string>, value: string) => encoded.concat([`${escapeUri(key)}=${escapeUri(value)}`]),
-          []
-        )
+        .reduce((encoded: Array<string>, value: string) => encoded.concat([`${encodedKey}=${escapeUri(value)}`]), [])
         .sort()
         .join("&");
     }
   }
 
   return keys
+    .sort()
     .map((key) => serialized[key])
     .filter((serialized) => serialized) // omit any falsy values
     .join("&");


### PR DESCRIPTION
When signing an HTTP request with SigV4, an incorrect signature will be generated if the query parameter key contains characters that need to be encoded.

The following query parameter reproduces it: `?params[page]=1&params[pageSize]=20`

According to the [AWS documentation][canonical-query-params], it seems that query parameters need to be sorted after encoding.

> `CanonicalQueryString` – The URI-encoded query string parameters. You URI-encode each name and value individually. You must also sort the parameters in the canonical query string alphabetically by key name. The sorting occurs after encoding.

[canonical-query-params]: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request

*Description of changes:*

* Sort query parameter keys after URI encoding in `getCanonicalQuery`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
