### PR TITLE
fix: avoid self referencing import for external build transforms

### DIFF
--- a/.changeset/sweet-horses-impress.md
+++ b/.changeset/sweet-horses-impress.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+avoid self referencing submodule import

--- a/packages/core/scripts/lint.js
+++ b/packages/core/scripts/lint.js
@@ -110,6 +110,19 @@ const walk = require("../../../scripts/utils/walk");
         );
       }
     }
+
+    const subModuleImports = [
+      ...new Set(
+        (sourceCode.toString().match(/(from |import\()"\@smithy\/core\/(.*?)";/g) || []).map(
+          (_) => _.match(/@smithy\/core\/(.*?)"/)[1]
+        )
+      ),
+    ];
+    const ownModule = item.match(/src\/submodules\/(.*?)\//)?.[1];
+
+    if (subModuleImports.includes(ownModule)) {
+      errors.push(`self-referencing submodule import found in ${item}`);
+    }
   }
 })().then(() => {
   if (errors.length) {

--- a/packages/core/src/submodules/protocols/requestBuilder.ts
+++ b/packages/core/src/submodules/protocols/requestBuilder.ts
@@ -1,6 +1,7 @@
-import { resolvedPath } from "@smithy/core/protocols";
 import { HttpRequest } from "@smithy/protocol-http";
 import type { SerdeContext } from "@smithy/types";
+
+import { resolvedPath } from "./resolve-path";
 
 /**
  * @internal


### PR DESCRIPTION
In one of the submodules there is a fully qualified import pointed to itself. 

This works in Node.js, but I believe some build transforms may have trouble with it as reported in https://github.com/aws/aws-sdk-js-v3/issues/6626.

This PR moves the import and adds a custom linter to prevent this pattern.