### PR TITLE
fix(smithy-client): remove support for instanceof operator in ServiceException

### DIFF
--- a/.changeset/curvy-cups-fly.md
+++ b/.changeset/curvy-cups-fly.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": minor
+---
+
+fix(smithy-client): remove support for instanceof operator

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -69,20 +69,6 @@ describe("ServiceException type checking", () => {
       expect(ServiceException.isInstance({ $metadata: {} })).toBe(false);
     });
   });
-
-  describe("instanceof", () => {
-    it("should return true for ServiceException instances", () => {
-      expect(error instanceof ServiceException).toBe(true);
-    });
-
-    it("should return true for duck-typed objects", () => {
-      expect(duckTyped instanceof ServiceException).toBe(true);
-    });
-
-    it("should return false for invalid objects", () => {
-      expect({} instanceof ServiceException).toBe(false);
-    });
-  });
 });
 
 describe("decorateServiceException", () => {

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -50,10 +50,6 @@ export class ServiceException extends Error implements SmithyException, Metadata
       (candidate.$fault === "client" || candidate.$fault === "server")
     );
   }
-
-  public static [Symbol.hasInstance](instance: unknown) {
-    return ServiceException.isInstance(instance);
-  }
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5642

*Description of changes:*
remove support for `instanceof` operator (at least temporarily) owing to https://github.com/aws/aws-sdk-js-v3/issues/6771 

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
