### PR TITLE
fix(node-http-handler): clear obsolete socket timeout listeners

### DIFF
--- a/.changeset/twenty-peaches-notice.md
+++ b/.changeset/twenty-peaches-notice.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Clear obsolete timeout handlers from socket.

--- a/packages/node-http-handler/src/set-socket-timeout.spec.ts
+++ b/packages/node-http-handler/src/set-socket-timeout.spec.ts
@@ -49,6 +49,7 @@ describe("setSocketTimeout", () => {
       socket: {
         setTimeout: vi.fn(),
       },
+      on: vi.fn(),
     };
 
     it("calls setTimeout on the socket if it is available after deferral", async () => {
@@ -64,6 +65,8 @@ describe("setSocketTimeout", () => {
         expectedDeferredSocketTimeout,
         expect.any(Function)
       );
+      expect(clientRequestWithSocket.on).toHaveBeenCalledTimes(1);
+      expect(clientRequestWithSocket.on).toHaveBeenLastCalledWith("close", expect.any(Function));
     });
   });
 

--- a/packages/node-http-handler/src/set-socket-timeout.ts
+++ b/packages/node-http-handler/src/set-socket-timeout.ts
@@ -19,6 +19,7 @@ export const setSocketTimeout = (
 
     if (request.socket) {
       request.socket.setTimeout(timeout, onTimeout);
+      request.on("close", () => request.socket?.removeListener("timeout", onTimeout));
     } else {
       request.setTimeout(timeout, onTimeout);
     }


### PR DESCRIPTION
*Issue #1530*

*Description of changes:*

This PR adds cleaning the socket timeout listener from the underlying socket upon requests `close`, to avoid leaking the listeners throughout a keepAlive socket's lifetime.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
