### PR TITLE
fix(node-http-handler): omit setting cache setting on request init when using default value

### DIFF
--- a/.changeset/good-cheetahs-wait.md
+++ b/.changeset/good-cheetahs-wait.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": patch
+---
+
+Omit setting cache setting on request init when using default value

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -112,8 +112,12 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
       headers: new Headers(request.headers),
       method: method,
       credentials,
-      cache: this.config!.cache ?? "default",
     };
+    // cache property is not supported in workerd runtime
+    // TODO: can we feature detect support for cache and not set this property when not supported?
+    if (this.config?.cache) {
+      requestOptions.cache = this.config.cache;
+    }
 
     if (body) {
       requestOptions.duplex = "half";


### PR DESCRIPTION
Fixes #1407 

Omit setting cache setting on request init when using default value
