### PR TITLE
fix(smithy-client): add prototype chain fallback for service exception

### DIFF
--- a/.changeset/rich-emus-cry.md
+++ b/.changeset/rich-emus-cry.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+prototype chain fallback for service exception

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -149,6 +149,19 @@ describe("Exception Hierarchy Tests", () => {
       expect(obj instanceof ClientServiceException).toBe(false);
       expect(obj instanceof ModeledClientServiceException).toBe(true);
     });
+
+    it("should handle exceptions where name indicates error type", () => {
+      const egError = new ServiceException({
+        name: "EgTooLarge",  // specific error type name
+        message: "Some size limit error",
+        $fault: "server",
+        $metadata: {}
+      });
+      // Should be recognized as a ServiceException
+      expect(egError instanceof ServiceException).toBe(true);
+      // The name property can be used to identify specific error types
+      expect(egError.name).toBe("EgTooLarge");
+    });
   });
 });
 

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -152,10 +152,10 @@ describe("Exception Hierarchy Tests", () => {
 
     it("should handle exceptions where name indicates error type", () => {
       const egError = new ServiceException({
-        name: "EgTooLarge",  // specific error type name
+        name: "EgTooLarge", // specific error type name
         message: "Some size limit error",
         $fault: "server",
-        $metadata: {}
+        $metadata: {},
       });
       // Should be recognized as a ServiceException
       expect(egError instanceof ServiceException).toBe(true);

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -97,6 +97,17 @@ describe("Exception Hierarchy Tests", () => {
       expect(clientException instanceof ClientServiceException).toBe(true);
       expect(clientException instanceof ModeledClientServiceException).toBe(false);
     });
+
+    it("should handle exceptions where name indicates error type", () => {
+      const egError = new ClientServiceException();
+      egError.name = "EgTooLarge"; // specific error type name
+      // Should maintain instanceof chain
+      expect(egError instanceof Error).toBe(true);
+      expect(egError instanceof ServiceException).toBe(true);
+      expect(egError instanceof ClientServiceException).toBe(true);
+      // The name property can be used to identify specific error types
+      expect(egError.name).toBe("EgTooLarge");
+    });
   });
 
   describe("ModeledClientServiceException Instance Tests", () => {
@@ -148,19 +159,6 @@ describe("Exception Hierarchy Tests", () => {
       expect(obj instanceof ServiceException).toBe(true);
       expect(obj instanceof ClientServiceException).toBe(false);
       expect(obj instanceof ModeledClientServiceException).toBe(true);
-    });
-
-    it("should handle exceptions where name indicates error type", () => {
-      const egError = new ServiceException({
-        name: "EgTooLarge", // specific error type name
-        message: "Some size limit error",
-        $fault: "server",
-        $metadata: {},
-      });
-      // Should be recognized as a ServiceException
-      expect(egError instanceof ServiceException).toBe(true);
-      // The name property can be used to identify specific error types
-      expect(egError.name).toBe("EgTooLarge");
     });
   });
 });

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -45,9 +45,10 @@ export class ServiceException extends Error implements SmithyException, Metadata
     if (!value) return false;
     const candidate = value as ServiceException;
     return (
-      Boolean(candidate.$fault) &&
-      Boolean(candidate.$metadata) &&
-      (candidate.$fault === "client" || candidate.$fault === "server")
+      ServiceException.prototype.isPrototypeOf(candidate) ||
+      (Boolean(candidate.$fault) &&
+        Boolean(candidate.$metadata) &&
+        (candidate.$fault === "client" || candidate.$fault === "server"))
     );
   }
 
@@ -58,9 +59,9 @@ export class ServiceException extends Error implements SmithyException, Metadata
     // Handle null/undefined
     if (!instance) return false;
     const candidate = instance as ServiceException;
-    // For ServiceException, check prototype chain or $-props
+    // For ServiceException, check only $-props
     if (this === ServiceException) {
-      return this.prototype.isPrototypeOf(instance) || ServiceException.isInstance(instance);
+      return ServiceException.isInstance(instance);
     }
     // For subclasses, check both prototype chain and name match
     // Note: instance must be ServiceException first (having $-props)

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -58,9 +58,9 @@ export class ServiceException extends Error implements SmithyException, Metadata
     // Handle null/undefined
     if (!instance) return false;
     const candidate = instance as ServiceException;
-    // For ServiceException, check only $-props
+    // For ServiceException, check prototype chain or $-props
     if (this === ServiceException) {
-      return ServiceException.isInstance(instance);
+      return this.prototype.isPrototypeOf(instance) || ServiceException.isInstance(instance);
     }
     // For subclasses, check both prototype chain and name match
     // Note: instance must be ServiceException first (having $-props)


### PR DESCRIPTION
*Description of changes:*
adds prototype chain check for the `isInstance` method for `ServiceException`

*Testing*
```console
✓ src/client.spec.ts (7)
 ✓ src/command.spec.ts (2)
 ✓ src/create-aggregated-client.spec.ts (4)
 ✓ src/date-utils.spec.ts (155)
 ↓ src/emitWarningIfUnsupportedVersion.spec.ts (7) [skipped]
 ✓ src/exceptions.spec.ts (16)
 ✓ src/get-value-from-text-node.spec.ts (3)
 ✓ src/is-serializable-header-value.spec.ts (4)
 ✓ src/lazy-json.spec.ts (7)
 ✓ src/object-mapping.spec.ts (8)
 ✓ src/parse-utils.spec.ts (430)
 ✓ src/quote-header.spec.ts (4)
 ✓ src/ser-utils.spec.ts (4)
 ✓ src/serde-json.spec.ts (3)
 ✓ src/split-every.spec.ts (5)
 ✓ src/split-header.spec.ts (2)

 Test Files  15 passed | 1 skipped (16)
      Tests  654 passed | 7 skipped (661)
   Start at  18:40:22
   Duration  1.39s (transform 836ms, setup 0ms, collect 1.71s, tests 353ms, environment 4ms, prepare 1.94s)
```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
