### PR TITLE
fix(node-http-handler): Write request body if 100 Continue response takes more than 1 second

### DIFF
--- a/.changeset/good-buttons-relax.md
+++ b/.changeset/good-buttons-relax.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+fix sending request when 100 Continue response takes more than 1 second

--- a/packages/node-http-handler/src/write-request-body.spec.ts
+++ b/packages/node-http-handler/src/write-request-body.spec.ts
@@ -59,4 +59,25 @@ describe(writeRequestBody.name, () => {
       await promise;
     }
   );
+
+  it("should send the body if the 100 Continue response is not received before the timeout", async () => {
+    const httpRequest = Object.assign(new EventEmitter(), {
+      end: vi.fn(),
+    }) as any;
+    const request = {
+      headers: {
+        expect: "100-continue",
+      },
+      body: Buffer.from("abcd"),
+      method: "GET",
+      hostname: "",
+      protocol: "https:",
+      path: "/",
+    };
+
+    const promise = writeRequestBody(httpRequest, request);
+    expect(httpRequest.end).not.toHaveBeenCalled();
+    await promise;
+    expect(httpRequest.end).toHaveBeenCalled();
+  });
 });

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -28,7 +28,7 @@ export async function writeRequestBody(
   if (expect === "100-continue") {
     sendBody = await Promise.race<boolean>([
       new Promise((resolve) => {
-        timeoutId = Number(timing.setTimeout(resolve, Math.max(MIN_WAIT_TIME, maxContinueTimeoutMs)));
+        timeoutId = Number(timing.setTimeout(() => resolve(true), Math.max(MIN_WAIT_TIME, maxContinueTimeoutMs)));
       }),
       new Promise((resolve) => {
         httpRequest.on("continue", () => {


### PR DESCRIPTION
Fixes the issue reported here: https://github.com/aws/aws-sdk-js-v3/issues/6805

*Description of changes:*

When the client makes a request with the `Expect: 100-continue` header, it will wait for 1000ms to get either a `100 Continue` response or an error. If it does not receive any response within the 1000ms, the intention seems to be that the client should write the body anyway. This behavior broke in #1459 because in the timeout case `resolve` is called with no arguments, which means that `sendBody` becomes undefined and the body is never sent. Even if the server returns a 100 Continue after 1001ms, the client is no longer waiting for that response and instead just idles until eventually the server returns an error.

This change restores the previous behavior, where the client will send the body after waiting 1000ms.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
