### PR TITLE
feat(util-stream): create checksum stream adapters

### DIFF
--- a/.changeset/red-cameras-repair.md
+++ b/.changeset/red-cameras-repair.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-stream": minor
+---
+
+create checksum stream adapter

--- a/packages/util-stream/karma.conf.js
+++ b/packages/util-stream/karma.conf.js
@@ -6,6 +6,7 @@ module.exports = function (config) {
     files: [
       "src/checksum/createChecksumStream.browser.spec.ts",
       "src/checksum/createChecksumStream.browser.ts",
+      "src/checksum/ChecksumStream.browser.ts",
       "src/getAwsChunkedEncodingStream.browser.spec.ts",
       "src/getAwsChunkedEncodingStream.browser.ts",
       "src/headStream.browser.ts",

--- a/packages/util-stream/karma.conf.js
+++ b/packages/util-stream/karma.conf.js
@@ -3,7 +3,14 @@
 module.exports = function (config) {
   config.set({
     frameworks: ["jasmine", "karma-typescript"],
-    files: ["src/getAwsChunkedEncodingStream.browser.ts", "src/getAwsChunkedEncodingStream.browser.spec.ts"],
+    files: [
+      "src/checksum/createChecksumStream.browser.spec.ts",
+      "src/checksum/createChecksumStream.browser.ts",
+      "src/getAwsChunkedEncodingStream.browser.spec.ts",
+      "src/getAwsChunkedEncodingStream.browser.ts",
+      "src/headStream.browser.ts",
+      "src/stream-type-check.ts",
+    ],
     exclude: ["**/*.d.ts"],
     preprocessors: {
       "**/*.ts": "karma-typescript",

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -56,16 +56,19 @@
   ],
   "browser": {
     "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
+    "./dist-es/checksum/createChecksumStream": "./dist-es/checksum/createChecksumStream.browser",
     "./dist-es/headStream": "./dist-es/headStream.browser",
     "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser",
     "./dist-es/splitStream": "./dist-es/splitStream.browser"
   },
   "react-native": {
     "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
+    "./dist-es/checksum/createChecksumStream": "./dist-es/checksum/createChecksumStream.browser",
     "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser",
     "./dist-es/headStream": "./dist-es/headStream.browser",
     "./dist-es/splitStream": "./dist-es/splitStream.browser",
     "./dist-cjs/getAwsChunkedEncodingStream": "./dist-cjs/getAwsChunkedEncodingStream.browser",
+    "./dist-cjs/checksum/createChecksumStream": "./dist-cjs/checksum/createChecksumStream.browser",
     "./dist-cjs/sdk-stream-mixin": "./dist-cjs/sdk-stream-mixin.browser",
     "./dist-cjs/headStream": "./dist-cjs/headStream.browser",
     "./dist-cjs/splitStream": "./dist-cjs/splitStream.browser"

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -55,20 +55,20 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
     "./dist-es/checksum/createChecksumStream": "./dist-es/checksum/createChecksumStream.browser",
+    "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
     "./dist-es/headStream": "./dist-es/headStream.browser",
     "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser",
     "./dist-es/splitStream": "./dist-es/splitStream.browser"
   },
   "react-native": {
-    "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
     "./dist-es/checksum/createChecksumStream": "./dist-es/checksum/createChecksumStream.browser",
+    "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
     "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser",
     "./dist-es/headStream": "./dist-es/headStream.browser",
     "./dist-es/splitStream": "./dist-es/splitStream.browser",
-    "./dist-cjs/getAwsChunkedEncodingStream": "./dist-cjs/getAwsChunkedEncodingStream.browser",
     "./dist-cjs/checksum/createChecksumStream": "./dist-cjs/checksum/createChecksumStream.browser",
+    "./dist-cjs/getAwsChunkedEncodingStream": "./dist-cjs/getAwsChunkedEncodingStream.browser",
     "./dist-cjs/sdk-stream-mixin": "./dist-cjs/sdk-stream-mixin.browser",
     "./dist-cjs/headStream": "./dist-cjs/headStream.browser",
     "./dist-cjs/splitStream": "./dist-cjs/splitStream.browser"

--- a/packages/util-stream/src/checksum/ChecksumStream.browser.ts
+++ b/packages/util-stream/src/checksum/ChecksumStream.browser.ts
@@ -1,0 +1,39 @@
+import { Checksum, Encoder } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export interface ChecksumStreamInit {
+  /**
+   * Base64 value of the expected checksum.
+   */
+  expectedChecksum: string;
+  /**
+   * For error messaging, the location from which the checksum value was read.
+   */
+  checksumSourceLocation: string;
+  /**
+   * The checksum calculator.
+   */
+  checksum: Checksum;
+  /**
+   * The stream to be checked.
+   */
+  source: ReadableStream;
+
+  /**
+   * Optional base 64 encoder if calling from a request context.
+   */
+  base64Encoder?: Encoder;
+}
+
+const ReadableStreamRef = typeof ReadableStream === "function" ? ReadableStream : function (): void {};
+
+/**
+ * This stub exists so that the readable returned by createChecksumStream
+ * identifies as "ChecksumStream" in alignment with the Node.js
+ * implementation.
+ *
+ * @extends ReadableStream
+ */
+export class ChecksumStream extends (ReadableStreamRef as any) {}

--- a/packages/util-stream/src/checksum/ChecksumStream.ts
+++ b/packages/util-stream/src/checksum/ChecksumStream.ts
@@ -1,0 +1,118 @@
+import { Checksum, Encoder } from "@smithy/types";
+import { toBase64 } from "@smithy/util-base64";
+import { Duplex, Readable } from "stream";
+
+/**
+ * @internal
+ */
+export interface ChecksumStreamInit<T extends Readable | ReadableStream> {
+  /**
+   * Base64 value of the expected checksum.
+   */
+  expectedChecksum: string;
+  /**
+   * For error messaging, the location from which the checksum value was read.
+   */
+  checksumSourceLocation: string;
+  /**
+   * The checksum calculator.
+   */
+  checksum: Checksum;
+  /**
+   * The stream to be checked.
+   */
+  source: T;
+
+  /**
+   * Optional base 64 encoder if calling from a request context.
+   */
+  base64Encoder?: Encoder;
+}
+
+/**
+ * @internal
+ *
+ * Wrapper for throwing checksum errors for streams without
+ * buffering the stream.
+ *
+ */
+export class ChecksumStream extends Duplex {
+  private expectedChecksum: string;
+  private checksumSourceLocation: string;
+  private checksum: Checksum;
+  private source?: Readable;
+  private base64Encoder: Encoder;
+
+  public constructor({
+    expectedChecksum,
+    checksum,
+    source,
+    checksumSourceLocation,
+    base64Encoder,
+  }: ChecksumStreamInit<Readable>) {
+    super();
+    if (typeof (source as Readable).pipe === "function") {
+      this.source = source as Readable;
+    } else {
+      throw new Error(
+        `@smithy/util-stream: unsupported source type ${source?.constructor?.name ?? source} in ChecksumStream.`
+      );
+    }
+
+    this.base64Encoder = base64Encoder ?? toBase64;
+    this.expectedChecksum = expectedChecksum;
+    this.checksum = checksum;
+    this.checksumSourceLocation = checksumSourceLocation;
+
+    // connect this stream to the end of the source stream.
+    this.source.pipe(this);
+  }
+
+  /**
+   * @internal do not call this directly.
+   */
+  public _read(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    size: number
+  ): void {}
+
+  /**
+   * @internal do not call this directly.
+   *
+   * When the upstream source flows data to this stream,
+   * calculate a step update of the checksum.
+   */
+  public _write(chunk: Buffer, encoding: string, callback: (err?: Error) => void): void {
+    try {
+      this.checksum.update(chunk);
+      this.push(chunk);
+    } catch (e: unknown) {
+      return callback(e as Error);
+    }
+    return callback();
+  }
+
+  /**
+   * @internal do not call this directly.
+   *
+   * When the upstream source finishes, perform the checksum comparison.
+   */
+  public async _final(callback: (err?: Error) => void): Promise<void> {
+    try {
+      const digest: Uint8Array = await this.checksum.digest();
+      const received = this.base64Encoder(digest);
+      if (this.expectedChecksum !== received) {
+        return callback(
+          new Error(
+            `Checksum mismatch: expected "${this.expectedChecksum}" but received "${received}"` +
+              ` in response header "${this.checksumSourceLocation}".`
+          )
+        );
+      }
+    } catch (e: unknown) {
+      return callback(e as Error);
+    }
+    this.push(null);
+    return callback();
+  }
+}

--- a/packages/util-stream/src/checksum/createChecksumStream.browser.spec.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.browser.spec.ts
@@ -3,8 +3,8 @@ import { toBase64 } from "@smithy/util-base64";
 import { toUtf8 } from "@smithy/util-utf8";
 
 import { headStream } from "../headStream.browser";
+import { ChecksumStream as ChecksumStreamWeb } from "./ChecksumStream.browser";
 import { createChecksumStream } from "./createChecksumStream.browser";
-import { ChecksumStream as ChecksumStreamWeb } from "./createChecksumStream.browser";
 
 describe("Checksum streams", () => {
   /**

--- a/packages/util-stream/src/checksum/createChecksumStream.browser.spec.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.browser.spec.ts
@@ -1,0 +1,89 @@
+import { Checksum } from "@smithy/types";
+import { toBase64 } from "@smithy/util-base64";
+import { toUtf8 } from "@smithy/util-utf8";
+
+import { headStream } from "../headStream.browser";
+import { createChecksumStream } from "./createChecksumStream.browser";
+import { ChecksumStream as ChecksumStreamWeb } from "./createChecksumStream.browser";
+
+describe("Checksum streams", () => {
+  /**
+   * Hash "algorithm" that appends all data together.
+   */
+  class Appender implements Checksum {
+    public hash = "";
+    async digest(): Promise<Uint8Array> {
+      return Buffer.from(this.hash);
+    }
+    reset(): void {
+      throw new Error("Function not implemented.");
+    }
+    update(chunk: Uint8Array): void {
+      this.hash += toUtf8(chunk);
+    }
+  }
+
+  const canonicalData = new Uint8Array("abcdefghijklmnopqrstuvwxyz".split("").map((_) => _.charCodeAt(0)));
+
+  const canonicalUtf8 = toUtf8(canonicalData);
+  const canonicalBase64 = toBase64(canonicalUtf8);
+
+  describe(createChecksumStream.name + " webstreams API", () => {
+    if (typeof ReadableStream !== "function") {
+      // test not applicable to Node.js 16.
+      return;
+    }
+
+    const makeStream = () => {
+      return new ReadableStream({
+        start(controller) {
+          canonicalData.forEach((byte) => {
+            controller.enqueue(new Uint8Array([byte]));
+          });
+          controller.close();
+        },
+      });
+    };
+
+    it("should extend a ReadableStream", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      expect(checksumStream).toBeInstanceOf(ReadableStream);
+      expect(checksumStream).toBeInstanceOf(ChecksumStreamWeb);
+
+      const collected = toUtf8(await headStream(checksumStream, Infinity));
+      expect(collected).toEqual(canonicalUtf8);
+      expect(stream.locked).toEqual(true);
+
+      // expectation is that it is resolved.
+      expect(await checksumStream.getReader().closed);
+    });
+
+    it("should throw during stream read if the checksum does not match", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: "different-expected-checksum",
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      try {
+        toUtf8(await headStream(checksumStream, Infinity));
+        throw new Error("stream was read successfully");
+      } catch (e: unknown) {
+        expect(String(e)).toEqual(
+          `Error: Checksum mismatch: expected "different-expected-checksum" but` +
+            ` received "${canonicalBase64}"` +
+            ` in response header "my-header".`
+        );
+      }
+    });
+  });
+});

--- a/packages/util-stream/src/checksum/createChecksumStream.browser.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.browser.ts
@@ -107,6 +107,8 @@ export const createChecksumStream = ({
   return readable;
 };
 
+const ReadableStreamRef = typeof ReadableStream === "function" ? ReadableStream : function (): void {};
+
 /**
  * This stub exists so that the readable returned by createChecksumStream
  * identifies as "ChecksumStream" in alignment with the Node.js
@@ -114,9 +116,4 @@ export const createChecksumStream = ({
  *
  * @extends ReadableStream
  */
-export function ChecksumStream(): void {}
-
-if (typeof ReadableStream === "function") {
-  ChecksumStream.prototype = Object.create(ReadableStream.prototype);
-  ChecksumStream.prototype.constructor = ChecksumStream;
-}
+export class ChecksumStream extends (ReadableStreamRef as any) {}

--- a/packages/util-stream/src/checksum/createChecksumStream.browser.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.browser.ts
@@ -1,0 +1,98 @@
+import { Checksum, Encoder } from "@smithy/types";
+import { toBase64 } from "@smithy/util-base64";
+
+/**
+ * @internal
+ */
+export interface ChecksumStreamInit {
+  /**
+   * Base64 value of the expected checksum.
+   */
+  expectedChecksum: string;
+  /**
+   * For error messaging, the location from which the checksum value was read.
+   */
+  checksumSourceLocation: string;
+  /**
+   * The checksum calculator.
+   */
+  checksum: Checksum;
+  /**
+   * The stream to be checked.
+   */
+  source: ReadableStream;
+
+  /**
+   * Optional base 64 encoder if calling from a request context.
+   */
+  base64Encoder?: Encoder;
+}
+
+/**
+ * Alias prevents compiler from turning
+ * ReadableStream into ReadableStream<any>, which is incompatible
+ * with the NodeJS.ReadableStream global type.
+ */
+export type ReadableStreamType = ReadableStream;
+
+/**
+ * @internal
+ *
+ * Creates a stream adapter for throwing checksum errors for streams without
+ * buffering the stream.
+ */
+export const createChecksumStream = ({
+  expectedChecksum,
+  checksum,
+  source,
+  checksumSourceLocation,
+  base64Encoder,
+}: ChecksumStreamInit): ReadableStreamType => {
+  if (!(source instanceof ReadableStream)) {
+    throw new Error(
+      `@smithy/util-stream: unsupported source type ${(source as any)?.constructor?.name ?? source} in ChecksumStream.`
+    );
+  }
+
+  const encoder = base64Encoder ?? toBase64;
+
+  if (typeof TransformStream !== "function") {
+    throw new Error(
+      "@smithy/util-stream: unable to instantiate ChecksumStream because API unavailable: ReadableStream/TransformStream."
+    );
+  }
+
+  const transform = new TransformStream({
+    start() {},
+    transform: async (chunk: any, controller: TransformStreamDefaultController) => {
+      /**
+       * When the upstream source finishes, perform the checksum comparison.
+       */
+      if (null === chunk) {
+        const digest: Uint8Array = await checksum.digest();
+        const received = encoder(digest);
+
+        if (expectedChecksum !== received) {
+          const error = new Error(
+            `Checksum mismatch: expected "${expectedChecksum}" but received "${received}"` +
+              ` in response header "${checksumSourceLocation}".`
+          );
+          controller.error(error);
+          throw error;
+        }
+        controller.terminate();
+        return;
+      }
+      /**
+       * When the upstream source flows data to this stream,
+       * calculate a step update of the checksum.
+       */
+      checksum.update(chunk);
+      controller.enqueue(chunk);
+    },
+    flush() {},
+  });
+
+  source.pipeThrough(transform);
+  return transform.readable;
+};

--- a/packages/util-stream/src/checksum/createChecksumStream.browser.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.browser.ts
@@ -114,7 +114,7 @@ export const createChecksumStream = ({
  *
  * @extends ReadableStream
  */
-export class ChecksumStream {}
+export function ChecksumStream(): void {}
 
 if (typeof ReadableStream === "function") {
   ChecksumStream.prototype = Object.create(ReadableStream.prototype);

--- a/packages/util-stream/src/checksum/createChecksumStream.browser.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.browser.ts
@@ -1,36 +1,10 @@
-import { Checksum, Encoder } from "@smithy/types";
 import { toBase64 } from "@smithy/util-base64";
 
 import { isReadableStream } from "../stream-type-check";
+import { ChecksumStream, ChecksumStreamInit } from "./ChecksumStream.browser";
 
 /**
  * @internal
- */
-export interface ChecksumStreamInit {
-  /**
-   * Base64 value of the expected checksum.
-   */
-  expectedChecksum: string;
-  /**
-   * For error messaging, the location from which the checksum value was read.
-   */
-  checksumSourceLocation: string;
-  /**
-   * The checksum calculator.
-   */
-  checksum: Checksum;
-  /**
-   * The stream to be checked.
-   */
-  source: ReadableStream;
-
-  /**
-   * Optional base 64 encoder if calling from a request context.
-   */
-  base64Encoder?: Encoder;
-}
-
-/**
  * Alias prevents compiler from turning
  * ReadableStream into ReadableStream<any>, which is incompatible
  * with the NodeJS.ReadableStream global type.
@@ -106,14 +80,3 @@ export const createChecksumStream = ({
   Object.setPrototypeOf(readable, ChecksumStream.prototype);
   return readable;
 };
-
-const ReadableStreamRef = typeof ReadableStream === "function" ? ReadableStream : function (): void {};
-
-/**
- * This stub exists so that the readable returned by createChecksumStream
- * identifies as "ChecksumStream" in alignment with the Node.js
- * implementation.
- *
- * @extends ReadableStream
- */
-export class ChecksumStream extends (ReadableStreamRef as any) {}

--- a/packages/util-stream/src/checksum/createChecksumStream.spec.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.spec.ts
@@ -4,7 +4,8 @@ import { toUtf8 } from "@smithy/util-utf8";
 import { Readable } from "stream";
 
 import { headStream } from "../headStream";
-import { createChecksumStream } from "./createChecksumStream";
+import { ChecksumStream, createChecksumStream } from "./createChecksumStream";
+import { ChecksumStream as ChecksumStreamWeb } from "./createChecksumStream.browser";
 
 describe("Checksum streams", () => {
   /**
@@ -44,6 +45,7 @@ describe("Checksum streams", () => {
 
       expect(checksumStream.constructor.name).toEqual("ChecksumStream");
       expect(checksumStream).toBeInstanceOf(Readable);
+      expect(checksumStream).toBeInstanceOf(ChecksumStream);
 
       const collected = toUtf8(await headStream(checksumStream, Infinity));
       expect(collected).toEqual(canonicalUtf8);
@@ -99,7 +101,9 @@ describe("Checksum streams", () => {
         source: stream,
       });
 
+      expect(checksumStream.constructor.name).toEqual("ChecksumStream");
       expect(checksumStream).toBeInstanceOf(ReadableStream);
+      expect(checksumStream).toBeInstanceOf(ChecksumStreamWeb);
 
       const collected = toUtf8(await headStream(checksumStream, Infinity));
       expect(collected).toEqual(canonicalUtf8);

--- a/packages/util-stream/src/checksum/createChecksumStream.spec.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.spec.ts
@@ -43,7 +43,6 @@ describe("Checksum streams", () => {
         source: stream,
       });
 
-      expect(checksumStream.constructor.name).toEqual("ChecksumStream");
       expect(checksumStream).toBeInstanceOf(Readable);
       expect(checksumStream).toBeInstanceOf(ChecksumStream);
 
@@ -101,7 +100,6 @@ describe("Checksum streams", () => {
         source: stream,
       });
 
-      expect(checksumStream.constructor.name).toEqual("ChecksumStream");
       expect(checksumStream).toBeInstanceOf(ReadableStream);
       expect(checksumStream).toBeInstanceOf(ChecksumStreamWeb);
 

--- a/packages/util-stream/src/checksum/createChecksumStream.spec.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.spec.ts
@@ -4,8 +4,9 @@ import { toUtf8 } from "@smithy/util-utf8";
 import { Readable } from "stream";
 
 import { headStream } from "../headStream";
-import { ChecksumStream, createChecksumStream } from "./createChecksumStream";
-import { ChecksumStream as ChecksumStreamWeb } from "./createChecksumStream.browser";
+import { ChecksumStream } from "./ChecksumStream";
+import { ChecksumStream as ChecksumStreamWeb } from "./ChecksumStream.browser";
+import { createChecksumStream } from "./createChecksumStream";
 
 describe("Checksum streams", () => {
   /**

--- a/packages/util-stream/src/checksum/createChecksumStream.spec.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.spec.ts
@@ -43,6 +43,7 @@ describe("Checksum streams", () => {
       });
 
       expect(checksumStream.constructor.name).toEqual("ChecksumStream");
+      expect(checksumStream).toBeInstanceOf(Readable);
 
       const collected = toUtf8(await headStream(checksumStream, Infinity));
       expect(collected).toEqual(canonicalUtf8);
@@ -84,7 +85,6 @@ describe("Checksum streams", () => {
           canonicalData.forEach((byte) => {
             controller.enqueue(new Uint8Array([byte]));
           });
-          controller.enqueue(null);
           controller.close();
         },
       });

--- a/packages/util-stream/src/checksum/createChecksumStream.spec.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.spec.ts
@@ -1,0 +1,133 @@
+import { Checksum } from "@smithy/types";
+import { toBase64 } from "@smithy/util-base64";
+import { toUtf8 } from "@smithy/util-utf8";
+import { Readable } from "stream";
+
+import { headStream } from "../headStream";
+import { createChecksumStream } from "./createChecksumStream";
+
+describe("Checksum streams", () => {
+  /**
+   * Hash "algorithm" that appends all data together.
+   */
+  class Appender implements Checksum {
+    public hash = "";
+    async digest(): Promise<Uint8Array> {
+      return Buffer.from(this.hash);
+    }
+    reset(): void {
+      throw new Error("Function not implemented.");
+    }
+    update(chunk: Uint8Array): void {
+      this.hash += toUtf8(chunk);
+    }
+  }
+
+  const canonicalData = new Uint8Array("abcdefghijklmnopqrstuvwxyz".split("").map((_) => _.charCodeAt(0)));
+
+  const canonicalUtf8 = toUtf8(canonicalData);
+  const canonicalBase64 = toBase64(canonicalUtf8);
+
+  describe(createChecksumStream.name, () => {
+    const makeStream = () => {
+      return Readable.from(Buffer.from(canonicalData.buffer, 0, 26));
+    };
+
+    it("should extend a Readable stream", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      expect(checksumStream.constructor.name).toEqual("ChecksumStream");
+
+      const collected = toUtf8(await headStream(checksumStream, Infinity));
+      expect(collected).toEqual(canonicalUtf8);
+      expect(stream.readableEnded).toEqual(true);
+      expect(checksumStream.readableEnded).toEqual(true);
+    });
+
+    it("should throw during stream read if the checksum does not match", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: "different-expected-checksum",
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      try {
+        toUtf8(await headStream(checksumStream, Infinity));
+        throw new Error("stream was read successfully");
+      } catch (e: unknown) {
+        expect(String(e)).toEqual(
+          `Error: Checksum mismatch: expected "different-expected-checksum" but` +
+            ` received "${canonicalBase64}"` +
+            ` in response header "my-header".`
+        );
+      }
+    });
+  });
+
+  describe(createChecksumStream.name + " webstreams API", () => {
+    if (typeof ReadableStream !== "function") {
+      // test not applicable to Node.js 16.
+      return;
+    }
+
+    const makeStream = () => {
+      return new ReadableStream({
+        start(controller) {
+          canonicalData.forEach((byte) => {
+            controller.enqueue(new Uint8Array([byte]));
+          });
+          controller.enqueue(null);
+          controller.close();
+        },
+      });
+    };
+
+    it("should extend a ReadableStream", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      expect(checksumStream).toBeInstanceOf(ReadableStream);
+
+      const collected = toUtf8(await headStream(checksumStream, Infinity));
+      expect(collected).toEqual(canonicalUtf8);
+      expect(stream.locked).toEqual(true);
+
+      // expectation is that it is resolved.
+      expect(await checksumStream.getReader().closed);
+    });
+
+    it("should throw during stream read if the checksum does not match", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: "different-expected-checksum",
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      try {
+        toUtf8(await headStream(checksumStream, Infinity));
+        throw new Error("stream was read successfully");
+      } catch (e: unknown) {
+        expect(String(e)).toEqual(
+          `Error: Checksum mismatch: expected "different-expected-checksum" but` +
+            ` received "${canonicalBase64}"` +
+            ` in response header "my-header".`
+        );
+      }
+    });
+  });
+});

--- a/packages/util-stream/src/checksum/createChecksumStream.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.ts
@@ -1,0 +1,133 @@
+import { Checksum, Encoder } from "@smithy/types";
+import { toBase64 } from "@smithy/util-base64";
+import { Duplex, Readable } from "stream";
+
+import { isReadableStream } from "../stream-type-check";
+import { createChecksumStream as createChecksumStreamWeb, ReadableStreamType } from "./createChecksumStream.browser";
+
+/**
+ * @internal
+ */
+export interface ChecksumStreamInit<T extends Readable | ReadableStream> {
+  /**
+   * Base64 value of the expected checksum.
+   */
+  expectedChecksum: string;
+  /**
+   * For error messaging, the location from which the checksum value was read.
+   */
+  checksumSourceLocation: string;
+  /**
+   * The checksum calculator.
+   */
+  checksum: Checksum;
+  /**
+   * The stream to be checked.
+   */
+  source: T;
+
+  /**
+   * Optional base 64 encoder if calling from a request context.
+   */
+  base64Encoder?: Encoder;
+}
+
+/**
+ * @internal
+ *
+ * Creates a stream mirroring the input stream's interface, but
+ * performs checksumming when reading to the end of the stream.
+ */
+export function createChecksumStream(init: ChecksumStreamInit<ReadableStreamType>): ReadableStreamType;
+export function createChecksumStream(init: ChecksumStreamInit<Readable>): Readable;
+export function createChecksumStream(
+  init: ChecksumStreamInit<Readable | ReadableStreamType>
+): Readable | ReadableStreamType {
+  if (typeof ReadableStream === "function" && isReadableStream(init.source)) {
+    return createChecksumStreamWeb(init as ChecksumStreamInit<ReadableStreamType>);
+  }
+  return new ChecksumStream(init as ChecksumStreamInit<Readable>);
+}
+
+/**
+ * @internal
+ *
+ * Wrapper for throwing checksum errors for streams without
+ * buffering the stream.
+ *
+ */
+class ChecksumStream extends Duplex {
+  private expectedChecksum: string;
+  private checksumSourceLocation: string;
+  private checksum: Checksum;
+  private source?: Readable;
+  private base64Encoder: Encoder;
+
+  public constructor({
+    expectedChecksum,
+    checksum,
+    source,
+    checksumSourceLocation,
+    base64Encoder,
+  }: ChecksumStreamInit<Readable>) {
+    super();
+    if (typeof (source as Readable).pipe === "function") {
+      this.source = source as Readable;
+    } else {
+      throw new Error(
+        `@smithy/util-stream: unsupported source type ${source?.constructor?.name ?? source} in ChecksumStream.`
+      );
+    }
+
+    this.base64Encoder = base64Encoder ?? toBase64;
+    this.expectedChecksum = expectedChecksum;
+    this.checksum = checksum;
+    this.checksumSourceLocation = checksumSourceLocation;
+
+    // connect this stream to the end of the source stream.
+    this.source.pipe(this);
+  }
+
+  /**
+   * @internal do not call this directly.
+   */
+  public _read(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    size: number
+  ): void {}
+
+  /**
+   * @internal do not call this directly.
+   *
+   * When the upstream source flows data to this stream,
+   * calculate a step update of the checksum.
+   */
+  public _write(chunk: Buffer, encoding: string, callback: (err?: Error) => void): void {
+    this.checksum.update(chunk);
+    this.push(chunk);
+    callback();
+  }
+
+  /**
+   * @internal do not call this directly.
+   *
+   * When the upstream source finishes, perform the checksum comparison.
+   */
+  public async _final(callback: (err?: Error) => void) {
+    try {
+      const digest: Uint8Array = await this.checksum.digest();
+      const received = this.base64Encoder(digest);
+      if (this.expectedChecksum !== received) {
+        callback(
+          new Error(
+            `Checksum mismatch: expected "${this.expectedChecksum}" but received "${received}"` +
+              ` in response header "${this.checksumSourceLocation}".`
+          )
+        );
+      }
+    } catch (e: unknown) {
+      callback(e as Error);
+    }
+    this.push(null);
+  }
+}

--- a/packages/util-stream/src/checksum/createChecksumStream.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.ts
@@ -129,5 +129,6 @@ class ChecksumStream extends Duplex {
       callback(e as Error);
     }
     this.push(null);
+    callback();
   }
 }

--- a/packages/util-stream/src/checksum/createChecksumStream.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.ts
@@ -1,36 +1,8 @@
-import { Checksum, Encoder } from "@smithy/types";
-import { toBase64 } from "@smithy/util-base64";
-import { Duplex, Readable } from "stream";
+import { Readable } from "stream";
 
 import { isReadableStream } from "../stream-type-check";
+import { ChecksumStream, ChecksumStreamInit } from "./ChecksumStream";
 import { createChecksumStream as createChecksumStreamWeb, ReadableStreamType } from "./createChecksumStream.browser";
-
-/**
- * @internal
- */
-export interface ChecksumStreamInit<T extends Readable | ReadableStream> {
-  /**
-   * Base64 value of the expected checksum.
-   */
-  expectedChecksum: string;
-  /**
-   * For error messaging, the location from which the checksum value was read.
-   */
-  checksumSourceLocation: string;
-  /**
-   * The checksum calculator.
-   */
-  checksum: Checksum;
-  /**
-   * The stream to be checked.
-   */
-  source: T;
-
-  /**
-   * Optional base 64 encoder if calling from a request context.
-   */
-  base64Encoder?: Encoder;
-}
 
 /**
  * @internal
@@ -47,92 +19,4 @@ export function createChecksumStream(
     return createChecksumStreamWeb(init as ChecksumStreamInit<ReadableStreamType>);
   }
   return new ChecksumStream(init as ChecksumStreamInit<Readable>);
-}
-
-/**
- * @internal
- *
- * Wrapper for throwing checksum errors for streams without
- * buffering the stream.
- *
- */
-export class ChecksumStream extends Duplex {
-  private expectedChecksum: string;
-  private checksumSourceLocation: string;
-  private checksum: Checksum;
-  private source?: Readable;
-  private base64Encoder: Encoder;
-
-  public constructor({
-    expectedChecksum,
-    checksum,
-    source,
-    checksumSourceLocation,
-    base64Encoder,
-  }: ChecksumStreamInit<Readable>) {
-    super();
-    if (typeof (source as Readable).pipe === "function") {
-      this.source = source as Readable;
-    } else {
-      throw new Error(
-        `@smithy/util-stream: unsupported source type ${source?.constructor?.name ?? source} in ChecksumStream.`
-      );
-    }
-
-    this.base64Encoder = base64Encoder ?? toBase64;
-    this.expectedChecksum = expectedChecksum;
-    this.checksum = checksum;
-    this.checksumSourceLocation = checksumSourceLocation;
-
-    // connect this stream to the end of the source stream.
-    this.source.pipe(this);
-  }
-
-  /**
-   * @internal do not call this directly.
-   */
-  public _read(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    size: number
-  ): void {}
-
-  /**
-   * @internal do not call this directly.
-   *
-   * When the upstream source flows data to this stream,
-   * calculate a step update of the checksum.
-   */
-  public _write(chunk: Buffer, encoding: string, callback: (err?: Error) => void): void {
-    try {
-      this.checksum.update(chunk);
-      this.push(chunk);
-    } catch (e: unknown) {
-      return callback(e as Error);
-    }
-    return callback();
-  }
-
-  /**
-   * @internal do not call this directly.
-   *
-   * When the upstream source finishes, perform the checksum comparison.
-   */
-  public async _final(callback: (err?: Error) => void): Promise<void> {
-    try {
-      const digest: Uint8Array = await this.checksum.digest();
-      const received = this.base64Encoder(digest);
-      if (this.expectedChecksum !== received) {
-        return callback(
-          new Error(
-            `Checksum mismatch: expected "${this.expectedChecksum}" but received "${received}"` +
-              ` in response header "${this.checksumSourceLocation}".`
-          )
-        );
-      }
-    } catch (e: unknown) {
-      return callback(e as Error);
-    }
-    this.push(null);
-    return callback();
-  }
 }

--- a/packages/util-stream/src/checksum/createChecksumStream.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.ts
@@ -56,7 +56,7 @@ export function createChecksumStream(
  * buffering the stream.
  *
  */
-class ChecksumStream extends Duplex {
+export class ChecksumStream extends Duplex {
   private expectedChecksum: string;
   private checksumSourceLocation: string;
   private checksum: Checksum;

--- a/packages/util-stream/src/index.ts
+++ b/packages/util-stream/src/index.ts
@@ -4,3 +4,4 @@ export * from "./sdk-stream-mixin";
 export * from "./splitStream";
 export * from "./headStream";
 export * from "./stream-type-check";
+export * from "./checksum/createChecksumStream";

--- a/packages/util-stream/src/index.ts
+++ b/packages/util-stream/src/index.ts
@@ -5,3 +5,4 @@ export * from "./splitStream";
 export * from "./headStream";
 export * from "./stream-type-check";
 export * from "./checksum/createChecksumStream";
+export * from "./checksum/ChecksumStream";


### PR DESCRIPTION
creates the `createChecksumStream` function to wrap streams with a checksum verification that throws when the stream is read to completion if the checksum verification fails.

Related to flexible checksums in AWS SDKs, but implementation is generic here. 

API reference:
- https://developer.mozilla.org/en-US/docs/Web/API/TransformStream
- https://nodejs.org/api/stream.html#duplex-and-transform-streams