### PR TITLE
fix: prevent infinite recursion with NoUndefined and RecursiveRequired re: DocumentType

### DIFF
--- a/packages/types/src/transform/no-undefined.spec.ts
+++ b/packages/types/src/transform/no-undefined.spec.ts
@@ -3,6 +3,7 @@ import type { Client } from "../client";
 import { CommandIO } from "../command";
 import type { HttpHandlerOptions } from "../http";
 import type { MetadataBearer } from "../response";
+import { DocumentType } from "../shapes";
 import type { Exact } from "./exact";
 import type { AssertiveClient, NoUndefined, UncheckedClient } from "./no-undefined";
 
@@ -13,6 +14,7 @@ type A = {
   required: string | undefined;
   optional?: string;
   nested: A;
+  document: DocumentType;
 };
 
 {
@@ -22,6 +24,8 @@ type A = {
   const assert1: Exact<T["required"], string> = true as const;
   const assert2: Exact<T["nested"]["required"], string> = true as const;
   const assert3: Exact<T["nested"]["nested"]["required"], string> = true as const;
+  const assert4: Exact<T["document"], DocumentType> = true as const;
+  const assert5: Exact<T["nested"]["document"], DocumentType> = true as const;
 }
 
 {
@@ -30,6 +34,7 @@ type A = {
     b: number | undefined;
     c: string | number | undefined;
     optional?: string;
+    document: DocumentType | undefined;
   };
 
   type MyOutput = {
@@ -37,6 +42,7 @@ type A = {
     b?: number;
     c?: string | number;
     r?: MyOutput;
+    document?: DocumentType;
   } & MetadataBearer;
 
   type MyConfig = {
@@ -66,6 +72,7 @@ type A = {
       a: "",
       b: 0,
       c: 0,
+      document: { aa: "b" },
     };
     const get = c.getObject(input);
     const output = null as unknown as Awaited<typeof get>;
@@ -73,10 +80,12 @@ type A = {
     const assert1: Exact<typeof output.a, string | undefined> = true as const;
     const assert2: Exact<typeof output.b, number | undefined> = true as const;
     const assert3: Exact<typeof output.c, string | number | undefined> = true as const;
+    const assert4: Exact<typeof output.document, DocumentType | undefined> = true as const;
     if (output.r) {
-      const assert4: Exact<typeof output.r.a, string | undefined> = true as const;
-      const assert5: Exact<typeof output.r.b, number | undefined> = true as const;
-      const assert6: Exact<typeof output.r.c, string | number | undefined> = true as const;
+      const assert5: Exact<typeof output.r.a, string | undefined> = true as const;
+      const assert6: Exact<typeof output.r.b, number | undefined> = true as const;
+      const assert7: Exact<typeof output.r.c, string | number | undefined> = true as const;
+      const assert8: Exact<typeof output.r.document, DocumentType | undefined> = true as const;
     }
   }
 
@@ -88,6 +97,7 @@ type A = {
       a: "",
       b: 0,
       c: 0,
+      document: { aa: "b" },
     };
     const get = c.getObject(input);
     const output = null as unknown as Awaited<typeof get>;
@@ -95,9 +105,11 @@ type A = {
     const assert1: Exact<typeof output.a, string> = true as const;
     const assert2: Exact<typeof output.b, number> = true as const;
     const assert3: Exact<typeof output.c, string | number> = true as const;
-    const assert4: Exact<typeof output.r.a, string> = true as const;
-    const assert5: Exact<typeof output.r.b, number> = true as const;
-    const assert6: Exact<typeof output.r.c, string | number> = true as const;
+    const assert4: Exact<typeof output.document, DocumentType> = true as const;
+    const assert5: Exact<typeof output.r.a, string> = true as const;
+    const assert6: Exact<typeof output.r.b, number> = true as const;
+    const assert7: Exact<typeof output.r.c, string | number> = true as const;
+    const assert8: Exact<typeof output.r.document, DocumentType> = true as const;
   }
 
   {
@@ -109,10 +121,12 @@ type A = {
     const assert1: Exact<typeof output.a, string | undefined> = true as const;
     const assert2: Exact<typeof output.b, number | undefined> = true as const;
     const assert3: Exact<typeof output.c, string | number | undefined> = true as const;
+    const assert4: Exact<typeof output.document, DocumentType | undefined> = true as const;
     if (output.r) {
-      const assert4: Exact<typeof output.r.a, string | undefined> = true as const;
-      const assert5: Exact<typeof output.r.b, number | undefined> = true as const;
-      const assert6: Exact<typeof output.r.c, string | number | undefined> = true as const;
+      const assert5: Exact<typeof output.r.a, string | undefined> = true as const;
+      const assert6: Exact<typeof output.r.b, number | undefined> = true as const;
+      const assert7: Exact<typeof output.r.c, string | number | undefined> = true as const;
+      const assert8: Exact<typeof output.r.document, DocumentType | undefined> = true as const;
     }
   }
 
@@ -125,10 +139,12 @@ type A = {
     const assert1: Exact<typeof output.a, string | undefined> = true as const;
     const assert2: Exact<typeof output.b, number | undefined> = true as const;
     const assert3: Exact<typeof output.c, string | number | undefined> = true as const;
+    const assert4: Exact<typeof output.document, DocumentType | undefined> = true as const;
     if (output.r) {
-      const assert4: Exact<typeof output.r.a, string | undefined> = true as const;
-      const assert5: Exact<typeof output.r.b, number | undefined> = true as const;
-      const assert6: Exact<typeof output.r.c, string | number | undefined> = true as const;
+      const assert5: Exact<typeof output.r.a, string | undefined> = true as const;
+      const assert6: Exact<typeof output.r.b, number | undefined> = true as const;
+      const assert7: Exact<typeof output.r.c, string | number | undefined> = true as const;
+      const assert8: Exact<typeof output.r.document, DocumentType | undefined> = true as const;
     }
   }
 }

--- a/packages/types/src/transform/no-undefined.ts
+++ b/packages/types/src/transform/no-undefined.ts
@@ -1,5 +1,6 @@
 import type { InvokeMethod, InvokeMethodOptionalArgs } from "../client";
 import type { GetOutputType } from "../command";
+import type { DocumentType } from "../shapes"
 
 /**
  * @public
@@ -33,7 +34,9 @@ export type UncheckedClient<Client extends object> = UncheckedClientOutputTypes<
  * Excludes undefined recursively.
  */
 export type NoUndefined<T> = T extends Function
-  ? T
+  ? T 
+  : T extends DocumentType
+  ? T 
   : [T] extends [object]
     ? {
         [key in keyof T]: NoUndefined<T[key]>;
@@ -46,6 +49,8 @@ export type NoUndefined<T> = T extends Function
  * Excludes undefined and optional recursively.
  */
 export type RecursiveRequired<T> = T extends Function
+  ? T
+  : T extends DocumentType
   ? T
   : [T] extends [object]
     ? {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When trying to use `AssertiveClient` or `UncheckedClient` for a request that contains a field of type `DocumentType` results in the following TypeScript error:

```
 error TS2589: Type instantiation is excessively deep and possibly infinite.
```

### Cause

Inside the `AssertiveClient` type definition, the `NoUndefined` type:

```
export type NoUndefined<T> = T extends Function ? T : [T] extends [object] ? {
    [key in keyof T]: NoUndefined<T[key]>;
} : Exclude<T, undefined>;
```

recursively iterates excluding `undefined`. The issue stems from the type `DocumentType` since it is self-referential which results in an infinite loop.

```
export type DocumentType = null | boolean | number | string | DocumentType[] | {
    [prop: string]: DocumentType;
};
```

### Fix

Update the `NoUndefined` and `RecursiveRequired` types to ignore `DocumentType` fields:

```
export type NoUndefined<T> = T extends Function
  ? T 
  : T extends DocumentType
  ? T 
  : [T] extends [object]
    ? {
        [key in keyof T]: NoUndefined<T[key]>;
      }
    : Exclude<T, undefined>;
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
