### PR TITLE
fix(core): add compatibility redirect for submodule types

### DIFF
--- a/.changeset/modern-pumpkins-yell.md
+++ b/.changeset/modern-pumpkins-yell.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+add compatibility types redirect

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -6,3 +6,4 @@
 *.tgz
 *.log
 package-lock.json
+!*.d.ts

--- a/packages/core/cbor.d.ts
+++ b/packages/core/cbor.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@smithy/core/cbor" {
+  export * from "@smithy/core/dist-types/submodules/cbor/index.d";
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,8 +68,9 @@
     }
   },
   "files": [
-    "dist-*/**",
-    "./cbor.js"
+    "./cbor.d.ts",
+    "./cbor.js",
+    "dist-*/**"
   ],
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/core",
   "repository": {

--- a/packages/core/scripts/lint.js
+++ b/packages/core/scripts/lint.js
@@ -28,9 +28,11 @@ for (const submodule of submodules) {
       };
       fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
     }
-    if (!pkgJson.files.includes(`./${submodule}.js`)) {
+    if (!pkgJson.files.includes(`./${submodule}.js`) || !pkgJson.files.includes(`./${submodule}.d.ts`)) {
       pkgJson.files.push(`./${submodule}.js`);
+      pkgJson.files.push(`./${submodule}.d.ts`);
       errors.push(`package.json files array missing ${submodule}.js compatibility redirect file.`);
+      pkgJson.files = [...new Set(pkgJson.files)].sort();
       fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
     }
     // tsconfig metadata.
@@ -54,6 +56,23 @@ for (const submodule of submodules) {
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
 module.exports = require("./dist-cjs/submodules/${submodule}/index.js");
+`
+      );
+    }
+    // compatibility types file.
+    const compatibilityTypesFile = path.join(root, `${submodule}.d.ts`);
+    if (!fs.existsSync(compatibilityTypesFile)) {
+      errors.push(`${submodule} is missing compatibility types file in the package root folder.`);
+      fs.writeFileSync(
+        compatibilityTypesFile,
+        `
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@smithy/core/${submodule}" {
+  export * from "@smithy/core/dist-types/submodules/${submodule}/index.d";
+}
 `
       );
     }


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6502

### Description
Adds a `.d.ts` file in the core root so that an import like `@smithy/core/submodule` not only maps via package.json exports, but also via traditional package relative pathing when contexts do not understand the exports metadata.

### Testing
created new linting rules for core submodules
