### PR TITLE
Improvement: Extend serdeContextBase by operationName

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -236,6 +236,7 @@ final class ServerGenerator {
                 });
         writer.indent();
         writer.write("let input;");
+        writer.write("serdeContextBase.operationName = operationName;");
         writer.openBlock("try {", "} catch (error: unknown) {", () -> {
             writer.openBlock("input = await serializer.deserialize(request, {", "});", () -> {
                 writer.write("endpoint: () => Promise.resolve(request), ...serdeContextBase");
@@ -287,7 +288,8 @@ final class ServerGenerator {
             writer.write("utf8Decoder: fromUtf8,");
             writer.write("streamCollector: streamCollector,");
             writer.write("requestHandler: new NodeHttpHandler(),");
-            writer.write("disableHostPrefix: true");
+            writer.write("disableHostPrefix: true,");
+            writer.write("operationName: \"\",");
         });
     }
 


### PR DESCRIPTION
Here’s a clearer and more structured version of your description:  

---

I need to extend `serdeContextBase` in `ServerGenerator.java`.  

When I make a request to my `ssdk`, I receive a `ValidationException`. I want to add metrics for this, but I can't determine which command was executed.  

If you add `operationName` to `serdeContextBase`, I'll be able to access this information everywhere.  

Example:
```js
    @Override
    protected void writeDefaultOutputHeaders(GenerationContext context, OperationShape operation) {
        context.getWriter().write("'x-command-name': ctx.operationName,");
    }

    @Override
    protected void writeDefaultErrorHeaders(GenerationContext context, StructureShape error) {
        context.getWriter().write("'x-command-name': ctx.operationName,");
    }
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
