### PR TITLE
fix(fetch-http-handler): add polyfill to collect Blob in react-native

### DIFF
--- a/.changeset/metal-emus-chew.md
+++ b/.changeset/metal-emus-chew.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": patch
+---
+
+Add polyfill to collect Blob in react-native environments

--- a/packages/fetch-http-handler/src/stream-collector.ts
+++ b/packages/fetch-http-handler/src/stream-collector.ts
@@ -1,12 +1,22 @@
 import { StreamCollector } from "@smithy/types";
+import { fromBase64 } from "@smithy/util-base64";
 
 export const streamCollector: StreamCollector = async (stream: Blob | ReadableStream): Promise<Uint8Array> => {
   if ((typeof Blob === "function" && stream instanceof Blob) || stream.constructor?.name === "Blob") {
-    return new Uint8Array(await (stream as Blob).arrayBuffer());
+    if (Blob.prototype.arrayBuffer !== undefined) {
+      return new Uint8Array(await (stream as Blob).arrayBuffer());
+    }
+    return collectBlob(stream as Blob);
   }
 
   return collectStream(stream as ReadableStream);
 };
+
+async function collectBlob(blob: Blob): Promise<Uint8Array> {
+  const base64 = await readToBase64(blob);
+  const arrayBuffer = fromBase64(base64);
+  return new Uint8Array(arrayBuffer);
+}
 
 async function collectStream(stream: ReadableStream): Promise<Uint8Array> {
   const chunks = [];
@@ -31,4 +41,27 @@ async function collectStream(stream: ReadableStream): Promise<Uint8Array> {
   }
 
   return collected;
+}
+
+function readToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      // reference: https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
+      // response from readAsDataURL is always prepended with "data:*/*;base64,"
+      if (reader.readyState !== 2) {
+        return reject(new Error("Reader aborted too early"));
+      }
+      const result = (reader.result ?? "") as string;
+      // Response can include only 'data:' for empty blob, return empty string in this case.
+      // Otherwise, return the string after ','
+      const commaIndex = result.indexOf(",");
+      const dataOffset = commaIndex > -1 ? commaIndex + 1 : result.length;
+      resolve(result.substring(dataOffset));
+    };
+    reader.onabort = () => reject(new Error("Read aborted"));
+    reader.onerror = () => reject(reader.error);
+    // reader.readAsArrayBuffer is not always available
+    reader.readAsDataURL(blob);
+  });
 }


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws-samples/aws-sdk-js-tests/issues/223
* https://github.com/aws/aws-sdk-js-v3/issues/6733
* https://github.com/aws/aws-sdk-js-v3/issues/6636
* https://github.com/aws/aws-sdk-js-v3/issues/6626#issuecomment-2506443781

*Description of changes:*

Adds polyfill to collect Blob in react-native environment where arrayBuffer API is not available.
This re-introduces the code removed in https://github.com/smithy-lang/smithy-typescript/pull/1179, but only when `Blob.prototype.arrayBuffer` implementation is not available.

Tested by copying fetch-http-handler artifacts to https://github.com/aws-samples/aws-sdk-js-tests/issues/223, and verifying that API call is successful.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
