### PR TITLE
chore(docs): move description block before deprecated tag

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -266,7 +266,7 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                     docs = docs.replace("{", "\\{")
                         .replace("}", "\\}");
                     if (member.getTrait(DeprecatedTrait.class).isPresent() || isTargetDeprecated(model, member)) {
-                        docs = "@deprecated\n\n" + docs;
+                        docs = docs + "\n\n@deprecated";
                     }
                     docs = addReleaseTag(member, docs);
                     writeDocs(docs);


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws/aws-sdk-js-v3/issues/6672
- P187212400

*Description of changes:*
- Currently the description for parameter is missing when param has deprecated tag. By moving deprecated tag after block, description should render correctly.

Resource: https://tsdoc.org/pages/tags/deprecated/

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
