### PR TITLE
chore(smithy-client): bring isSerializableHeaderValue into smithy-client

### DIFF
--- a/.changeset/small-gifts-tease.md
+++ b/.changeset/small-gifts-tease.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+serialize empty strings and collections in headers

--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -13,6 +13,7 @@ export * from "./exceptions";
 export * from "./extended-encode-uri-component";
 export * from "./get-array-if-single-item";
 export * from "./get-value-from-text-node";
+export * from "./is-serializable-header-value";
 export * from "./lazy-json";
 export * from "./object-mapping";
 export * from "./parse-utils";

--- a/packages/smithy-client/src/is-serializable-header-value.spec.ts
+++ b/packages/smithy-client/src/is-serializable-header-value.spec.ts
@@ -1,0 +1,23 @@
+import { isSerializableHeaderValue } from "./is-serializable-header-value";
+
+describe(isSerializableHeaderValue.name, () => {
+  it("considers empty strings serializable", () => {
+    expect(isSerializableHeaderValue("")).toBe(true);
+  });
+
+  it("considers empty collections serializable", () => {
+    expect(isSerializableHeaderValue(new Set())).toBe(true);
+    expect(isSerializableHeaderValue([])).toBe(true);
+  });
+
+  it("considers most falsy data values to be serializable", () => {
+    expect(isSerializableHeaderValue(false)).toBe(true);
+    expect(isSerializableHeaderValue(0)).toBe(true);
+    expect(isSerializableHeaderValue(new Date(0))).toBe(true);
+  });
+
+  it("considered undefined and null to be unserializable", () => {
+    expect(isSerializableHeaderValue(undefined)).toBe(false);
+    expect(isSerializableHeaderValue(null)).toBe(false);
+  });
+});

--- a/packages/smithy-client/src/is-serializable-header-value.ts
+++ b/packages/smithy-client/src/is-serializable-header-value.ts
@@ -1,0 +1,7 @@
+/**
+ * @internal
+ * @returns whether the header value is serializable.
+ */
+export const isSerializableHeaderValue = (value: any) => {
+  return value != null;
+};


### PR DESCRIPTION
for use in https://github.com/smithy-lang/smithy-typescript/pull/1412

upstream of this: https://github.com/smithy-lang/smithy/pull/2403 protocol test change