### PR TITLE
fix(node-http-handler): skip sending body without waiting for a timeout on response, if "expect" request header with "100-continue" is provided

### DIFF
--- a/.changeset/hungry-eels-accept.md
+++ b/.changeset/hungry-eels-accept.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+skip sending body without waiting for a timeout on response, if "expect" request header with "100-continue" is provided

--- a/packages/node-http-handler/src/write-request-body.spec.ts
+++ b/packages/node-http-handler/src/write-request-body.spec.ts
@@ -1,0 +1,62 @@
+import EventEmitter from "events";
+import { describe, expect, test as it, vi } from "vitest";
+
+import { writeRequestBody } from "./write-request-body";
+
+describe(writeRequestBody.name, () => {
+  it("should wait for the continue event if request has expect=100-continue", async () => {
+    const httpRequest = Object.assign(new EventEmitter(), {
+      end: vi.fn(),
+    }) as any;
+    const request = {
+      headers: {
+        expect: "100-continue",
+      },
+      body: Buffer.from("abcd"),
+      method: "GET",
+      hostname: "",
+      protocol: "https:",
+      path: "/",
+    };
+    let done: (value?: unknown) => void;
+    const promise = new Promise((r) => (done = r));
+    setTimeout(async () => {
+      httpRequest.emit("continue", {});
+      done();
+    }, 25);
+    await writeRequestBody(httpRequest, request);
+    expect(httpRequest.end).toHaveBeenCalled();
+    await promise;
+  });
+  it(
+    "should not send the body if the request is expect=100-continue" +
+      "but a response is received before the continue event",
+    async () => {
+      const httpRequest = Object.assign(new EventEmitter(), {
+        end: vi.fn(),
+      }) as any;
+      const request = {
+        headers: {
+          expect: "100-continue",
+        },
+        body: {
+          pipe: vi.fn(),
+        },
+        method: "GET",
+        hostname: "",
+        protocol: "https:",
+        path: "/",
+      };
+      let done: (value?: unknown) => void;
+      const promise = new Promise((r) => (done = r));
+      setTimeout(() => {
+        httpRequest.emit("response", {});
+        done();
+      }, 25);
+      await writeRequestBody(httpRequest, request);
+      expect(request.body.pipe).not.toHaveBeenCalled();
+      expect(httpRequest.end).not.toHaveBeenCalled();
+      await promise;
+    }
+  );
+});

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -23,40 +23,38 @@ export async function writeRequestBody(
   const expect = headers["Expect"] || headers["expect"];
 
   let timeoutId = -1;
-  let skipWritingBody = false;
+  let sendBody = true;
 
   if (expect === "100-continue") {
-    await Promise.race<void>([
+    sendBody = await Promise.race<boolean>([
       new Promise((resolve) => {
         timeoutId = Number(timing.setTimeout(resolve, Math.max(MIN_WAIT_TIME, maxContinueTimeoutMs)));
       }),
       new Promise((resolve) => {
         httpRequest.on("continue", () => {
           timing.clearTimeout(timeoutId);
-          resolve();
+          resolve(true);
         });
         httpRequest.on("response", () => {
           // if this handler is called, then response is
           // already received and there is no point in
           // sending body or waiting
-          skipWritingBody = true;
           timing.clearTimeout(timeoutId);
-          resolve();
+          resolve(false);
         });
         httpRequest.on("error", () => {
-          skipWritingBody = true;
           timing.clearTimeout(timeoutId);
           // this handler does not reject with the error
           // because there is already an error listener
           // on the request in node-http-handler
           // and node-http2-handler.
-          resolve();
+          resolve(false);
         });
       }),
     ]);
   }
 
-  if (!skipWritingBody) {
+  if (sendBody) {
     writeBody(httpRequest, request.body);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, S3 in AWS-SDK uses "expect: 100-continue" header.
In case of errors, for example "403 Forbidden", the request fails only on timeout. This happens because while sendRequestBody is waiting for "continue" event, a "response" event is fired and "continue" is not fired at all.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
