### PR TITLE
add support for error cause in transient error checks

### DIFF
--- a/.changeset/good-dots-run.md
+++ b/.changeset/good-dots-run.md
@@ -1,0 +1,6 @@
+---
+"@smithy/service-error-classification": patch
+"@smithy/types": patch
+---
+
+add support for error cause in transient error checks

--- a/packages/service-error-classification/src/index.spec.ts
+++ b/packages/service-error-classification/src/index.spec.ts
@@ -15,14 +15,16 @@ const checkForErrorType = (
     name?: string;
     httpStatusCode?: number;
     $retryable?: RetryableTrait;
+    cause?: Partial<Error>;
   },
   errorTypeResult: boolean
 ) => {
-  const { name, httpStatusCode, $retryable } = options;
+  const { name, httpStatusCode, $retryable, cause } = options;
   const error = Object.assign(new Error(), {
     name,
     $metadata: { httpStatusCode },
     $retryable,
+    cause,
   });
   expect(isErrorTypeFunc(error as SdkError)).toBe(errorTypeResult);
 };
@@ -127,6 +129,12 @@ describe("isTransientError", () => {
       break;
     }
   }
+
+  TRANSIENT_ERROR_CODES.forEach((name) => {
+    it(`should declare error with cause with the name "${name}" to be a Transient error`, () => {
+      checkForErrorType(isTransientError, { cause: { name } }, true);
+    });
+  });
 });
 
 describe("isServerError", () => {

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -35,7 +35,8 @@ export const isTransientError = (error: SdkError) =>
   isClockSkewCorrectedError(error) ||
   TRANSIENT_ERROR_CODES.includes(error.name) ||
   NODEJS_TIMEOUT_ERROR_CODES.includes((error as { code?: string })?.code || "") ||
-  TRANSIENT_ERROR_STATUS_CODES.includes(error.$metadata?.httpStatusCode || 0);
+  TRANSIENT_ERROR_STATUS_CODES.includes(error.$metadata?.httpStatusCode || 0) ||
+  (error.cause !== undefined && isTransientError(error.cause));
 
 export const isServerError = (error: SdkError) => {
   if (error.$metadata?.httpStatusCode !== undefined) {

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -90,4 +90,5 @@ export type SdkError = Error &
        */
       readonly clockSkewCorrected?: true;
     };
+    cause?: Error;
   };


### PR DESCRIPTION
*Issue #1446 

*Description of changes:*

Updates `isTransientError` to recursively check the `cause` property if the underlying error is also transient. This continues until either the error cause chain is exhausted or a causing error is determined to be transient. This correctly annotates node http2 errors which wrap `ETIMEDOUT` errors.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
