### PR TITLE
chore: use lowercase headers in middleware-compression

### DIFF
--- a/.changeset/eighty-queens-yawn.md
+++ b/.changeset/eighty-queens-yawn.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-compression": patch
+---
+
+use lowercase headers

--- a/packages/middleware-compression/src/compressionMiddleware.spec.ts
+++ b/packages/middleware-compression/src/compressionMiddleware.spec.ts
@@ -95,7 +95,7 @@ describe(compressionMiddleware.name, () => {
             body: mockCompressedStream,
             headers: {
               ...mockArgs.request.headers,
-              "Content-Encoding": "gzip",
+              "content-encoding": "gzip",
             },
           },
         });
@@ -130,7 +130,7 @@ describe(compressionMiddleware.name, () => {
             body: mockCompressedBody,
             headers: {
               ...mockArgs.request.headers,
-              "Content-Encoding": "gzip",
+              "content-encoding": "gzip",
             },
           },
         });
@@ -148,7 +148,7 @@ describe(compressionMiddleware.name, () => {
           request: {
             ...mockArgs.request,
             headers: {
-              "Content-Encoding": mockExistingContentEncoding,
+              "content-encoding": mockExistingContentEncoding,
             },
           },
         } as any);
@@ -160,7 +160,7 @@ describe(compressionMiddleware.name, () => {
             body: mockCompressedBody,
             headers: {
               ...mockArgs.request.headers,
-              "Content-Encoding": [mockExistingContentEncoding, "gzip"].join(","),
+              "content-encoding": [mockExistingContentEncoding, "gzip"].join(","),
             },
           },
         });

--- a/packages/middleware-compression/src/compressionMiddleware.ts
+++ b/packages/middleware-compression/src/compressionMiddleware.ts
@@ -79,13 +79,13 @@ export const compressionMiddleware =
 
         if (isRequestCompressed) {
           // Either append to the header if it already exists, else set it
-          if (headers["Content-Encoding"]) {
+          if (headers["content-encoding"]) {
             updatedHeaders = {
               ...headers,
-              "Content-Encoding": `${headers["Content-Encoding"]},${algorithm}`,
+              "content-encoding": `${headers["content-encoding"]},${algorithm}`,
             };
           } else {
-            updatedHeaders = { ...headers, "Content-Encoding": algorithm };
+            updatedHeaders = { ...headers, "content-encoding": algorithm };
           }
 
           // We've matched on one supported algorithm in the


### PR DESCRIPTION
headers are case insensitive, but this matches the protocol tests better