### PR TITLE
fix for operationContextParam codegen

### DIFF
--- a/.changeset/thick-socks-cross.md
+++ b/.changeset/thick-socks-cross.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+fix for operation context params

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,6 +198,13 @@ subprojects {
                     exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
                 }
             }
+        } else {
+            tasks.test {
+                testLogging {
+                    events("failed")
+                    exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+                }
+            }
         }
 
         /*

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
@@ -92,6 +92,9 @@ export const resolveParams = async <
       case "builtInParams":
         endpointParams[name] = await createConfigValueProvider<Config>(instruction.name, name, clientConfig)();
         break;
+      case "operationContextParams":
+        endpointParams[name] = instruction.get(commandInput);
+        break;
       default:
         throw new Error("Unrecognized endpoint parameter instruction: " + JSON.stringify(instruction));
     }

--- a/packages/middleware-endpoint/src/types.ts
+++ b/packages/middleware-endpoint/src/types.ts
@@ -6,7 +6,8 @@ export interface EndpointParameterInstructions {
     | BuiltInParamInstruction
     | ClientContextParamInstruction
     | StaticContextParamInstruction
-    | ContextParamInstruction;
+    | ContextParamInstruction
+    | OperationContextParamInstruction;
 }
 
 /**
@@ -39,4 +40,12 @@ export interface StaticContextParamInstruction {
 export interface ContextParamInstruction {
   type: "contextParams";
   name: string; // The input structure's member name that has contextParams trait
+}
+
+/**
+ * @internal
+ */
+export interface OperationContextParamInstruction {
+  type: "operationContextParams";
+  get(input: any): any;
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -344,7 +344,7 @@ final class CommandGenerator implements Runnable {
             operationContextParamValues.forEach((name, jmesPathForInputInJs) -> {
                 writer.write(
                     """
-                    $L: { type: \"operationContextParams\", name: $L },
+                    $L: { type: \"operationContextParams\", get: (input: any) => $L },
                     """,
                     name, jmesPathForInputInJs);
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -344,7 +344,7 @@ final class CommandGenerator implements Runnable {
             operationContextParamValues.forEach((name, jmesPathForInputInJs) -> {
                 writer.write(
                     """
-                    $L: { type: \"operationContextParams\", get: (input: any) => $L },
+                    $L: { type: \"operationContextParams\", get: (input?: any) => $L },
                     """,
                     name, jmesPathForInputInJs);
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -274,7 +274,7 @@ public class RuleSetParameterFinder {
         Optional<OperationContextParamsTrait> trait = operation.getTrait(OperationContextParamsTrait.class);
         if (trait.isPresent()) {
             trait.get().getParameters().forEach((name, definition) -> {
-                String separator = ".";
+                String separator = "?.";
                 String value = "input";
                 String path = definition.getPath();
 
@@ -289,13 +289,13 @@ public class RuleSetParameterFinder {
                     if (part.startsWith("keys(")) {
                         // Get provided object for which keys are to be extracted.
                         String object = part.substring(5, part.length() - 1);
-                        value = "Object.keys(" + value + separator + object + ")";
+                        value = "Object.keys(" + value + separator + object + " ?? {})";
                         continue;
                     }
 
                     // Process list wildcard expression https://jmespath.org/specification.html#wildcard-expressions
                     if (part.equals("*") || part.equals("[*]")) {
-                        value = "Object.values(" + value + ")";
+                        value = "Object.values(" + value + " ?? {})";
                         continue;
                     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -275,14 +275,14 @@ public class RuleSetParameterFinder {
         if (trait.isPresent()) {
             trait.get().getParameters().forEach((name, definition) -> {
                 String separator = ".";
-                String value = "this" + separator + "input";
+                String value = "input";
                 String path = definition.getPath();
 
                 // Split JMESPath expression string on separator and add JavaScript equivalent.
                 for (String part : path.split("[" + separator + "]")) {
                     if (value.endsWith(")")) {
                         // The value is an object, which needs to run on map.
-                        value += ".map(obj => obj";
+                        value += ".map((obj: any) => obj";
                     }
 
                     // Process keys https://jmespath.org/specification.html#keys
@@ -303,7 +303,7 @@ public class RuleSetParameterFinder {
                     if (part.endsWith("[*]")) {
                         // Get key to run hash wildcard on.
                         String key = part.substring(0, part.length() - 3);
-                        value = value + separator + key + separator + "map(obj => obj";
+                        value = value + separator + key + separator + "map((obj: any) => obj";
                         continue;
                     }
 
@@ -312,8 +312,9 @@ public class RuleSetParameterFinder {
                 }
 
                 // Remove no-op map, if it exists.
-                if (value.endsWith(separator + "map(obj => obj")) {
-                    value = value.substring(0, value.length() - 15);
+                final String noOpMap = "map((obj: any) => obj";
+                if (value.endsWith(separator + noOpMap)) {
+                    value = value.substring(0, value.length() - noOpMap.length() - separator.length());
                 }
 
                 // Close all open brackets.

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -39,12 +39,12 @@ public class CommandGeneratorTest {
         testCommmandCodegen(
             "endpointsV2/endpoints-operation-context-params.smithy",
             new String[] {
-                "opContextParamIdentifier: { type: \"operationContextParams\", name: this.input.fooString }",
-                "opContextParamSubExpression: { type: \"operationContextParams\", name: this.input.fooObj.bar }",
-                "opContextParamWildcardExpressionList: { type: \"operationContextParams\", name: this.input.fooList }",
-                "opContextParamWildcardExpressionListObj: { type: \"operationContextParams\", name: this.input.fooListObj.map(obj => obj.key) }",
-                "opContextParamWildcardExpressionHash: { type: \"operationContextParams\", name: Object.values(this.input.fooObjObj).map(obj => obj.bar) }",
-                "opContextParamKeys: { type: \"operationContextParams\", name: Object.keys(this.input.fooKeys) }",
+                "opContextParamIdentifier: { type: \"operationContextParams\", get: (input: any) => input.fooString }",
+                "opContextParamSubExpression: { type: \"operationContextParams\", get: (input: any) => input.fooObj.bar }",
+                "opContextParamWildcardExpressionList: { type: \"operationContextParams\", get: (input: any) => input.fooList }",
+                "opContextParamWildcardExpressionListObj: { type: \"operationContextParams\", get: (input: any) => input.fooListObj.map((obj: any) => obj.key) }",
+                "opContextParamWildcardExpressionHash: { type: \"operationContextParams\", get: (input: any) => Object.values(input.fooObjObj).map((obj: any) => obj.bar) }",
+                "opContextParamKeys: { type: \"operationContextParams\", get: (input: any) => Object.keys(input.fooKeys) }",
             }
         );
     }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -39,12 +39,12 @@ public class CommandGeneratorTest {
         testCommmandCodegen(
             "endpointsV2/endpoints-operation-context-params.smithy",
             new String[] {
-                "opContextParamIdentifier: { type: \"operationContextParams\", get: (input: any) => input.fooString }",
-                "opContextParamSubExpression: { type: \"operationContextParams\", get: (input: any) => input.fooObj.bar }",
-                "opContextParamWildcardExpressionList: { type: \"operationContextParams\", get: (input: any) => input.fooList }",
-                "opContextParamWildcardExpressionListObj: { type: \"operationContextParams\", get: (input: any) => input.fooListObj.map((obj: any) => obj.key) }",
-                "opContextParamWildcardExpressionHash: { type: \"operationContextParams\", get: (input: any) => Object.values(input.fooObjObj).map((obj: any) => obj.bar) }",
-                "opContextParamKeys: { type: \"operationContextParams\", get: (input: any) => Object.keys(input.fooKeys) }",
+                "opContextParamIdentifier: { type: \"operationContextParams\", get: (input?: any) => input?.fooString }",
+                "opContextParamSubExpression: { type: \"operationContextParams\", get: (input?: any) => input?.fooObj?.bar }",
+                "opContextParamWildcardExpressionList: { type: \"operationContextParams\", get: (input?: any) => input?.fooList }",
+                "opContextParamWildcardExpressionListObj: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObj?.map((obj: any) => obj?.key) }",
+                "opContextParamWildcardExpressionHash: { type: \"operationContextParams\", get: (input?: any) => Object.values(input?.fooObjObj ?? {}).map((obj: any) => obj?.bar) }",
+                "opContextParamKeys: { type: \"operationContextParams\", get: (input?: any) => Object.keys(input?.fooKeys ?? {}) }",
             }
         );
     }


### PR DESCRIPTION
Internal JS-5629

This PR fixes codegen for operationContextParam by changing the path expression result into a mapping function based on the command's input. The getter functions are made non-throwing so as not to perform unintentional client side validation.