### PR TITLE
feat(smithy-client): add isInstance method for ServiceException class

### DIFF
--- a/.changeset/warm-pans-cross.md
+++ b/.changeset/warm-pans-cross.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": minor
+---
+
+feat: type check helper method to to know if something is an instance of the ServiceException class

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -34,36 +34,54 @@ it("ExceptionOptionType allows specifying message", () => {
   expect(exception.code).toBe("code");
 });
 
-describe("ServiceException.isInstance", () => {
-  it("should return true for valid ServiceException instances", () => {
-    const error = new ServiceException({
-      name: "Error",
-      $fault: "client",
-      $metadata: {},
+describe("ServiceException type checking", () => {
+  const error = new ServiceException({
+    name: "Error",
+    $fault: "client",
+    $metadata: {},
+  });
+
+  const duckTyped = {
+    $fault: "server",
+    $metadata: {},
+  };
+
+  describe("isInstance", () => {
+    it("should return true for ServiceException instances", () => {
+      expect(ServiceException.isInstance(error)).toBe(true);
     });
-    expect(ServiceException.isInstance(error)).toBe(true);
+
+    it("should return true for duck-typed objects", () => {
+      expect(ServiceException.isInstance(duckTyped)).toBe(true);
+    });
+
+    it("should return false for null or undefined", () => {
+      expect(ServiceException.isInstance(null)).toBe(false);
+      expect(ServiceException.isInstance(undefined)).toBe(false);
+    });
+
+    it("should return false for invalid $fault values", () => {
+      expect(ServiceException.isInstance({ $fault: "invalid", $metadata: {} })).toBe(false);
+    });
+
+    it("should return false for missing properties", () => {
+      expect(ServiceException.isInstance({ $fault: "client" })).toBe(false);
+      expect(ServiceException.isInstance({ $metadata: {} })).toBe(false);
+    });
   });
 
-  it("should return true for valid duck-typed objects", () => {
-    const duckTyped = {
-      $fault: "server",
-      $metadata: {},
-    };
-    expect(ServiceException.isInstance(duckTyped)).toBe(true);
-  });
+  describe("instanceof", () => {
+    it("should return true for ServiceException instances", () => {
+      expect(error instanceof ServiceException).toBe(true);
+    });
 
-  it("should return false for null or undefined", () => {
-    expect(ServiceException.isInstance(null)).toBe(false);
-    expect(ServiceException.isInstance(undefined)).toBe(false);
-  });
+    it("should return true for duck-typed objects", () => {
+      expect(duckTyped instanceof ServiceException).toBe(true);
+    });
 
-  it("should return false for invalid $fault values", () => {
-    expect(ServiceException.isInstance({ $fault: "invalid", $metadata: {} })).toBe(false);
-  });
-
-  it("should return false for missing properties", () => {
-    expect(ServiceException.isInstance({ $fault: "client" })).toBe(false);
-    expect(ServiceException.isInstance({ $metadata: {} })).toBe(false);
+    it("should return false for invalid objects", () => {
+      expect({} instanceof ServiceException).toBe(false);
+    });
   });
 });
 

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -34,6 +34,39 @@ it("ExceptionOptionType allows specifying message", () => {
   expect(exception.code).toBe("code");
 });
 
+describe("ServiceException.isInstance", () => {
+  it("should return true for valid ServiceException instances", () => {
+    const error = new ServiceException({
+      name: "Error",
+      $fault: "client",
+      $metadata: {},
+    });
+    expect(ServiceException.isInstance(error)).toBe(true);
+  });
+
+  it("should return true for valid duck-typed objects", () => {
+    const duckTyped = {
+      $fault: "server",
+      $metadata: {},
+    };
+    expect(ServiceException.isInstance(duckTyped)).toBe(true);
+  });
+
+  it("should return false for null or undefined", () => {
+    expect(ServiceException.isInstance(null)).toBe(false);
+    expect(ServiceException.isInstance(undefined)).toBe(false);
+  });
+
+  it("should return false for invalid $fault values", () => {
+    expect(ServiceException.isInstance({ $fault: "invalid", $metadata: {} })).toBe(false);
+  });
+
+  it("should return false for missing properties", () => {
+    expect(ServiceException.isInstance({ $fault: "client" })).toBe(false);
+    expect(ServiceException.isInstance({ $metadata: {} })).toBe(false);
+  });
+});
+
 describe("decorateServiceException", () => {
   const exception = new ServiceException({
     name: "Error",

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -51,7 +51,7 @@ export class ServiceException extends Error implements SmithyException, Metadata
     );
   }
 
-  static [Symbol.hasInstance](instance: unknown) {
+  public static [Symbol.hasInstance](instance: unknown) {
     return ServiceException.isInstance(instance);
   }
 }

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -37,6 +37,19 @@ export class ServiceException extends Error implements SmithyException, Metadata
     this.$fault = options.$fault;
     this.$metadata = options.$metadata;
   }
+
+  /**
+   * Checks if a value is an instance of ServiceException (duck typed)
+   */
+  public static isInstance(value: unknown): value is ServiceException {
+    if (!value) return false;
+    const candidate = value as ServiceException;
+    return (
+      Boolean(candidate.$fault) &&
+      Boolean(candidate.$metadata) &&
+      (candidate.$fault === "client" || candidate.$fault === "server")
+    );
+  }
 }
 
 /**

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -50,6 +50,10 @@ export class ServiceException extends Error implements SmithyException, Metadata
       (candidate.$fault === "client" || candidate.$fault === "server")
     );
   }
+
+  static [Symbol.hasInstance](instance: unknown) {
+    return ServiceException.isInstance(instance);
+  }
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5478

*Description of changes:*
Adds an `isInstance` type check helper method for generic `ServiceException` class in `smithy-client`.

`ServiceException.isInstance(e)`/ `e instanceof ServiceException` should now tell if something is an instance of the generic `ServiceException` class

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
