### PR TITLE
removes smithy-team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @smithy-lang/aws-sdk-js-team @smithy-lang/smithy
+* @smithy-lang/aws-sdk-js-team
 


### PR DESCRIPTION
see also: https://github.com/aws/aws-sdk-js-v3/pull/6616

The AWS SDK for JavaScript team will take over codeowner responsibilities with the Smithy team participating ad hoc.