### PR TITLE
chore(package.json): bump engines and @types/node to >=18.x

### DIFF
--- a/.changeset/lazy-doors-exist.md
+++ b/.changeset/lazy-doors-exist.md
@@ -1,0 +1,28 @@
+---
+"@smithy/service-client-documentation-generator": major
+"@smithy/eventstream-serde-universal": major
+"@smithy/util-defaults-mode-browser": major
+"@smithy/credential-provider-imds": major
+"@smithy/util-defaults-mode-node": major
+"@smithy/eventstream-serde-node": major
+"@smithy/shared-ini-file-loader": major
+"@smithy/util-body-length-node": major
+"@smithy/node-config-provider": major
+"@smithy/util-config-provider": major
+"@smithy/eventstream-codec": major
+"@smithy/node-http-handler": major
+"@smithy/hash-stream-node": major
+"@smithy/util-buffer-from": major
+"@smithy/util-stream-node": major
+"@smithy/util-middleware": major
+"@smithy/util-endpoints": major
+"@smithy/smithy-client": major
+"@smithy/util-base64": major
+"@smithy/util-stream": major
+"@smithy/util-retry": major
+"@smithy/hash-node": major
+"@smithy/md5-js": major
+"@smithy/core": major
+---
+
+drop node16 support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: "yarn"
 
       - name: Set up JDK ${{ matrix.java }}
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: "yarn"
       - name: Install dependencies
         run: yarn
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 20, 22]
+        node: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: "yarn"
       - name: Install dependencies
         run: yarn
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: "yarn"
       - name: Install
         run: yarn

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 For Client SDK code generation, the `typescript-client-codegen` plugin provides a framework for generating extensible TypeScript clients that can support multiple JavaScript platforms, including Node.js, Browser, and React-Native. See [the section on generating a client to see how to get started](#generating-a-client), or [the `typescript-client-codegen` documentation](#client-sdk-code-generation-typescript-client-codegen-plugin).
 
-> Note: Node.js support includes versions >= 16, and is subject to change.
+> Note: Node.js support includes versions >= 18, and is subject to change.
 
 For Server SDK code generation, the `typescript-server-codegen` plugin provides a framework for generating server scaffolding at a higher level of abstraction and with type safety. More documentation can be found at in [the `typescript-server-codegen` documentation](#server-sdk-code-generation-typescript-server-codegen-plugin), or [smithy.io](https://smithy.io/2.0/ts-ssdk/index.html).
 

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -29,7 +29,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -37,7 +37,7 @@
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {
@@ -87,7 +87,7 @@
     "directory": "packages/core"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "json-bigint": "^1.0.0",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -34,7 +34,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -42,7 +42,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@smithy/util-utf8": "workspace:^",
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -27,14 +27,14 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -29,14 +29,14 @@
   },
   "devDependencies": {
     "@smithy/util-utf8": "workspace:^",
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "hash-test-vectors": "^1.3.2",
@@ -37,7 +37,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -30,14 +30,14 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "5.2.0",
     "@smithy/util-hex-encoding": "workspace:^",
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@smithy/util-base64": "workspace:^",
     "@smithy/util-hex-encoding": "workspace:^",
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "hash-test-vectors": "^1.3.2",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -31,7 +31,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-compression/package.json
+++ b/packages/middleware-compression/package.json
@@ -35,7 +35,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -29,7 +29,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -40,7 +40,7 @@
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -52,7 +52,7 @@
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -29,7 +29,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -36,7 +36,7 @@
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -31,14 +31,14 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -33,14 +33,14 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -29,7 +29,7 @@
     "typedoc": "0.23.23"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -29,7 +29,7 @@
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -6,7 +6,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -45,7 +45,7 @@
     "./dist-es/slurpFile": false
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -42,7 +42,7 @@
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {
@@ -52,7 +52,7 @@
     "directory": "packages/smithy-client"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<=4.0": {

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -36,7 +36,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -16,7 +16,7 @@
     "test:watch": "yarn g:vitest watch"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -34,7 +34,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -34,7 +34,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -28,14 +28,14 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -30,7 +30,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -32,7 +32,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -41,7 +41,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -27,7 +27,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -31,7 +31,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -39,7 +39,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-retry/package.json
+++ b/packages/util-retry/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
@@ -41,7 +41,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -27,14 +27,14 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-stream-node/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-node/src/sdk-stream-mixin.ts
@@ -46,15 +46,11 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<Readable> => {
         // Prevent side effect of consuming webstream.
         throw new Error("The stream has been consumed by other callbacks.");
       }
-      // @ts-expect-error toWeb() is only available in Node.js >= 17.0.0
       if (typeof Readable.toWeb !== "function") {
-        throw new Error(
-          "Readable.toWeb() is not supported. Please make sure you are using Node.js >= 17.0.0, or polyfill is available."
-        );
+        throw new Error("Readable.toWeb() is not supported. Please make ensure a polyfill is available.");
       }
       transformed = true;
-      // @ts-expect-error toWeb() is only available in Node.js >= 17.0.0
-      return Readable.toWeb(stream);
+      return Readable.toWeb(stream) as ReadableStream;
     },
   });
 };

--- a/packages/util-stream-node/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-node/src/sdk-stream-mixin.ts
@@ -47,7 +47,7 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<Readable> => {
         throw new Error("The stream has been consumed by other callbacks.");
       }
       if (typeof Readable.toWeb !== "function") {
-        throw new Error("Readable.toWeb() is not supported. Please make ensure a polyfill is available.");
+        throw new Error("Readable.toWeb() is not supported. Please ensure a polyfill is available.");
       }
       transformed = true;
       return Readable.toWeb(stream) as ReadableStream;

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -39,14 +39,14 @@
   },
   "devDependencies": {
     "@smithy/util-test": "workspace:^",
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-stream/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.spec.ts
@@ -146,14 +146,12 @@ describe(sdkStreamMixin.name, () => {
     });
 
     describe("when Readable.toWeb() is not supported", () => {
-      // @ts-expect-error
       const originalToWebImpl = Readable.toWeb;
       beforeAll(() => {
         // @ts-expect-error
         Readable.toWeb = undefined;
       });
       afterAll(() => {
-        // @ts-expect-error
         Readable.toWeb = originalToWebImpl;
       });
 
@@ -169,22 +167,18 @@ describe(sdkStreamMixin.name, () => {
     });
 
     describe("when Readable.toWeb() is supported", () => {
-      // @ts-expect-error
       const originalToWebImpl = Readable.toWeb;
       beforeAll(() => {
-        // @ts-expect-error
         Readable.toWeb = vi.fn().mockReturnValue("A web stream");
       });
 
       afterAll(() => {
-        // @ts-expect-error
         Readable.toWeb = originalToWebImpl;
       });
 
       it("should transform Node stream to web stream", async () => {
         const sdkStream = sdkStreamMixin(passThrough);
         sdkStream.transformToWebStream();
-        // @ts-expect-error
         expect(Readable.toWeb).toBeCalled();
       });
 

--- a/packages/util-stream/src/sdk-stream-mixin.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.ts
@@ -55,7 +55,7 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<ReadableStream | Blob
         throw new Error("The stream has been consumed by other callbacks.");
       }
       if (typeof Readable.toWeb !== "function") {
-        throw new Error("Readable.toWeb() is not supported. Please make ensure a polyfill is available.");
+        throw new Error("Readable.toWeb() is not supported. Please ensure a polyfill is available.");
       }
       transformed = true;
       return Readable.toWeb(stream) as ReadableStream;

--- a/packages/util-stream/src/sdk-stream-mixin.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.ts
@@ -54,15 +54,11 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<ReadableStream | Blob
         // Prevent side effect of consuming webstream.
         throw new Error("The stream has been consumed by other callbacks.");
       }
-      // @ts-expect-error toWeb() is only available in Node.js >= 17.0.0
       if (typeof Readable.toWeb !== "function") {
-        throw new Error(
-          "Readable.toWeb() is not supported. Please make sure you are using Node.js >= 17.0.0, or polyfill is available."
-        );
+        throw new Error("Readable.toWeb() is not supported. Please make ensure a polyfill is available.");
       }
       transformed = true;
-      // @ts-expect-error toWeb() is only available in Node.js >= 17.0.0
-      return Readable.toWeb(stream);
+      return Readable.toWeb(stream) as ReadableStream;
     },
   });
 };

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -34,7 +34,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -29,7 +29,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/smithy-rpcv2-cbor/package.json
+++ b/private/smithy-rpcv2-cbor/package.json
@@ -47,14 +47,14 @@
   },
   "devDependencies": {
     "@tsconfig/node16": "16.1.3",
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.19.69",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "^3.0.0",
     "typescript": "~4.9.5"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/smithy-rpcv2-cbor/package.json
+++ b/private/smithy-rpcv2-cbor/package.json
@@ -46,7 +46,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node16": "16.1.3",
+    "@tsconfig/node18": "18.2.4",
     "@types/node": "^18.19.69",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/smithy-rpcv2-cbor/package.json
+++ b/private/smithy-rpcv2-cbor/package.json
@@ -51,7 +51,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "^3.0.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.2.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/private/smithy-rpcv2-cbor/src/runtimeConfig.ts
+++ b/private/smithy-rpcv2-cbor/src/runtimeConfig.ts
@@ -25,14 +25,17 @@ export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
     runtime: "node",
     defaultsMode,
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
-    maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+    maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
-      loadNodeConfig({
-        ...NODE_RETRY_MODE_CONFIG_OPTIONS,
-        default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
-      }),
+      loadNodeConfig(
+        {
+          ...NODE_RETRY_MODE_CONFIG_OPTIONS,
+          default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
+        },
+        config
+      ),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };

--- a/private/smithy-rpcv2-cbor/tsconfig.es.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.es.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "lib": ["dom"],
-    "module": "esnext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "outDir": "dist-es"
   }
 }

--- a/private/smithy-rpcv2-cbor/tsconfig.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/util-test/package.json
+++ b/private/util-test/package.json
@@ -21,7 +21,7 @@
     "tslib": "^2.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "concurrently": "7.0.0",

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -160,7 +160,7 @@ module.exports = class Inliner {
 
     const buildOptions = {
       platform: this.platform,
-      target: ["node16"],
+      target: ["node18"],
       bundle: true,
       format: "cjs",
       mainFields: ["main"],

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -45,7 +45,7 @@ public enum TypeScriptDependency implements Dependency {
     AWS_SMITHY_CLIENT("dependencies", "@smithy/smithy-client", true),
     INVALID_DEPENDENCY("dependencies", "@smithy/invalid-dependency", true),
     CONFIG_RESOLVER("dependencies", "@smithy/config-resolver", true),
-    TYPES_NODE("devDependencies", "@types/node", "^16.18.96", true),
+    TYPES_NODE("devDependencies", "@types/node", "^18.11.9", true),
 
     MIDDLEWARE_CONTENT_LENGTH("dependencies", "@smithy/middleware-content-length", true),
     MIDDLEWARE_SERDE("dependencies", "@smithy/middleware-serde", true),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -45,7 +45,7 @@ public enum TypeScriptDependency implements Dependency {
     AWS_SMITHY_CLIENT("dependencies", "@smithy/smithy-client", true),
     INVALID_DEPENDENCY("dependencies", "@smithy/invalid-dependency", true),
     CONFIG_RESOLVER("dependencies", "@smithy/config-resolver", true),
-    TYPES_NODE("devDependencies", "@types/node", "^18.11.9", true),
+    TYPES_NODE("devDependencies", "@types/node", "^18.19.69", true),
 
     MIDDLEWARE_CONTENT_LENGTH("dependencies", "@smithy/middleware-content-length", true),
     MIDDLEWARE_SERDE("dependencies", "@smithy/middleware-serde", true),

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.9.5"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -23,7 +23,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "^3.0.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.2.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -19,7 +19,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node16": "16.1.3",
+    "@tsconfig/node18": "18.2.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "^3.0.0",

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "lib": ["dom"],
-    "module": "esnext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "outDir": "dist-es"
   }
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -38,7 +38,7 @@
     "downlevel-dts": "^0.7.0",
     "jest": "29.7.0",
     "rimraf": "^3.0.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.2.2"
   },
   "files": [
     "dist/cjs/**/*.js",

--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -33,7 +33,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "^0.7.0",
     "jest": "29.7.0",
@@ -47,7 +47,7 @@
     "!**/*.spec.*"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/smithy-typescript-ssdk-libs/server-apigateway/tsconfig.es.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "esnext",
+    "module": "ESNext",
     "outDir": "dist/es"
   }
 }

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -33,7 +33,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "^0.7.0",
     "jest": "29.7.0",
@@ -47,7 +47,7 @@
     "!**/*.spec.*"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -38,7 +38,7 @@
     "downlevel-dts": "^0.7.0",
     "jest": "29.7.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.9.5"
+    "typescript": "~5.2.2"
   },
   "files": [
     "dist/cjs/**/*.js",

--- a/smithy-typescript-ssdk-libs/server-common/tsconfig.es.json
+++ b/smithy-typescript-ssdk-libs/server-common/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "esnext",
+    "module": "ESNext",
     "outDir": "dist/es"
   }
 }

--- a/smithy-typescript-ssdk-libs/server-node/package.json
+++ b/smithy-typescript-ssdk-libs/server-node/package.json
@@ -32,7 +32,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/node": "^16.18.96",
+    "@types/node": "^18.11.9",
     "concurrently": "7.0.0",
     "downlevel-dts": "^0.7.0",
     "jest": "29.7.0",
@@ -46,7 +46,7 @@
     "!**/*.spec.*"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/smithy-typescript-ssdk-libs/server-node/package.json
+++ b/smithy-typescript-ssdk-libs/server-node/package.json
@@ -37,7 +37,7 @@
     "downlevel-dts": "^0.7.0",
     "jest": "29.7.0",
     "rimraf": "^3.0.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.2.2"
   },
   "files": [
     "dist/cjs/**/*.js",

--- a/smithy-typescript-ssdk-libs/server-node/tsconfig.es.json
+++ b/smithy-typescript-ssdk-libs/server-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "esnext",
+    "module": "ESNext",
     "outDir": "dist/es"
   }
 }

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
-    "module": "esnext",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "noEmitHelpers": false,
     "target": "ES2020",
     "strict": true

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "noEmitHelpers": false,
     "target": "ES2020",
     "strict": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,7 +2821,7 @@ __metadata:
     "@smithy/util-middleware": "workspace:^"
     "@smithy/util-retry": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@tsconfig/node16": 16.1.3
+    "@tsconfig/node18": 18.2.4
     "@types/node": ^18.19.69
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
@@ -3151,10 +3151,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16@npm:16.1.3":
-  version: 16.1.3
-  resolution: "@tsconfig/node16@npm:16.1.3"
-  checksum: 097f33cb7fe9577cc3c4b7a8d26c7e8b6c45c868d3bda1e2cd120111693b98f88a5138e643e7a6f79d53d94717c3624dc33398804647bf6e0e8782604bbfad53
+"@tsconfig/node18@npm:18.2.4":
+  version: 18.2.4
+  resolution: "@tsconfig/node18@npm:18.2.4"
+  checksum: 80623cb9c129c78d51fe6c4a256ba986f12f02ff02dc2a1e5b33dd13a7983f767b6792cfcd51b3dd1c8256ea105f1fea31f64a2070564e37787ab3d9a1a1e7e3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,7 +113,7 @@ __metadata:
     jest: 29.7.0
     rimraf: ^3.0.2
     tslib: ^1.8.0
-    typescript: ~4.9.5
+    typescript: ~5.2.2
   languageName: unknown
   linkType: soft
 
@@ -130,7 +130,7 @@ __metadata:
     re2-wasm: ^1.0.2
     rimraf: ^3.0.2
     tslib: ^1.8.0
-    typescript: ^4.9.5
+    typescript: ~5.2.2
   languageName: unknown
   linkType: soft
 
@@ -146,7 +146,7 @@ __metadata:
     jest: 29.7.0
     rimraf: ^3.0.2
     tslib: ^1.8.0
-    typescript: ~4.9.5
+    typescript: ~5.2.2
   languageName: unknown
   linkType: soft
 
@@ -2827,7 +2827,7 @@ __metadata:
     downlevel-dts: 0.10.1
     rimraf: ^3.0.0
     tslib: ^2.6.2
-    typescript: ~4.9.5
+    typescript: ~5.2.2
   languageName: unknown
   linkType: soft
 
@@ -9996,7 +9996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.1.0-dev.20201026, typescript@npm:^4.9.5, typescript@npm:~4.9.5":
+"typescript@npm:^4.1.0-dev.20201026":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
@@ -10036,7 +10036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.1.0-dev.20201026#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>, typescript@patch:typescript@~4.9.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.1.0-dev.20201026#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,7 @@ __metadata:
     "@smithy/protocol-http": "workspace:^"
     "@smithy/types": "workspace:^"
     "@types/aws-lambda": ^8.10.72
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: ^0.7.0
     jest: 29.7.0
@@ -123,7 +123,7 @@ __metadata:
   dependencies:
     "@smithy/protocol-http": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: ^0.7.0
     jest: 29.7.0
@@ -140,7 +140,7 @@ __metadata:
   dependencies:
     "@smithy/protocol-http": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: ^0.7.0
     jest: 29.7.0
@@ -2266,7 +2266,7 @@ __metadata:
     "@smithy/util-middleware": "workspace:^"
     "@smithy/util-stream": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     json-bigint: ^1.0.0
@@ -2284,7 +2284,7 @@ __metadata:
     "@smithy/property-provider": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/url-parser": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2301,7 +2301,7 @@ __metadata:
     "@smithy/types": "workspace:^"
     "@smithy/util-hex-encoding": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2343,7 +2343,7 @@ __metadata:
   dependencies:
     "@smithy/eventstream-serde-universal": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2359,7 +2359,7 @@ __metadata:
     "@smithy/eventstream-codec": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2428,7 +2428,7 @@ __metadata:
     "@smithy/types": "workspace:^"
     "@smithy/util-buffer-from": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     hash-test-vectors: ^1.3.2
@@ -2446,7 +2446,7 @@ __metadata:
     "@smithy/types": "workspace:^"
     "@smithy/util-hex-encoding": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2497,7 +2497,7 @@ __metadata:
     "@smithy/util-base64": "workspace:^"
     "@smithy/util-hex-encoding": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     hash-test-vectors: ^1.3.2
@@ -2634,7 +2634,7 @@ __metadata:
     "@smithy/property-provider": "workspace:^"
     "@smithy/shared-ini-file-loader": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2651,7 +2651,7 @@ __metadata:
     "@smithy/protocol-http": "workspace:^"
     "@smithy/querystring-builder": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2717,7 +2717,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/service-client-documentation-generator@workspace:packages/service-client-documentation-generator"
   dependencies:
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2743,7 +2743,7 @@ __metadata:
   resolution: "@smithy/shared-ini-file-loader@workspace:packages/shared-ini-file-loader"
   dependencies:
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2782,7 +2782,7 @@ __metadata:
     "@smithy/protocol-http": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/util-stream": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2863,7 +2863,7 @@ __metadata:
   dependencies:
     "@smithy/util-buffer-from": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2888,7 +2888,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/util-body-length-node@workspace:packages/util-body-length-node"
   dependencies:
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2912,7 +2912,7 @@ __metadata:
   resolution: "@smithy/util-buffer-from@workspace:packages/util-buffer-from"
   dependencies:
     "@smithy/is-array-buffer": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2925,7 +2925,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/util-config-provider@workspace:packages/util-config-provider"
   dependencies:
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2941,7 +2941,7 @@ __metadata:
     "@smithy/property-provider": "workspace:^"
     "@smithy/smithy-client": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     bowser: ^2.11.0
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
@@ -2961,7 +2961,7 @@ __metadata:
     "@smithy/property-provider": "workspace:^"
     "@smithy/smithy-client": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -2976,7 +2976,7 @@ __metadata:
   dependencies:
     "@smithy/node-config-provider": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -3002,7 +3002,7 @@ __metadata:
   resolution: "@smithy/util-middleware@workspace:packages/util-middleware"
   dependencies:
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -3017,7 +3017,7 @@ __metadata:
   dependencies:
     "@smithy/service-error-classification": "workspace:^"
     "@smithy/types": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -3050,7 +3050,7 @@ __metadata:
     "@smithy/node-http-handler": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/util-buffer-from": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -3071,7 +3071,7 @@ __metadata:
     "@smithy/util-hex-encoding": "workspace:^"
     "@smithy/util-test": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
-    "@types/node": ^16.18.96
+    "@types/node": ^18.11.9
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: 3.0.2
@@ -3367,14 +3367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.18.96":
-  version: 16.18.97
-  resolution: "@types/node@npm:16.18.97"
-  checksum: 54f44aaeaa523d4c728177d070aeb20b8011e12ac45aff0d992e350e10cac4d899ac6429cd0f06a6c3a001c8a6cd204429b1a16628d82f1b1e4cc1cbdeca780f
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^18.19.69":
+"@types/node@npm:^18.11.9, @types/node@npm:^18.19.69":
   version: 18.19.70
   resolution: "@types/node@npm:18.19.70"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,7 +2822,7 @@ __metadata:
     "@smithy/util-retry": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
     "@tsconfig/node16": 16.1.3
-    "@types/node": ^16.18.96
+    "@types/node": ^18.19.69
     concurrently: 7.0.0
     downlevel-dts: 0.10.1
     rimraf: ^3.0.0
@@ -3371,6 +3371,15 @@ __metadata:
   version: 16.18.97
   resolution: "@types/node@npm:16.18.97"
   checksum: 54f44aaeaa523d4c728177d070aeb20b8011e12ac45aff0d992e350e10cac4d899ac6429cd0f06a6c3a001c8a6cd204429b1a16628d82f1b1e4cc1cbdeca780f
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.19.69":
+  version: 18.19.70
+  resolution: "@types/node@npm:18.19.70"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 6ce382b659a03fb694b8af4bbf3a397c0f8b6448ab4c0f17fc58de8fe649c474146b88c0317ab0ccb50ce9e251464498b0aa43227f1626d4f65bd196cbae6764
   languageName: node
   linkType: hard
 
@@ -10100,6 +10109,13 @@ __metadata:
     buffer: ^5.2.1
     through: ^2.3.8
   checksum: 0e67c4a91f4fa0fc7b4045f8b914d3498c2fc2e8c39c359977708ec85ac6d6029840e97f508675fdbdf21fcb8d276ca502043406f3682b70f075e69aae626d1d
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Issue #, if available:*

This changes generated artifacts to support Node.js 18.x as the minimum Node.js version.

We announced [the end of support for Node.js 16.x in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-16-x-in-the-aws-sdk-for-javascript-v3/) starting January 6, 2025 back in July, 2024.

*Description of changes:*

bump engines (base-package.json) and @types/node to use minimum Node.js version 18.x.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
