### PR TITLE
fix: add uuid types when adding uuid

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -79,6 +79,7 @@ public enum TypeScriptDependency implements Dependency {
 
     NODE_CONFIG_PROVIDER("dependencies", "@smithy/node-config-provider", false),
 
+    UUID_TYPES("dependencies", "@types/uuid", "^9.0.1", false),
     UUID("dependencies", "uuid", "^9.0.1", false),
 
     // Conditionally added when httpChecksumRequired trait exists

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -881,7 +881,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         boolean isIdempotencyToken = binding.getMember().hasTrait(IdempotencyTokenTrait.class);
         if (isIdempotencyToken) {
-            writer.addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
+            writer
+                .addDependency(TypeScriptDependency.UUID_TYPES)
+                .addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
         }
         boolean isRequired = binding.getMember().isRequired();
         String idempotencyComponent = (isIdempotencyToken && !isRequired) ? " ?? generateIdempotencyToken()" : "";
@@ -1013,6 +1015,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         boolean isIdempotencyToken = binding.getMember().hasTrait(IdempotencyTokenTrait.class);
         if (isIdempotencyToken) {
             context.getWriter()
+                .addDependency(TypeScriptDependency.UUID_TYPES)
                 .addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/CborShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/CborShapeSerVisitor.java
@@ -127,7 +127,9 @@ public class CborShapeSerVisitor extends DocumentShapeSerVisitor {
                 boolean isUnaryCall = UnaryFunctionCall.check(valueExpression);
 
                 if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
-                    writer.addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
+                    writer
+                        .addDependency(TypeScriptDependency.UUID_TYPES)
+                        .addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
 
                     writer.write("'$L': [true, _ => _ ?? generateIdempotencyToken()],", memberName);
                 } else {


### PR DESCRIPTION
uuid doesn't import its own types package and is under an older system of having types in the `@types/` organization. 

This imports those types when importing `uuid`.