### PR TITLE
remove String extension in LazyJsonString

### DIFF
--- a/.changeset/warm-dragons-wash.md
+++ b/.changeset/warm-dragons-wash.md
@@ -1,5 +1,5 @@
 ---
-"@smithy/smithy-client": major
+"@smithy/smithy-client": minor
 ---
 
 remove String extension in LazyJsonString

--- a/.changeset/warm-dragons-wash.md
+++ b/.changeset/warm-dragons-wash.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": major
+---
+
+remove String extension in LazyJsonString

--- a/packages/smithy-client/src/lazy-json.spec.ts
+++ b/packages/smithy-client/src/lazy-json.spec.ts
@@ -1,27 +1,44 @@
 import { describe, expect, test as it } from "vitest";
 
 import { LazyJsonString } from "./lazy-json";
+
 describe("LazyJsonString", () => {
-  it("returns identical values for toString(), valueOf(), and toJSON()", () => {
-    const jsonValue = LazyJsonString.from({ foo: "bar" });
-    expect(jsonValue.valueOf()).toBe(JSON.stringify({ foo: "bar" }));
-    expect(jsonValue.toString()).toBe(JSON.stringify({ foo: "bar" }));
-    expect(jsonValue.toJSON()).toBe(JSON.stringify({ foo: "bar" }));
+  it("should have string methods", () => {
+    const jsonValue = new LazyJsonString('"foo"');
+    expect(jsonValue.length).toBe(5);
+    expect(jsonValue.toString()).toBe('"foo"');
+  });
+
+  it("should deserialize json properly", () => {
+    const jsonValue = new LazyJsonString('"foo"');
+    expect(jsonValue.deserializeJSON()).toBe("foo");
+    const wrongJsonValue = new LazyJsonString("foo");
+    expect(() => wrongJsonValue.deserializeJSON()).toThrow();
+  });
+
+  it("should get JSON string properly", () => {
+    const jsonValue = new LazyJsonString('{"foo", "bar"}');
+    expect(jsonValue.toJSON()).toBe('{"foo", "bar"}');
   });
 
   it("can instantiate from LazyJsonString class", () => {
-    const original = LazyJsonString.from('"foo"');
+    const original = new LazyJsonString('"foo"');
     const newOne = LazyJsonString.from(original);
     expect(newOne.toString()).toBe('"foo"');
   });
 
   it("can instantiate from String class", () => {
-    const jsonValue = LazyJsonString.from('"foo"');
+    const jsonValue = LazyJsonString.from(new String('"foo"'));
     expect(jsonValue.toString()).toBe('"foo"');
   });
 
   it("can instantiate from object", () => {
     const jsonValue = LazyJsonString.from({ foo: "bar" });
     expect(jsonValue.toString()).toBe('{"foo":"bar"}');
+  });
+
+  it("passes instanceof String check", () => {
+    const jsonValue = LazyJsonString.from({ foo: "bar" });
+    expect(jsonValue).toBeInstanceOf(String);
   });
 });

--- a/packages/smithy-client/src/lazy-json.spec.ts
+++ b/packages/smithy-client/src/lazy-json.spec.ts
@@ -2,37 +2,26 @@ import { describe, expect, test as it } from "vitest";
 
 import { LazyJsonString } from "./lazy-json";
 describe("LazyJsonString", () => {
-  it("should has string methods", () => {
-    const jsonValue = new LazyJsonString('"foo"');
-    expect(jsonValue.length).toBe(5);
-    expect(jsonValue.toString()).toBe('"foo"');
-  });
-
-  it("should deserialize json properly", () => {
-    const jsonValue = new LazyJsonString('"foo"');
-    expect(jsonValue.deserializeJSON()).toBe("foo");
-    const wrongJsonValue = new LazyJsonString("foo");
-    expect(() => wrongJsonValue.deserializeJSON()).toThrow();
-  });
-
-  it("should get JSON string properly", () => {
-    const jsonValue = new LazyJsonString('{"foo", "bar"}');
-    expect(jsonValue.toJSON()).toBe('{"foo", "bar"}');
+  it("returns identical values for toString(), valueOf(), and toJSON()", () => {
+    const jsonValue = LazyJsonString.from({ foo: "bar" });
+    expect(jsonValue.valueOf()).toBe(JSON.stringify({ foo: "bar" }));
+    expect(jsonValue.toString()).toBe(JSON.stringify({ foo: "bar" }));
+    expect(jsonValue.toJSON()).toBe(JSON.stringify({ foo: "bar" }));
   });
 
   it("can instantiate from LazyJsonString class", () => {
-    const original = new LazyJsonString('"foo"');
-    const newOne = LazyJsonString.fromObject(original);
+    const original = LazyJsonString.from('"foo"');
+    const newOne = LazyJsonString.from(original);
     expect(newOne.toString()).toBe('"foo"');
   });
 
   it("can instantiate from String class", () => {
-    const jsonValue = LazyJsonString.fromObject(new String('"foo"'));
+    const jsonValue = LazyJsonString.from('"foo"');
     expect(jsonValue.toString()).toBe('"foo"');
   });
 
   it("can instantiate from object", () => {
-    const jsonValue = LazyJsonString.fromObject({ foo: "bar" });
+    const jsonValue = LazyJsonString.from({ foo: "bar" });
     expect(jsonValue.toString()).toBe('{"foo":"bar"}');
   });
 });

--- a/packages/smithy-client/src/lazy-json.ts
+++ b/packages/smithy-client/src/lazy-json.ts
@@ -1,39 +1,73 @@
 /**
+ * @public
+ *
+ * A model field with this type means that you may provide a JavaScript
+ * object in lieu of a JSON string, and it will be serialized to JSON
+ * automatically before being sent in a request.
+ *
+ * For responses, you will receive a "LazyJsonString", which is a boxed String object
+ * with additional mixin methods.
+ * To get the string value, call `.toString()`, or to get the JSON object value,
+ * call `.deserializeJSON()` or parse it yourself.
+ */
+export type AutomaticJsonStringConversion = Parameters<typeof JSON.stringify>[0] | LazyJsonString;
+
+/**
  * @internal
  *
- * This class allows the usage of data objects in fields that expect
- * JSON strings. It serializes the data object into JSON
- * if needed during the request serialization step.
- *
  */
-export class LazyJsonString {
-  private constructor(private value: string) {}
-
-  public toString(): string {
-    return this.value;
-  }
-
-  public valueOf(): string {
-    return this.value;
-  }
-
-  public toJSON(): string {
-    return this.value;
-  }
-
-  public static from(object: any): LazyJsonString {
-    if (object instanceof LazyJsonString) {
-      return object;
-    } else if (typeof object === "string") {
-      return new LazyJsonString(object);
-    }
-    return new LazyJsonString(JSON.stringify(object));
-  }
+export interface LazyJsonString extends String {
+  new (s: string): typeof LazyJsonString;
 
   /**
-   * @deprecated call from() instead.
+   * @returns the JSON parsing of the string value.
    */
-  public static fromObject(object: any): LazyJsonString {
-    return LazyJsonString.from(object);
-  }
+  deserializeJSON(): any;
+
+  /**
+   * @returns the original string value rather than a JSON.stringified value.
+   */
+  toJSON(): string;
 }
+
+/**
+ * @internal
+ *
+ * Extension of the native String class in the previous implementation
+ * has negative global performance impact on method dispatch for strings,
+ * and is generally discouraged.
+ *
+ * This current implementation may look strange, but is necessary to preserve the interface and
+ * behavior of extending the String class.
+ */
+export function LazyJsonString(val: string): void {
+  const str = Object.assign(new String(val), {
+    deserializeJSON() {
+      return JSON.parse(String(val));
+    },
+
+    toString() {
+      return String(val);
+    },
+
+    toJSON() {
+      return String(val);
+    },
+  });
+
+  return str as never;
+}
+
+LazyJsonString.from = (object: any): LazyJsonString => {
+  if (object && typeof object === "object" && (object instanceof LazyJsonString || "deserializeJSON" in object)) {
+    return object as any;
+  } else if (typeof object === "string" || Object.getPrototypeOf(object) === String.prototype) {
+    return LazyJsonString(String(object) as string) as any;
+  }
+  return LazyJsonString(JSON.stringify(object)) as any;
+};
+
+/**
+ * @deprecated use from.
+ */
+LazyJsonString.fromObject = LazyJsonString.from;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -300,8 +300,12 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         if (mediaTypeTrait.isPresent()) {
             String mediaType = mediaTypeTrait.get().getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
-                Symbol.Builder builder = createSymbolBuilder(shape, "__LazyJsonString | string");
-                return addSmithyUseImport(builder, "LazyJsonString", "__LazyJsonString").build();
+                Symbol.Builder builder = createSymbolBuilder(shape, "__AutomaticJsonStringConversion | string");
+                return addSmithyUseImport(
+                    builder,
+                    "AutomaticJsonStringConversion",
+                    "__AutomaticJsonStringConversion"
+                ).build();
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -176,7 +176,7 @@ public final class HttpProtocolGeneratorUtils {
             if (CodegenUtils.isJsonMediaType(mediaType)) {
                 TypeScriptWriter writer = context.getWriter();
                 writer.addImport("LazyJsonString", "__LazyJsonString", TypeScriptDependency.AWS_SMITHY_CLIENT);
-                return "__LazyJsonString.fromObject(" + dataSource + ")";
+                return "__LazyJsonString.from(" + dataSource + ")";
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
             }
@@ -210,7 +210,7 @@ public final class HttpProtocolGeneratorUtils {
             if (CodegenUtils.isJsonMediaType(mediaType)) {
                 TypeScriptWriter writer = context.getWriter();
                 writer.addImport("LazyJsonString", "__LazyJsonString", TypeScriptDependency.AWS_SMITHY_CLIENT);
-                return "new __LazyJsonString(" + dataSource + ")";
+                return "__LazyJsonString.from(" + dataSource + ")";
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
             }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -191,7 +191,7 @@ public class SymbolProviderTest {
         SymbolProvider provider = new SymbolVisitor(model, settings);
         Symbol memberSymbol = provider.toSymbol(member);
 
-        assertThat(memberSymbol.getName(), equalTo("__LazyJsonString | string"));
+        assertThat(memberSymbol.getName(), equalTo("__AutomaticJsonStringConversion | string"));
     }
 
     @Test

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -98,7 +98,7 @@ public class DocumentMemberDeserVisitorTest {
                 {StringShape.builder().id(id).build(), "__expectString(" + DATA_SOURCE + ")", source},
                 {
                     StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
-                    "new __LazyJsonString(" + DATA_SOURCE + ")",
+                    "__LazyJsonString.from(" + DATA_SOURCE + ")",
                     source
                 },
                 {BlobShape.builder().id(id).build(), "context.base64Decoder(" + DATA_SOURCE + ")", source},

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -83,7 +83,7 @@ public class DocumentMemberSerVisitorTest {
                 {StringShape.builder().id(id).build(), DATA_SOURCE},
                 {
                     StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
-                    "__LazyJsonString.fromObject(" + DATA_SOURCE + ")"
+                    "__LazyJsonString.from(" + DATA_SOURCE + ")"
                 },
                 {BlobShape.builder().id(id).build(), "context.base64Encoder(" + DATA_SOURCE + ")"},
                 {DocumentShape.builder().id(id).build(), delegate},


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/6182

removes String extension, which causes global string de-optimization. Refactors LazyJsonString to use a boxed String with mixins rather than extending String.