### PR TITLE
Bump codegen version to 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.26.0 (2025-01-22)
+
+### Features
+- Dropped support for Node.js 16 ([#1487](https://github.com/smithy-lang/smithy-typescript/pull/1487))
+- Upgraded smithyGradleVersion to 1.2.0 ([#1499](https://github.com/smithy-lang/smithy-typescript/pull/1499))
+- Passed client configuration to loadNodeConfig calls ([#1471](https://github.com/smithy-lang/smithy-typescript/pull/1471))
+- Removed String extension in LazyJsonString ([#1468](https://github.com/smithy-lang/smithy-typescript/pull/1468))
+- Upgraded vitest to 2.1.8 ([#1496](https://github.com/smithy-lang/smithy-typescript/pull/1496))
+
+### Bug Fixes
+- Fixed code generation issue for operationContextParam ([#1475](https://github.com/smithy-lang/smithy-typescript/pull/1475))
+- Resolved obj and array JS literals from JMESPath types for waiters ([#1462](https://github.com/smithy-lang/smithy-typescript/pull/1462))
+
 ## 0.25.0 (2024-11-18)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
     // Add the Smithy TypeScript code generator dependency
     "maven": {
         "dependencies": [
-            "software.amazon.smithy.typescript:smithy-typescript-codegen:0.25.0"
+            "software.amazon.smithy.typescript:smithy-typescript-codegen:0.26.0"
         ]
     },
     "plugins": {
@@ -141,7 +141,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.25.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.26.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.25.0"
+    version = "0.26.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5673

*Description of changes:*
Bump codegen version to 0.26.0

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
