### PR TITLE
fix: allow blobs in Node.js splitStream fn

### DIFF
--- a/.changeset/rotten-fans-rest.md
+++ b/.changeset/rotten-fans-rest.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-stream": patch
+---
+
+allow Blob in node.js splitStream

--- a/packages/util-stream/src/splitStream.spec.ts
+++ b/packages/util-stream/src/splitStream.spec.ts
@@ -40,4 +40,19 @@ describe(splitStream.name, () => {
       expect(bytes1).toEqual(bytes2);
     }
   });
+  it("should split a web:Blob", async () => {
+    if (typeof Blob !== "undefined") {
+      const inputChunks = [97, 98, 99, 100];
+
+      const myBlob = new Blob([new Uint8Array(inputChunks)])
+
+      const [a, b] = await splitWebStream(myBlob);
+
+      const bytes1 = await webStreamCollector(a);
+      const bytes2 = await webStreamCollector(b);
+
+      expect(bytes1).toEqual(new Uint8Array([97, 98, 99, 100]));
+      expect(bytes1).toEqual(bytes2);
+    }
+  });
 });

--- a/packages/util-stream/src/splitStream.spec.ts
+++ b/packages/util-stream/src/splitStream.spec.ts
@@ -44,7 +44,7 @@ describe(splitStream.name, () => {
     if (typeof Blob !== "undefined") {
       const inputChunks = [97, 98, 99, 100];
 
-      const myBlob = new Blob([new Uint8Array(inputChunks)])
+      const myBlob = new Blob([new Uint8Array(inputChunks)]);
 
       const [a, b] = await splitWebStream(myBlob);
 

--- a/packages/util-stream/src/splitStream.ts
+++ b/packages/util-stream/src/splitStream.ts
@@ -2,7 +2,7 @@ import type { Readable } from "stream";
 import { PassThrough } from "stream";
 
 import { splitStream as splitWebStream } from "./splitStream.browser";
-import { isReadableStream } from "./stream-type-check";
+import { isBlob, isReadableStream } from "./stream-type-check";
 
 /**
  * @param stream
@@ -13,7 +13,7 @@ export async function splitStream(stream: ReadableStream): Promise<[ReadableStre
 export async function splitStream(
   stream: Readable | ReadableStream
 ): Promise<[Readable | ReadableStream, Readable | ReadableStream]> {
-  if (isReadableStream(stream)) {
+  if (isReadableStream(stream) || isBlob(stream)) {
     return splitWebStream(stream);
   }
   const stream1 = new PassThrough();

--- a/packages/util-stream/src/stream-type-check.ts
+++ b/packages/util-stream/src/stream-type-check.ts
@@ -12,3 +12,10 @@ type ReadableStreamType = ReadableStream;
 export const isReadableStream = (stream: unknown): stream is ReadableStreamType =>
   typeof ReadableStream === "function" &&
   (stream?.constructor?.name === ReadableStream.name || stream instanceof ReadableStream);
+
+/**
+ * @internal
+ */
+export const isBlob = (blob: unknown): blob is Blob => {
+  return typeof Blob === "function" && (blob?.constructor?.name === Blob.name || blob instanceof Blob);
+};


### PR DESCRIPTION
Allow blobs through the splitStream function in Node.js. 

This is not for a reported issue but I encountered this in testing.