### PR TITLE
fix(node-http-handler): fix constructor socketAcquisitionWarningTimeout does not work

### DIFF
--- a/.changeset/popular-dolls-allow.md
+++ b/.changeset/popular-dolls-allow.md
@@ -1,5 +1,5 @@
 ---
-"@smithy/node-http-handler": minor
+"@smithy/node-http-handler": patch
 ---
 
 Fix constructor socketAcquisitionWarningTimeout does not work

--- a/.changeset/popular-dolls-allow.md
+++ b/.changeset/popular-dolls-allow.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": minor
+---
+
+Fix constructor socketAcquisitionWarningTimeout does not work

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -122,7 +122,8 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
   }
 
   private resolveDefaultConfig(options?: NodeHttpHandlerOptions | void): ResolvedNodeHttpHandlerConfig {
-    const { requestTimeout, connectionTimeout, socketTimeout, socketAcquisitionWarningTimeout, httpAgent, httpsAgent } = options || {};
+    const { requestTimeout, connectionTimeout, socketTimeout, socketAcquisitionWarningTimeout, httpAgent, httpsAgent } =
+      options || {};
     const keepAlive = true;
     const maxSockets = 50;
 

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -122,13 +122,14 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
   }
 
   private resolveDefaultConfig(options?: NodeHttpHandlerOptions | void): ResolvedNodeHttpHandlerConfig {
-    const { requestTimeout, connectionTimeout, socketTimeout, httpAgent, httpsAgent } = options || {};
+    const { requestTimeout, connectionTimeout, socketTimeout, socketAcquisitionWarningTimeout, httpAgent, httpsAgent } = options || {};
     const keepAlive = true;
     const maxSockets = 50;
 
     return {
       connectionTimeout,
       requestTimeout: requestTimeout ?? socketTimeout,
+      socketAcquisitionWarningTimeout,
       httpAgent: (() => {
         if (httpAgent instanceof hAgent || typeof (httpAgent as hAgent)?.destroy === "function") {
           return httpAgent as hAgent;


### PR DESCRIPTION
*Issue:* https://github.com/smithy-lang/smithy-typescript/issues/1528

*Description of changes:*

[NodeHttpHandler](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/Interface/NodeHttpHandlerOptions/) “socketAcquisitionWarningTimeout” option does not work correctly.

Fix it



