### PR TITLE
fix(util-waiter): fix waiter validation

### DIFF
--- a/.changeset/eleven-poems-bake.md
+++ b/.changeset/eleven-poems-bake.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-waiter": minor
+---
+
+modify the waitUntilObjectExists Validation for minDelay

--- a/.changeset/eleven-poems-bake.md
+++ b/.changeset/eleven-poems-bake.md
@@ -1,5 +1,5 @@
 ---
-"@smithy/util-waiter": minor
+"@smithy/util-waiter": patch
 ---
 
-modify the waitUntilObjectExists Validation for minDelay
+this validation is fixed for all waiters

--- a/.changeset/eleven-poems-bake.md
+++ b/.changeset/eleven-poems-bake.md
@@ -2,4 +2,4 @@
 "@smithy/util-waiter": patch
 ---
 
-this validation is fixed for all waiters
+fix range validation in waiters

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -54,11 +54,7 @@ describe(validateWaiterOptions.name, () => {
     waiterOptions.maxWaitTime = 0.5;
     waiterOptions.minDelay = 0.0001;
     waiterOptions.maxDelay = 0.4;
-    try {
-      validateWaiterOptions(waiterOptions);
-    } catch (e) {
-      expect(e).toBe("SHOULD NOT ERROR HERE");
-    }
+    validateWaiterOptions(waiterOptions); 
   });  
 
   it("should throw when maxWaitTime is less than 0", () => {

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -50,6 +50,17 @@ describe(validateWaiterOptions.name, () => {
     }
   });
 
+  it("should not throw an error with small decimal numbers", () => {
+    waiterOptions.maxWaitTime = 0.5;
+    waiterOptions.minDelay = 0.0001;
+    waiterOptions.maxDelay = 0.4;
+    try {
+      validateWaiterOptions(waiterOptions);
+    } catch (e) {
+      expect(e).toBe("SHOULD NOT ERROR HERE");
+    }
+  });  
+
   it("should throw when maxWaitTime is less than 0", () => {
     waiterOptions.maxWaitTime = -2;
     waiterOptions.minDelay = -1;

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -54,8 +54,8 @@ describe(validateWaiterOptions.name, () => {
     waiterOptions.maxWaitTime = 0.5;
     waiterOptions.minDelay = 0.0001;
     waiterOptions.maxDelay = 0.4;
-    validateWaiterOptions(waiterOptions); 
-  });  
+    validateWaiterOptions(waiterOptions);
+  });
 
   it("should throw when maxWaitTime is less than 0", () => {
     waiterOptions.maxWaitTime = -2;

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -7,11 +7,11 @@ import { WaiterOptions } from "../waiter";
  * @param options - a waiter configuration object
  */
 export const validateWaiterOptions = <Client>(options: WaiterOptions<Client>): void => {
-  if (options.maxWaitTime < 1) {
+  if (options.maxWaitTime <= 0) {
     throw new Error(`WaiterConfiguration.maxWaitTime must be greater than 0`);
-  } else if (options.minDelay < 1) {
+  } else if (options.minDelay <= 0) {
     throw new Error(`WaiterConfiguration.minDelay must be greater than 0`);
-  } else if (options.maxDelay < 1) {
+  } else if (options.maxDelay <= 0) {
     throw new Error(`WaiterConfiguration.maxDelay must be greater than 0`);
   } else if (options.maxWaitTime <= options.minDelay) {
     throw new Error(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/6767

*Description of changes:*
The waitUntilObjectExists function was incorrectly throwing an error:
Error: WaiterConfiguration.minDelay must be greater than 0
When minDelay was set to 0.5.

Changes Made:
Updated validateWaiterOptions to only throw an error if minDelay, maxDelay, or maxWaitTime are less than or equal to 0 instead of < 1.
Added a test case to verify that small values like 0.01 do not throw an error.
This ensures that fractional values (e.g., 0.5, 0.01) work correctly while keeping 0 invalid. 

*Testing*
for util-waiter:

 ✓ src/waiter.spec.ts (5)
 ✓ src/utils/validate.spec.ts (7)
 ✓ src/poller.spec.ts (5)
 ✓ src/index.spec.ts (1)
 ✓ src/createWaiter.spec.ts (3)

 Test Files  5 passed (5)
      Tests  21 passed (21)
   Start at  12:01:40
   Duration  223ms (transform 105ms, setup 0ms, collect 212ms, tests 15ms, environment 0ms, prepare 227ms)

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
