### PR TITLE
Support JMESPath flatten in OperationContextParams

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -366,10 +366,17 @@ public class RuleSetParameterFinder {
         }
 
         // Process Flatten operator https://jmespath.org/specification.html#flatten-operator
-        if (part.endsWith("[*][]")) {
+        if (part.endsWith("[]")) {
             // Get key to run hash wildcard on.
-            String key = part.substring(0, part.length() - 5);
-            value = value + separator + key + ".flat()";
+            String key = part.substring(0, part.length() - 2);
+
+            // If key is on list item
+            if (key.endsWith("[*]")) {
+                value = value + separator + key.substring(0, key.length() - 3) + ".flat()";
+            } else {
+                // key is on object
+                value = value + separator + key + ").flat()";
+            }
             return value;
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -316,9 +316,15 @@ public class RuleSetParameterFinder {
                     value += getJmesPathExpression(separator, "obj", part) + ",";
                     if (commaIndex == -1) {
                         // Remove trailing comma and close bracket.
-                        value = value.substring(0, value.length() - 1) + "].filter((i) => i))";
+                        value = value.substring(0, value.length() - 1) + "].filter((i) => i)";
                         break;
                     }
+                }
+
+                // Process Flatten operator https://jmespath.org/specification.html#flatten-operator
+                if (path.startsWith("[]")) {
+                    value += ".flat()";
+                    path = path.substring(2);
                 }
                 continue;
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -365,6 +365,14 @@ public class RuleSetParameterFinder {
             return value;
         }
 
+        // Process Flatten operator https://jmespath.org/specification.html#flatten-operator
+        if (part.endsWith("[*][]")) {
+            // Get key to run hash wildcard on.
+            String key = part.substring(0, part.length() - 5);
+            value = value + separator + key + ".flat()";
+            return value;
+        }
+
         // Treat remaining part as identifier without spaces https://jmespath.org/specification.html#identifiers
         value += separator + part;
         return value;

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -42,6 +42,7 @@ public class CommandGeneratorTest {
                 "opContextParamIdentifier: { type: \"operationContextParams\", get: (input?: any) => input?.fooString }",
                 "opContextParamSubExpression: { type: \"operationContextParams\", get: (input?: any) => input?.fooObj?.bar }",
                 "opContextParamWildcardExpressionList: { type: \"operationContextParams\", get: (input?: any) => input?.fooList }",
+                "opContextParamWildcardExpressionListFlatten: { type: \"operationContextParams\", get: (input?: any) => input?.fooListList.flat() }",
                 "opContextParamWildcardExpressionListObj: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObj?.map((obj: any) => obj?.key) }",
                 "opContextParamWildcardExpressionHash: { type: \"operationContextParams\", get: (input?: any) => Object.values(input?.fooObjObj ?? {}).map((obj: any) => obj?.bar) }",
                 "opContextParamMultiSelectList: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObjObj?.map((obj: any) => [obj?.fooList[0],obj?.fooObject?.bar,obj?.fooString].filter((i) => i)) }",

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -44,6 +44,7 @@ public class CommandGeneratorTest {
                 "opContextParamWildcardExpressionList: { type: \"operationContextParams\", get: (input?: any) => input?.fooList }",
                 "opContextParamWildcardExpressionListFlatten: { type: \"operationContextParams\", get: (input?: any) => input?.fooListList.flat() }",
                 "opContextParamWildcardExpressionListObj: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObj?.map((obj: any) => obj?.key) }",
+                "opContextParamWildcardExpressionListObjListFlatten: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObjList?.map((obj: any) => obj?.key).flat() }",
                 "opContextParamWildcardExpressionHash: { type: \"operationContextParams\", get: (input?: any) => Object.values(input?.fooObjObj ?? {}).map((obj: any) => obj?.bar) }",
                 "opContextParamMultiSelectList: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObjObj?.map((obj: any) => [obj?.fooList[0],obj?.fooObject?.bar,obj?.fooString].filter((i) => i)) }",
                 "opContextParamMultiSelectListFlatten: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObjObj?.map((obj: any) => [obj?.fooList].filter((i) => i).flat()) }",

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -45,6 +45,7 @@ public class CommandGeneratorTest {
                 "opContextParamWildcardExpressionListObj: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObj?.map((obj: any) => obj?.key) }",
                 "opContextParamWildcardExpressionHash: { type: \"operationContextParams\", get: (input?: any) => Object.values(input?.fooObjObj ?? {}).map((obj: any) => obj?.bar) }",
                 "opContextParamMultiSelectList: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObjObj?.map((obj: any) => [obj?.fooList[0],obj?.fooObject?.bar,obj?.fooString].filter((i) => i)) }",
+                "opContextParamMultiSelectListFlatten: { type: \"operationContextParams\", get: (input?: any) => input?.fooListObjObj?.map((obj: any) => [obj?.fooList].filter((i) => i).flat()) }",
                 "opContextParamKeys: { type: \"operationContextParams\", get: (input?: any) => Object.keys(input?.fooKeys ?? {}) }",
             }
         );

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/endpointsV2/endpoints-operation-context-params.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/endpointsV2/endpoints-operation-context-params.smithy
@@ -23,6 +23,9 @@ namespace smithy.example
         opContextParamMultiSelectList: {
             type: "stringArray",
         },
+        opContextParamMultiSelectListFlatten: {
+            type: "stringArray",
+        },
         opContextParamKeys: {
             type: "stringArray",
         },
@@ -41,6 +44,7 @@ service Example {
     "opContextParamWildcardExpressionListObj": { path: "fooListObj[*].key" }
     "opContextParamWildcardExpressionHash": { path: "fooObjObj.*.bar" }
     "opContextParamMultiSelectList": { path: "fooListObjObj[*].[fooList[0], fooObject.bar, fooString]" }
+    "opContextParamMultiSelectListFlatten": { path: "fooListObjObj[*].[fooList][]" }
     "opContextParamKeys": { path: "keys(fooKeys)" }
 )
 operation GetFoo {

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/endpointsV2/endpoints-operation-context-params.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/endpointsV2/endpoints-operation-context-params.smithy
@@ -14,6 +14,9 @@ namespace smithy.example
         opContextParamWildcardExpressionList: {
             type: "stringArray",
         },
+        opContextParamWildcardExpressionListFlatten: {
+            type: "stringArray",
+        },
         opContextParamWildcardExpressionListObj: {
             type: "stringArray",
         },
@@ -41,6 +44,7 @@ service Example {
     "opContextParamIdentifier": { path: "fooString" }
     "opContextParamSubExpression": { path: "fooObj.bar" }
     "opContextParamWildcardExpressionList": { path: "fooList[*]" }
+    "opContextParamWildcardExpressionListFlatten": { path: "fooListList[*][]" }
     "opContextParamWildcardExpressionListObj": { path: "fooListObj[*].key" }
     "opContextParamWildcardExpressionHash": { path: "fooObjObj.*.bar" }
     "opContextParamMultiSelectList": { path: "fooListObjObj[*].[fooList[0], fooObject.bar, fooString]" }
@@ -56,6 +60,7 @@ operation GetFoo {
 structure GetFooInput {
     fooKeys: FooObject,
     fooList: FooList,
+    fooListList: FooListList,
     fooListObj: FooListObject,
     fooListObjObj: FooListObjectObject,
     fooObj: FooObject,
@@ -79,6 +84,10 @@ structure FooMultiSelectObjectObject {
 
 structure FooObjectObject {
     baz: FooObject
+}
+
+list FooListList {
+    member: FooList
 }
 
 list FooList {

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/endpointsV2/endpoints-operation-context-params.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/endpointsV2/endpoints-operation-context-params.smithy
@@ -20,6 +20,9 @@ namespace smithy.example
         opContextParamWildcardExpressionListObj: {
             type: "stringArray",
         },
+        opContextParamWildcardExpressionListObjListFlatten: {
+            type: "stringArray",
+        },
         opContextParamWildcardExpressionHash: {
             type: "stringArray",
         },
@@ -46,6 +49,7 @@ service Example {
     "opContextParamWildcardExpressionList": { path: "fooList[*]" }
     "opContextParamWildcardExpressionListFlatten": { path: "fooListList[*][]" }
     "opContextParamWildcardExpressionListObj": { path: "fooListObj[*].key" }
+    "opContextParamWildcardExpressionListObjListFlatten": { path: "fooListObjList[*].key[]" }
     "opContextParamWildcardExpressionHash": { path: "fooObjObj.*.bar" }
     "opContextParamMultiSelectList": { path: "fooListObjObj[*].[fooList[0], fooObject.bar, fooString]" }
     "opContextParamMultiSelectListFlatten": { path: "fooListObjObj[*].[fooList][]" }
@@ -62,6 +66,7 @@ structure GetFooInput {
     fooList: FooList,
     fooListList: FooListList,
     fooListObj: FooListObject,
+    fooListObjList: FooListObjectList,
     fooListObjObj: FooListObjectObject,
     fooObj: FooObject,
     fooObjObj: FooObjectObject,
@@ -100,6 +105,14 @@ list FooListObject {
 
 structure FooListObjectMember {
     key: String
+}
+
+list FooListObjectList {
+    member: FooListObjectListMember
+}
+
+structure FooListObjectListMember {
+    key: FooList
 }
 
 structure GetFooOutput {}


### PR DESCRIPTION
*Issue #, if available:*
* Internal JS-5749
* JMESPath docs: https://jmespath.org/specification.html#flatten-operator
* Array.prototype.flat() https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat

*Description of changes:*
Support JMESPath flatten in OperationContextParams

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
