### PR TITLE
fix(node-http-handler): fix invalid usage of parsed url

### DIFF
--- a/.changeset/gold-bugs-sneeze.md
+++ b/.changeset/gold-bugs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+remove brackets from hostname

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -153,6 +153,24 @@ describe("NodeHttpHandler", () => {
         expect(hRequestSpy.mock.calls[0][0]?.port).toEqual(1234);
         expect(hRequestSpy.mock.calls[0][0]?.path).toEqual("/some/path?some=query#fragment");
       });
+
+      it("removes brackets from hostname", async () => {
+        const nodeHttpHandler = new NodeHttpHandler({});
+        const httpRequest = {
+          protocol: "http:",
+          username: "username",
+          password: "password",
+          hostname: "[host]",
+          port: 1234,
+          path: "/some/path",
+          query: {
+            some: "query",
+          },
+          fragment: "fragment",
+        };
+        await nodeHttpHandler.handle(httpRequest as any);
+        expect(hRequestSpy.mock.calls[0][0]?.host).toEqual("host");
+      });
     });
   });
 

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -210,8 +210,8 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         path += `#${request.fragment}`;
       }
 
-      let hostname: string;
-      if (request.hostname.startsWith("[") && request.hostname.endsWith("]")) {
+      let hostname = request.hostname ?? "";
+      if (hostname[0] === "[" && hostname.endsWith("]")) {
         hostname = request.hostname.slice(1, -1);
       } else {
         hostname = request.hostname;

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -209,9 +209,17 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
       if (request.fragment) {
         path += `#${request.fragment}`;
       }
+
+      let hostname: string;
+      if (request.hostname.startsWith("[") && request.hostname.endsWith("]")) {
+        hostname = request.hostname.slice(1, -1);
+      } else {
+        hostname = request.hostname;
+      }
+
       const nodeHttpsOptions: RequestOptions = {
         headers: request.headers,
-        host: request.hostname,
+        host: hostname,
         method: request.method,
         path,
         port: request.port,


### PR DESCRIPTION
*[issue](https://github.com/aws/aws-sdk-js-v3/issues/6495)*

*Description of changes:*

Nodejs `URL` is not fully compatible with `http.RequestOptions` see https://github.com/nodejs/node/issues/39738

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
