### PR TITLE
fix(signature-v4): add hoistable headers config

### DIFF
--- a/.changeset/happy-emus-crash.md
+++ b/.changeset/happy-emus-crash.md
@@ -1,0 +1,6 @@
+---
+"@smithy/signature-v4": minor
+"@smithy/types": minor
+---
+
+configurable hoisted headers

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -131,6 +131,7 @@ export class SignatureV4 implements RequestPresigner, RequestSigner, StringSigne
       unsignableHeaders,
       unhoistableHeaders,
       signableHeaders,
+      hoistableHeaders,
       signingRegion,
       signingService,
     } = options;
@@ -146,7 +147,7 @@ export class SignatureV4 implements RequestPresigner, RequestSigner, StringSigne
     }
 
     const scope = createScope(shortDate, region, signingService ?? this.service);
-    const request = moveHeadersToQuery(prepareRequest(originalRequest), { unhoistableHeaders });
+    const request = moveHeadersToQuery(prepareRequest(originalRequest), { unhoistableHeaders, hoistableHeaders });
 
     if (credentials.sessionToken) {
       request.query[TOKEN_QUERY_PARAM] = credentials.sessionToken;

--- a/packages/signature-v4/src/moveHeadersToQuery.spec.ts
+++ b/packages/signature-v4/src/moveHeadersToQuery.spec.ts
@@ -99,4 +99,36 @@ describe("moveHeadersToQuery", () => {
       SNAP: "crackle, pop",
     });
   });
+
+  it("should obey hoistableHeaders configuration over unhoistableHeaders", () => {
+    const req = moveHeadersToQuery(
+      new HttpRequest({
+        ...minimalRequest,
+        headers: {
+          Host: "www.example.com",
+          "X-Amz-Website-Redirect-Location": "/index.html",
+          Foo: "bar",
+          fizz: "buzz",
+          SNAP: "crackle, pop",
+          "X-Amz-Storage-Class": "STANDARD_IA",
+        },
+      }),
+      {
+        hoistableHeaders: new Set(["x-amz-website-redirect-location", "snap"]),
+        unhoistableHeaders: new Set(["x-amz-website-redirect-location"]),
+      }
+    );
+
+    expect(req.query).toEqual({
+      SNAP: "crackle, pop",
+      "X-Amz-Storage-Class": "STANDARD_IA",
+      "X-Amz-Website-Redirect-Location": "/index.html",
+    });
+
+    expect(req.headers).toEqual({
+      Host: "www.example.com",
+      Foo: "bar",
+      fizz: "buzz",
+    });
+  });
 });

--- a/packages/signature-v4/src/moveHeadersToQuery.ts
+++ b/packages/signature-v4/src/moveHeadersToQuery.ts
@@ -6,12 +6,15 @@ import type { HttpRequest as IHttpRequest, QueryParameterBag } from "@smithy/typ
  */
 export const moveHeadersToQuery = (
   request: IHttpRequest,
-  options: { unhoistableHeaders?: Set<string> } = {}
+  options: { unhoistableHeaders?: Set<string>; hoistableHeaders?: Set<string> } = {}
 ): IHttpRequest & { query: QueryParameterBag } => {
   const { headers, query = {} as QueryParameterBag } = HttpRequest.clone(request);
   for (const name of Object.keys(headers)) {
     const lname = name.toLowerCase();
-    if (lname.slice(0, 6) === "x-amz-" && !options.unhoistableHeaders?.has(lname)) {
+    if (
+      (lname.slice(0, 6) === "x-amz-" && !options.unhoistableHeaders?.has(lname)) ||
+      options.hoistableHeaders?.has(lname)
+    ) {
       query[name] = headers[name];
       delete headers[name];
     }

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -75,6 +75,12 @@ export interface RequestPresigningArguments extends RequestSigningArguments {
    * lower case and then checked for existence in the unhoistableHeaders set.
    */
   unhoistableHeaders?: Set<string>;
+
+  /**
+   * This overrides any values set by unhoistableHeaders.
+   * These headers will be hoisted into the query string and signed.
+   */
+  hoistableHeaders?: Set<string>;
 }
 
 /**

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -77,7 +77,7 @@ export interface RequestPresigningArguments extends RequestSigningArguments {
   unhoistableHeaders?: Set<string>;
 
   /**
-   * This overrides any values set by unhoistableHeaders.
+   * This overrides any headers with the same name(s) set by unhoistableHeaders.
    * These headers will be hoisted into the query string and signed.
    */
   hoistableHeaders?: Set<string>;


### PR DESCRIPTION
allows additive configuration over header hoisting with `hoistableHeaders`, where previously users could only configure the `unhoistableHeaders`.

For example, with S3, it was either incorrectly deduced or limited by S3 feature availability at the time that SSE headers were considered unhoistable. For backwards compatibility we will still default them to unhoisted, but as of today my testing shows this not to be true.

This change enables the following use case:

```ts
const params = {
  Key: "...",
  Bucket: "...",
  ServerSideEncryption: "aws:kms",
  SSEKMSKeyId: "arn:aws:kms:us-west-2:0000:key/abcd-1234-abcd",
};
const s3Client = new S3Client();
const command = new PutObjectCommand(params);

const preSignedUrl =
  (await getSignedUrl(s3Client, command, {
    hoistableHeaders: new Set(["x-amz-server-side-encryption", "x-amz-server-side-encryption-aws-kms-key-id"]),
  }));
```

context: https://github.com/aws/aws-sdk-js-v3/pull/1701