### PR TITLE
fix(core): use unique symbol to indicate tags for cbor serialization

### DIFF
--- a/.changeset/sweet-planets-give.md
+++ b/.changeset/sweet-planets-give.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+make CBOR tags more distinct in JS

--- a/packages/core/src/submodules/cbor/cbor-decode.ts
+++ b/packages/core/src/submodules/cbor/cbor-decode.ts
@@ -26,6 +26,7 @@ import {
   specialNull,
   specialTrue,
   specialUndefined,
+  tag,
   Uint8,
   Uint32,
   Uint64,
@@ -122,7 +123,7 @@ export function decode(at: Uint32, to: Uint32): CborValueType {
         const valueOffset = _offset;
 
         _offset = offset + valueOffset;
-        return { tag: castBigInt(unsignedInt), value };
+        return tag({ tag: castBigInt(unsignedInt), value });
       }
     case majorUtf8String:
     case majorMap:

--- a/packages/core/src/submodules/cbor/cbor-encode.ts
+++ b/packages/core/src/submodules/cbor/cbor-encode.ts
@@ -187,7 +187,9 @@ export function encode(_input: any): void {
           encodeHeader(majorTag, input.tag);
           continue;
         } else {
-          throw new Error("tag encountered with missing fields, need 'tag' and 'value', found: " + JSON.stringify(input));
+          throw new Error(
+            "tag encountered with missing fields, need 'tag' and 'value', found: " + JSON.stringify(input)
+          );
         }
       }
       const keys = Object.keys(input);

--- a/packages/core/src/submodules/cbor/cbor-encode.ts
+++ b/packages/core/src/submodules/cbor/cbor-encode.ts
@@ -9,12 +9,14 @@ import {
   majorMap,
   majorNegativeInt64,
   majorSpecial,
+  majorTag,
   majorUint64,
   majorUnstructuredByteString,
   majorUtf8String,
   specialFalse,
   specialNull,
   specialTrue,
+  tagSymbol,
   Uint64,
 } from "./cbor-types";
 import { alloc } from "./cbor-types";
@@ -179,6 +181,15 @@ export function encode(_input: any): void {
       cursor += input.byteLength;
       continue;
     } else if (typeof input === "object") {
+      if (input[tagSymbol]) {
+        if ("tag" in input && "value" in input) {
+          encodeStack.push(input.value);
+          encodeHeader(majorTag, input.tag);
+          continue;
+        } else {
+          throw new Error("tag encountered with missing fields, need 'tag' and 'value', found: " + JSON.stringify(input));
+        }
+      }
       const keys = Object.keys(input);
       for (let i = keys.length - 1; i >= 0; --i) {
         const key = keys[i];

--- a/packages/core/src/submodules/cbor/cbor-types.ts
+++ b/packages/core/src/submodules/cbor/cbor-types.ts
@@ -10,6 +10,7 @@ export type CborItemType =
 export type CborTagType = {
   tag: Uint64 | number;
   value: CborValueType;
+  [tagSymbol]: true;
 };
 export type CborUnstructuredByteStringType = Uint8Array;
 export type CborListType<T = any> = Array<T>;
@@ -65,4 +66,27 @@ export const minorIndefinite = 31; // 0b11111
 
 export function alloc(size: number) {
   return typeof Buffer !== "undefined" ? Buffer.alloc(size) : new Uint8Array(size);
+}
+
+/**
+ * @public
+ *
+ * The presence of this symbol as an object key indicates it should be considered a tag
+ * for CBOR serialization purposes.
+ *
+ * The object must also have the properties "tag" and "value".
+ */
+export const tagSymbol = Symbol("@smithy/core/cbor::tagSymbol");
+
+/**
+ * @public
+ * Applies the tag symbol to the object.
+ */
+export function tag(data: { tag: number | bigint; value: any; [tagSymbol]?: true }): {
+  tag: number | bigint;
+  value: any;
+  [tagSymbol]: true;
+} {
+  data[tagSymbol] = true;
+  return data as typeof data & { [tagSymbol]: true };
 }

--- a/packages/core/src/submodules/cbor/cbor.ts
+++ b/packages/core/src/submodules/cbor/cbor.ts
@@ -17,8 +17,13 @@ export const cbor = {
     return decode(0, payload.length);
   },
   serialize(input: any) {
-    encode(input);
-    return toUint8Array();
+    try {
+      encode(input);
+      return toUint8Array();
+    } catch (e) {
+      toUint8Array(); // resets cursor.
+      throw e;
+    }
   },
   /**
    * @public

--- a/packages/core/src/submodules/cbor/index.ts
+++ b/packages/core/src/submodules/cbor/index.ts
@@ -1,2 +1,3 @@
 export { cbor } from "./cbor";
 export * from "./parseCborBody";
+export { tagSymbol, tag } from "./cbor-types";

--- a/packages/core/src/submodules/cbor/parseCborBody.ts
+++ b/packages/core/src/submodules/cbor/parseCborBody.ts
@@ -4,6 +4,7 @@ import { HeaderBag as __HeaderBag, HttpResponse, SerdeContext as __SerdeContext,
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 
 import { cbor } from "./cbor";
+import { tag, tagSymbol } from "./cbor-types";
 
 /**
  * @internal
@@ -27,11 +28,11 @@ export const parseCborBody = (streamBody: any, context: SerdeContext): any => {
 /**
  * @internal
  */
-export const dateToTag = (date: Date): { tag: 1; value: number } => {
-  return {
+export const dateToTag = (date: Date): { tag: number | bigint; value: any; [tagSymbol]: true } => {
+  return tag({
     tag: 1,
     value: date.getTime() / 1000,
-  };
+  });
 };
 
 /**


### PR DESCRIPTION
This PR fixes tag serialization for CBOR. 

There was no previous way to distinguish an actual tag as opposed to a map that structurally resembled a tag like
`{ tag: 1, value: 100 }`.