### PR TITLE
feat(docs): add client config option reference

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -254,7 +254,7 @@ final class CommandGenerator implements Runnable {
                         packageName)
                 + String.format("// const { %s, %s } = require(\"%s\"); // CommonJS import%n", serviceName, commandName,
                         packageName)
-                + String.format("const client = new %s(config);%n", serviceName)
+                + String.format("const client = new %s(config); // See AWS SDK config options: https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/configuring-the-jssdk.html%n", serviceName)
                 + String.format("const input = %s%n",
                         StructureExampleGenerator.generateStructuralHintDocumentation(
                                 model.getShape(operation.getInputShape()).get(), model, false, true))


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws/aws-sdk-js-v3/issues/6858

*Description of changes:*
- Add a comment with client config options to developer guide link in code example syntax for reference
- `// See AWS SDK config options: https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/configuring-the-jssdk.html`


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
