### PR TITLE
fix(smithy-client): instanceof support for ServiceException class

### DIFF
--- a/.changeset/yellow-hats-live.md
+++ b/.changeset/yellow-hats-live.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": minor
+---
+
+adds support for instanceof operator for ServiceException class

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -41,7 +41,7 @@ describe("Exception Hierarchy Tests", () => {
       super({
         name: "ClientServiceException",
         $fault: "client",
-        $metadata: {}
+        $metadata: {},
       });
       Object.setPrototypeOf(this, ClientServiceException.prototype);
     }
@@ -55,7 +55,7 @@ describe("Exception Hierarchy Tests", () => {
     }
   }
 
-  describe("Plain Object Tests", () => {
+  describe("Empty Object Tests", () => {
     it("empty object should not be instanceof any exception", () => {
       expect({} instanceof Error).toBe(false);
       expect({} instanceof ServiceException).toBe(false);
@@ -78,7 +78,7 @@ describe("Exception Hierarchy Tests", () => {
     const serviceException = new ServiceException({
       name: "ServiceException",
       $fault: "client",
-      $metadata: {}
+      $metadata: {},
     });
 
     it("ServiceException instance should be instanceof Error and ServiceException", () => {

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -60,8 +60,7 @@ export class ServiceException extends Error implements SmithyException, Metadata
       return ServiceException.isInstance(instance);
     } else {
       // For subclasses, use standard prototype chain check
-      return instance instanceof Error &&
-             this.prototype.isPrototypeOf(instance);
+      return instance instanceof Error && this.prototype.isPrototypeOf(instance);
     }
   }
 }

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -65,7 +65,12 @@ export class ServiceException extends Error implements SmithyException, Metadata
     // For subclasses, check both prototype chain and name match
     // Note: instance must be ServiceException first (having $-props)
     if (ServiceException.isInstance(instance)) {
-      return this.prototype.isPrototypeOf(instance) || candidate.name === this.name;
+      // Only do name comparison if both sides have non-empty names
+      if (candidate.name && this.name) {
+        return this.prototype.isPrototypeOf(instance) || candidate.name === this.name;
+      }
+      // Otherwise fall back to just prototype check
+      return this.prototype.isPrototypeOf(instance);
     }
     return false;
   }

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -55,13 +55,19 @@ export class ServiceException extends Error implements SmithyException, Metadata
    * Custom instanceof check to support the operator for ServiceException base class
    */
   public static [Symbol.hasInstance](instance: unknown): boolean {
+    // Handle null/undefined
+    if (!instance) return false;
+    const candidate = instance as ServiceException;
+    // For ServiceException, check only $-props
     if (this === ServiceException) {
-      // For the base ServiceException class, use duck typing
       return ServiceException.isInstance(instance);
-    } else {
-      // For subclasses, use standard prototype chain check
-      return instance instanceof Error && this.prototype.isPrototypeOf(instance);
     }
+    // For subclasses, check both prototype chain and name match
+    // Note: instance must be ServiceException first (having $-props)
+    if (ServiceException.isInstance(instance)) {
+      return this.prototype.isPrototypeOf(instance) || candidate.name === this.name;
+    }
+    return false;
   }
 }
 

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -32,7 +32,7 @@ export class ServiceException extends Error implements SmithyException, Metadata
 
   constructor(options: ServiceExceptionOptions) {
     super(options.message);
-    Object.setPrototypeOf(this, ServiceException.prototype);
+    Object.setPrototypeOf(this, Object.getPrototypeOf(this).constructor.prototype);
     this.name = options.name;
     this.$fault = options.$fault;
     this.$metadata = options.$metadata;
@@ -49,6 +49,20 @@ export class ServiceException extends Error implements SmithyException, Metadata
       Boolean(candidate.$metadata) &&
       (candidate.$fault === "client" || candidate.$fault === "server")
     );
+  }
+
+  /**
+   * Custom instanceof check to support the operator for ServiceException base class
+   */
+  public static [Symbol.hasInstance](instance: unknown): boolean {
+    if (this === ServiceException) {
+      // For the base ServiceException class, use duck typing
+      return ServiceException.isInstance(instance);
+    } else {
+      // For subclasses, use standard prototype chain check
+      return instance instanceof Error &&
+             this.prototype.isPrototypeOf(instance);
+    }
   }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5478, Internal JS-5642

*Description of changes:*
adds proper support for the `instanceof` operator to ServiceException while ensuring subclasses maintain strict prototype checking.

1. adds `[Symbol.hasInstance]` to ServiceException that supports `instanceof` checks according to the assertion table noted below (in the comments).
 

2. fixes prototype chain setup in ServiceException constructor to properly support inheritance.
```typescript
Object.setPrototypeOf(this, Object.getPrototypeOf(this).constructor.prototype);
```
this resolves an issue where duck-typed objects were incorrectly matching subclass `instanceof` checks (e.g. `dummyServiceException instanceof NoSuchKey` would return true even when it wasn't actually a NoSuchKey instance). 



*Testing*
for `smithy-client`:
```console
✓ src/get-value-from-text-node.spec.ts (3)
 ✓ src/exceptions.spec.ts (16)
 ✓ src/lazy-json.spec.ts (7)
 ✓ src/date-utils.spec.ts (155)
 ✓ src/client.spec.ts (7)
 ✓ src/parse-utils.spec.ts (430)
 ✓ src/command.spec.ts (2)
 ✓ src/object-mapping.spec.ts (8)
 ✓ src/is-serializable-header-value.spec.ts (4)
 ✓ src/quote-header.spec.ts (4)
 ✓ src/create-aggregated-client.spec.ts (4)
 ✓ src/split-every.spec.ts (5)
 ✓ src/split-header.spec.ts (2)
 ✓ src/ser-utils.spec.ts (4)
 ✓ src/serde-json.spec.ts (3)
 ↓ src/emitWarningIfUnsupportedVersion.spec.ts (7) [skipped]

 Test Files  15 passed | 1 skipped (16)
      Tests  654 passed | 7 skipped (661)
   Start at  18:24:37
   Duration  1.77s (transform 1.01s, setup 2ms, collect 1.71s, tests 565ms, environment 3ms, prepare 2.46s)
```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
