### PR TITLE
chore: add default accepts header for rpcv2Cbor

### DIFF
--- a/private/smithy-rpcv2-cbor/src/protocols/Rpcv2cbor.ts
+++ b/private/smithy-rpcv2-cbor/src/protocols/Rpcv2cbor.ts
@@ -1243,4 +1243,5 @@ const throwDefaultError = withBaseException(__BaseException);
 const SHARED_HEADERS: __HeaderBag = {
   "content-type": "application/cbor",
   "smithy-protocol": "rpc-v2-cbor",
+  accept: "application/cbor",
 };

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/SmithyRpcV2Cbor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/SmithyRpcV2Cbor.java
@@ -266,7 +266,8 @@ public class SmithyRpcV2Cbor extends HttpRpcProtocolGenerator {
         writer.openBlock("const SHARED_HEADERS: __HeaderBag = {", "};", () -> {
             writer.write("'content-type': $S,", getDocumentContentType());
             writer.write("""
-                "smithy-protocol": "rpc-v2-cbor"
+                "smithy-protocol": "rpc-v2-cbor",
+                "accept": "application/cbor",
                 """);
         });
     }


### PR DESCRIPTION
adds a default `accept: application/cbor` request header for the rpcv2cbor protocol.