### PR TITLE
feat(core/serde): add NumericValue container

### DIFF
--- a/.changeset/neat-queens-peel.md
+++ b/.changeset/neat-queens-peel.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+add numeric value container for serde

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,13 @@
       "import": "./dist-es/submodules/protocols/index.js",
       "require": "./dist-cjs/submodules/protocols/index.js",
       "types": "./dist-types/submodules/protocols/index.d.ts"
+    },
+    "./serde": {
+      "module": "./dist-es/submodules/serde/index.js",
+      "node": "./dist-cjs/submodules/serde/index.js",
+      "import": "./dist-es/submodules/serde/index.js",
+      "require": "./dist-cjs/submodules/serde/index.js",
+      "types": "./dist-types/submodules/serde/index.d.ts"
     }
   },
   "author": {
@@ -78,6 +85,8 @@
     "./cbor.js",
     "./protocols.d.ts",
     "./protocols.js",
+    "./serde.d.ts",
+    "./serde.js",
     "dist-*/**"
   ],
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/core",

--- a/packages/core/serde.d.ts
+++ b/packages/core/serde.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@smithy/core/serde" {
+  export * from "@smithy/core/dist-types/submodules/serde/index.d";
+}

--- a/packages/core/serde.js
+++ b/packages/core/serde.js
@@ -1,0 +1,6 @@
+
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+module.exports = require("./dist-cjs/submodules/serde/index.js");

--- a/packages/core/src/submodules/serde/index.ts
+++ b/packages/core/src/submodules/serde/index.ts
@@ -1,0 +1,1 @@
+export * from "./value/NumericValue";

--- a/packages/core/src/submodules/serde/value/NumericValue.spec.ts
+++ b/packages/core/src/submodules/serde/value/NumericValue.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test as it } from "vitest";
+
+import { NumericValue, nv } from "./NumericValue";
+
+describe(NumericValue.name, () => {
+  it("holds a string representation of a numeric value", () => {
+    const num = nv("1.0");
+    expect(num).toBeInstanceOf(NumericValue);
+    expect(num.string).toEqual("1.0");
+    expect(num.type).toEqual("bigDecimal");
+  });
+});

--- a/packages/core/src/submodules/serde/value/NumericValue.ts
+++ b/packages/core/src/submodules/serde/value/NumericValue.ts
@@ -1,0 +1,36 @@
+/**
+ * Types which may be represented by {@link NumericValue}.
+ *
+ * There is currently only one option, because BigInteger and Long should
+ * use JS BigInt directly, and all other numeric types can be contained in JS Number.
+ *
+ * @public
+ */
+export type NumericType = "bigDecimal";
+
+/**
+ * Serialization container for Smithy simple types that do not have a
+ * direct JavaScript runtime representation.
+ *
+ * This container does not perform numeric mathematical operations.
+ * It is a container for discerning a value's true type.
+ *
+ * It allows storage of numeric types not representable in JS without
+ * making a decision on what numeric library to use.
+ *
+ * @public
+ */
+export class NumericValue {
+  public constructor(
+    public readonly string: string,
+    public readonly type: NumericType
+  ) {}
+}
+
+/**
+ * Serde shortcut.
+ * @internal
+ */
+export function nv(string: string): NumericValue {
+  return new NumericValue(string, "bigDecimal");
+}

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     "paths": {
       "@smithy/core/cbor": ["./src/submodules/cbor/index.ts"],
-      "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"]
+      "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"],
+      "@smithy/core/serde": ["./src/submodules/serde/index.ts"]
     }
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/core/tsconfig.es.json
+++ b/packages/core/tsconfig.es.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "paths": {
       "@smithy/core/cbor": ["./src/submodules/cbor/index.ts"],
-      "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"]
+      "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"],
+      "@smithy/core/serde": ["./src/submodules/serde/index.ts"]
     }
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/core/tsconfig.types.json
+++ b/packages/core/tsconfig.types.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     "paths": {
       "@smithy/core/cbor": ["./src/submodules/cbor/index.ts"],
-      "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"]
+      "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"],
+      "@smithy/core/serde": ["./src/submodules/serde/index.ts"]
     }
   },
   "extends": "../../tsconfig.types.json",


### PR DESCRIPTION
- creates the core/serde submodule, which will later be expanded when much of serde moves from codegen to JS runtime
- adds a NumericValue container (unused so far) for holding BigDecimal data without deciding on a numeric library on behalf of the user

This is not currently in use, but will facilitate future work on serde. It will also unify behavior related to too-large numerics. Currently there is inconsistent behavior among protocols when handling large numbers. Some make best-effort attempts to fit into Number and some throw errors disallowing large numbers. Both of those are not desirable for customers. 

We should aim to preserve numeric precision in all cases without coupling to any specific numeric library. A simple string container with a type differentiator field accomplishes that.