### PR TITLE
feat(core): add http debug utility to core/protocols

### DIFF
--- a/.changeset/hot-points-type.md
+++ b/.changeset/hot-points-type.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+add http debug utility

--- a/packages/core/debug.d.ts
+++ b/packages/core/debug.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@smithy/core/debug" {
+  export * from "@smithy/core/dist-types/submodules/debug/index.d";
+}

--- a/packages/core/debug.js
+++ b/packages/core/debug.js
@@ -1,0 +1,6 @@
+
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+module.exports = require("./dist-cjs/submodules/debug/index.js");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,13 @@
       "import": "./dist-es/submodules/serde/index.js",
       "require": "./dist-cjs/submodules/serde/index.js",
       "types": "./dist-types/submodules/serde/index.d.ts"
+    },
+    "./debug": {
+      "module": "./dist-es/submodules/debug/index.js",
+      "node": "./dist-cjs/submodules/debug/index.js",
+      "import": "./dist-es/submodules/debug/index.js",
+      "require": "./dist-cjs/submodules/debug/index.js",
+      "types": "./dist-types/submodules/debug/index.d.ts"
     }
   },
   "author": {
@@ -83,6 +90,8 @@
   "files": [
     "./cbor.d.ts",
     "./cbor.js",
+    "./debug.d.ts",
+    "./debug.js",
     "./protocols.d.ts",
     "./protocols.js",
     "./serde.d.ts",

--- a/packages/core/src/submodules/debug/httpDebugLogging.spec.ts
+++ b/packages/core/src/submodules/debug/httpDebugLogging.spec.ts
@@ -1,0 +1,256 @@
+import { HttpRequest, HttpResponse } from "@smithy/protocol-http/src";
+import { Readable } from "node:stream";
+import { describe, expect, test as it, vi } from "vitest";
+
+import { addHttpDebugLogMiddleware } from "./httpDebugLogging";
+
+describe(addHttpDebugLogMiddleware.name, () => {
+  describe("JSON", () => {
+    const httpRequest = new HttpRequest({
+      headers: {
+        header1: "headerValue1",
+      },
+      query: {
+        query1: "queryValue1",
+      },
+      protocol: "https:",
+      hostname: "localhost",
+      path: "/path",
+      body: JSON.stringify({ requestBody: "OK" }),
+    });
+
+    const httpResponse = new HttpResponse({
+      headers: {
+        responseHeader1: "responseHeaderValue1",
+      },
+      statusCode: 200,
+      body: Readable.from('{ "responseBody": "OK" }'),
+    });
+
+    it("should pass http request and response data through a logger", async () => {
+      const next = () => ({
+        response: httpResponse,
+      });
+      const args = {
+        request: httpRequest,
+      };
+
+      const mwStack = {
+        addRelativeTo(middleware: (next: Function, context: any) => (args) => Promise<any>): void {
+          middleware(next, {})(args);
+        },
+      } as any;
+
+      const logger = {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      addHttpDebugLogMiddleware(mwStack, {
+        request: {
+          client: true,
+          command: true,
+          method: true,
+          url: true,
+          headers: true,
+          formatBody: true,
+          body: true,
+        },
+        response: {
+          statusCode: true,
+          headers: true,
+          body: true,
+          formatBody: true,
+        },
+        logger: logger,
+      });
+
+      // inner tested fn is un-awaitable.
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(vi.mocked(logger.debug).mock.calls.flat()).toEqual([
+        "200 GET UnknownClient UnknownCommand",
+        "    https://localhost/path",
+        `    >> Request URL queryParams: {
+      "query1": "queryValue1"
+    }`,
+        `    >>== Request Headers: {
+      "header1": "headerValue1"
+    }`,
+        "    >>>=== Request Body Start ======",
+        `    {
+      "requestBody": "OK"
+    }`,
+        "    >>>=== Request Body End ======",
+        `    <<== Response Headers: {
+      "responseHeader1": "responseHeaderValue1"
+    }`,
+        "    <<<=== Response Body Start ======",
+        `    {
+      "responseBody": "OK"
+    }`,
+        "    <<<=== Response Body End ======",
+      ]);
+    });
+  });
+
+  describe("XML", () => {
+    const httpRequest = new HttpRequest({
+      headers: {
+        header1: "headerValue1",
+      },
+      query: {
+        query1: "queryValue1",
+      },
+      protocol: "https:",
+      hostname: "localhost",
+      path: "/path",
+      body: `<?xml version="1.0" encoding="UTF-8"?><WebsiteConfiguration xmlns="https://prod.company.com/doc/2006-03-01/"><ErrorDocument><Key>string</Key></ErrorDocument><IndexDocument><Suffix>string</Suffix></IndexDocument><RedirectAllRequestsTo><HostName>string</HostName><Protocol>string</Protocol></RedirectAllRequestsTo><RoutingRules><RoutingRule><Condition><HttpErrorCodeReturnedEquals>string</HttpErrorCodeReturnedEquals><KeyPrefixEquals>string</KeyPrefixEquals></Condition><Redirect><HostName>string</HostName><HttpRedirectCode>string</HttpRedirectCode><Protocol>string</Protocol><ReplaceKeyPrefixWith>string</ReplaceKeyPrefixWith><ReplaceKeyWith>string</ReplaceKeyWith></Redirect></RoutingRule></RoutingRules></WebsiteConfiguration>`,
+    });
+
+    const httpResponse = new HttpResponse({
+      headers: {
+        responseHeader1: "responseHeaderValue1",
+      },
+      statusCode: 200,
+      body: Readable.from(
+        `<?xml version="1.0" encoding="UTF-8"?><BucketLoggingStatus><LoggingEnabled><TargetBucket>string</TargetBucket><TargetGrants><Grant><Grantee><DisplayName>string</DisplayName><EmailAddress>string</EmailAddress><ID>string</ID><xsi:type>string</xsi:type><URI>string</URI></Grantee><Permission>string</Permission></Grant></TargetGrants><TargetObjectKeyFormat><PartitionedPrefix><PartitionDateSource>string</PartitionDateSource></PartitionedPrefix><SimplePrefix></SimplePrefix></TargetObjectKeyFormat><TargetPrefix>string</TargetPrefix></LoggingEnabled></BucketLoggingStatus>`
+      ),
+    });
+
+    it("should pass http request and response data through a logger", async () => {
+      const next = () => ({
+        response: httpResponse,
+      });
+      const args = {
+        request: httpRequest,
+      };
+
+      const mwStack = {
+        addRelativeTo(middleware: (next: Function, context: any) => (args) => Promise<any>): void {
+          middleware(next, {})(args);
+        },
+      } as any;
+
+      addHttpDebugLogMiddleware(mwStack, "lines headers formatted");
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+      // inner tested fn is un-awaitable.
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(vi.mocked(spy).mock.calls.flat()).toEqual([
+        "200 GET UnknownClient UnknownCommand",
+        "    https://localhost/path",
+        `    >> Request URL queryParams: {
+      "query1": "queryValue1"
+    }`,
+        `    >>== Request Headers: {
+      "header1": "headerValue1"
+    }`,
+        "    >>>=== Request Body Start ======",
+        `    <?xml version="1.0" encoding="UTF-8"?>
+      <WebsiteConfiguration xmlns="https://prod.company.com/doc/2006-03-01/">
+        <ErrorDocument>
+          <Key>
+            string
+          </Key>
+        </ErrorDocument>
+        <IndexDocument>
+          <Suffix>
+            string
+          </Suffix>
+        </IndexDocument>
+        <RedirectAllRequestsTo>
+          <HostName>
+            string
+          </HostName>
+          <Protocol>
+            string
+          </Protocol>
+        </RedirectAllRequestsTo>
+        <RoutingRules>
+          <RoutingRule>
+            <Condition>
+              <HttpErrorCodeReturnedEquals>
+                string
+              </HttpErrorCodeReturnedEquals>
+              <KeyPrefixEquals>
+                string
+              </KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+              <HostName>
+                string
+              </HostName>
+              <HttpRedirectCode>
+                string
+              </HttpRedirectCode>
+              <Protocol>
+                string
+              </Protocol>
+              <ReplaceKeyPrefixWith>
+                string
+              </ReplaceKeyPrefixWith>
+              <ReplaceKeyWith>
+                string
+              </ReplaceKeyWith>
+            </Redirect>
+          </RoutingRule>
+        </RoutingRules>
+      </WebsiteConfiguration>`,
+        "    >>>=== Request Body End ======",
+        `    <<== Response Headers: {
+      "responseHeader1": "responseHeaderValue1"
+    }`,
+        "    <<<=== Response Body Start ======",
+        `    <?xml version="1.0" encoding="UTF-8"?>
+      <BucketLoggingStatus>
+        <LoggingEnabled>
+          <TargetBucket>
+            string
+          </TargetBucket>
+          <TargetGrants>
+            <Grant>
+              <Grantee>
+                <DisplayName>
+                  string
+                </DisplayName>
+                <EmailAddress>
+                  string
+                </EmailAddress>
+                <ID>
+                  string
+                </ID>
+                <xsi:type>
+                  string
+                </xsi:type>
+                <URI>
+                  string
+                </URI>
+              </Grantee>
+              <Permission>
+                string
+              </Permission>
+            </Grant>
+          </TargetGrants>
+          <TargetObjectKeyFormat>
+            <PartitionedPrefix>
+              <PartitionDateSource>
+                string
+              </PartitionDateSource>
+            </PartitionedPrefix>
+            <SimplePrefix>
+            </SimplePrefix>
+          </TargetObjectKeyFormat>
+          <TargetPrefix>
+            string
+          </TargetPrefix>
+        </LoggingEnabled>
+      </BucketLoggingStatus>`,
+        "    <<<=== Response Body End ======",
+      ]);
+    });
+  });
+});

--- a/packages/core/src/submodules/debug/httpDebugLogging.ts
+++ b/packages/core/src/submodules/debug/httpDebugLogging.ts
@@ -1,0 +1,320 @@
+import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import type {
+  DeserializeHandler,
+  DeserializeHandlerArguments,
+  HandlerExecutionContext,
+  Logger,
+  MiddlewareStack,
+} from "@smithy/types";
+import { headStream } from "@smithy/util-stream";
+import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
+
+/**
+ * FOR DEBUG USE ONLY.
+ * Attaching these debug loggers will degrade performance since body streams may need to be read twice.
+ *
+ * When given as a string,
+ * Including "line" will turn on method, statusCode, client, command, URL logging.
+ * Including "header" will turn on request and response header logging.
+ * Including "body" will turn on response body logging.
+ * Including "formatted" will turn on response body logging with formatting.
+ *
+ * @public
+ */
+export type HttpDebugLoggingOptions =
+  | string
+  | {
+      request?: {
+        /**
+         * The client name.
+         */
+        client?: boolean;
+        /**
+         * The command name.
+         */
+        command?: boolean;
+        /**
+         * HTTP request method.
+         */
+        method?: boolean;
+        /**
+         * HTTP request URL.
+         */
+        url?: boolean;
+        /**
+         * HTTP request headers.
+         */
+        headers?: boolean;
+        /**
+         * HTTP request payload/body.
+         */
+        body?: boolean;
+        /**
+         * Attempt to format body (JSON, XML supported).
+         */
+        formatBody?: boolean | "json" | "xml";
+      };
+      response?: {
+        /**
+         * HTTP response status code.
+         */
+        statusCode?: boolean;
+        /**
+         * HTTP response headers.
+         */
+        headers?: boolean;
+        /**
+         * HTTP body in utf-8.
+         * Does not work for HTTP2 and will be unreadable for BLOB payloads.
+         */
+        body?: boolean;
+        /**
+         * Attempt to format body (JSON, XML supported).
+         */
+        formatBody?: boolean | "json" | "xml";
+      };
+      logger?: Logger;
+    };
+
+/**
+ * FOR DEBUG USE ONLY.
+ * Attaching these debug loggers will degrade performance since body streams may need to be read twice.
+ *
+ * @public
+ *
+ * @param middlewareStack - client or command stack to which to attach functions.
+ * @param options - what to log.
+ */
+export function addHttpDebugLogMiddleware(
+  middlewareStack: MiddlewareStack<any, any>,
+  options: HttpDebugLoggingOptions = {}
+) {
+  const optionsObject: Required<Exclude<HttpDebugLoggingOptions, string>> = {
+    request: {},
+    response: {},
+    logger: console,
+  };
+  if (typeof options === "string") {
+    const [line, header, body, formatted] = [
+      options.includes("line"),
+      options.includes("header"),
+      options.includes("body"),
+      options.includes("formatted"),
+    ];
+    if (line || header || body || formatted) {
+      optionsObject.request.command = true;
+      optionsObject.request.client = true;
+      optionsObject.request.url = true;
+      optionsObject.request.method = true;
+      optionsObject.response.statusCode = true;
+    }
+    if (header) {
+      optionsObject.request.headers = true;
+      optionsObject.response.headers = true;
+    }
+    if (body || formatted) {
+      optionsObject.request.body = true;
+      optionsObject.response.body = true;
+    }
+    if (formatted) {
+      optionsObject.request.formatBody = true;
+      optionsObject.response.formatBody = true;
+    }
+  } else {
+    Object.assign(optionsObject, options);
+  }
+
+  middlewareStack.addRelativeTo(
+    (next: DeserializeHandler<any, any>, context: HandlerExecutionContext) =>
+      async (args: DeserializeHandlerArguments<any>) => {
+        let result: any = undefined;
+        let error: unknown = undefined;
+        let request: HttpRequest | unknown = undefined;
+        let response: HttpResponse | unknown;
+
+        try {
+          result = await next(args);
+          request = args.request;
+          response = result.response;
+        } catch (e) {
+          error = e;
+          response = e.$response;
+          if (response && e.$responseBodyText) {
+            (response as HttpResponse).body = fromUtf8(e.$responseBodyText);
+          }
+        }
+
+        if (HttpRequest.isInstance(request) && HttpResponse.isInstance(response)) {
+          const logger = optionsObject.logger;
+          const line: string[] = [];
+          if (optionsObject.response.statusCode) {
+            line.push(String(response.statusCode));
+          }
+          if (optionsObject.request.method) {
+            line.push(request.method);
+          }
+          const { clientName = "UnknownClient", commandName = "UnknownCommand" } = context;
+          if (optionsObject.request.client) {
+            line.push(clientName);
+          }
+          if (optionsObject.request.command) {
+            line.push(commandName);
+          }
+          logger.debug(line.join(" "));
+          const indentation = line.length ? 4 : 0;
+
+          if (optionsObject.request.url) {
+            let auth = "";
+            if (request.username != null || request.password != null) {
+              const username = request.username ?? "";
+              const password = "***";
+              auth = `${username}:${password}@`;
+            }
+
+            const { port, path } = request;
+            const url = `${request.protocol}//${auth}${request.hostname}${port ? `:${port}` : ""}${path}`;
+            logger.debug(indent(indentation, url));
+            if (Object.keys(request.query).length) {
+              logger.debug(indent(4, ">> Request URL queryParams: " + JSON.stringify(request.query, null, 2)));
+            }
+          }
+          if (optionsObject.request.headers) {
+            const headers = {
+              ...request.headers,
+            };
+            for (const key in headers) {
+              if (key.toLowerCase().match(/security|-token/)) {
+                headers[key] = "***";
+              }
+              if (key.toLowerCase() === "authorization") {
+                let value = "***";
+                if (headers[key].match(/Credential=[A-Z0-9]+/)) {
+                  value = headers[key]
+                    .replace(/Credential=[A-Z0-9\w]+/, "Credential=***")
+                    .replace(/Signature=\w+/, "Signature=***");
+                }
+                headers[key] = value;
+              }
+            }
+            logger.debug(indent(indentation, ">>== Request Headers: " + JSON.stringify(headers, null, 2)));
+          }
+          if (optionsObject.request.body) {
+            const body = await (async () => {
+              if (typeof request.body === "string") {
+                return fromUtf8(request.body);
+              }
+              try {
+                return await headStream(request.body, Infinity);
+              } catch (e) {
+                return fromUtf8(request.body ? String(request.body) : "");
+              }
+            })();
+            const text = format(body, optionsObject.request.formatBody);
+            logger.debug(indent(indentation, `>>>=== Request Body Start ======`));
+            logger.debug(indent(indentation, text));
+            logger.debug(indent(indentation, `>>>=== Request Body End ======`));
+            request.body = body;
+          }
+
+          if (optionsObject.response.headers) {
+            logger.debug(indent(indentation, "<<== Response Headers: " + JSON.stringify(response.headers, null, 2)));
+          }
+          if (optionsObject.response.body) {
+            const bodyBytes = await headStream(response.body, Infinity);
+            const text = format(bodyBytes, optionsObject.response.formatBody);
+            logger.debug(indent(indentation, `<<<=== Response Body Start ======`));
+            logger.debug(indent(indentation, text));
+            logger.debug(indent(indentation, `<<<=== Response Body End ======`));
+            response.body = bodyBytes;
+          }
+        }
+
+        if (error) {
+          throw error;
+        }
+        return result;
+      },
+    {
+      toMiddleware: "deserializerMiddleware",
+      relation: "after",
+      name: "httpDebugLogMiddleware",
+      override: true,
+    }
+  );
+}
+
+/**
+ * @internal
+ */
+function format(str: string | Uint8Array, format: boolean | "json" | "xml" = false): string {
+  if (!str) {
+    return "";
+  }
+  let text = "";
+  try {
+    text = toUtf8(str);
+    if (format === true || format === "json") {
+      try {
+        text = JSON.stringify(JSON.parse(text), null, 2);
+      } catch (e) {
+        // ignore error, text is not JSON.
+      }
+    }
+    if (format === true || format === "xml") {
+      try {
+        if (text.startsWith("<?xml")) {
+          text = simpleFormatXml(text);
+        }
+      } catch (e) {
+        // ignore error, text is not XML.
+      }
+    }
+  } catch (e) {
+    text = `Failed to read bytes to utf-8: ${String(e)}`;
+  }
+  return text;
+}
+
+/**
+ * @internal
+ */
+function indent(spaces: number, str: string): string {
+  const indentation = "\n" + " ".repeat(spaces);
+  return " ".repeat(spaces) + str.split("\n").join(indentation);
+}
+
+/**
+ * Ok, parsing XML without an XML parsing library
+ * is one of the classic mistakes of software development.
+ *
+ * However, this is for optional debug printing purposes only, and
+ * we do not want to take an additional XML dependency
+ * for that.
+ *
+ * @internal
+ */
+function simpleFormatXml(xml: string): string {
+  let b = "";
+  let indentation = 0;
+  for (let i = 0; i < xml.length; ++i) {
+    const c = xml[i];
+
+    if (c === "<") {
+      if (xml[i + 1] === "/") {
+        b += "\n" + " ".repeat(indentation - 2) + c;
+        indentation -= 4;
+      } else {
+        b += c;
+      }
+    } else if (c === ">") {
+      indentation += 2;
+      b += c + "\n" + " ".repeat(indentation);
+    } else {
+      b += c;
+    }
+  }
+  return b
+    .split("\n")
+    .filter((s) => !!s.trim())
+    .join("\n");
+}

--- a/packages/core/src/submodules/debug/index.ts
+++ b/packages/core/src/submodules/debug/index.ts
@@ -1,0 +1,1 @@
+export { addHttpDebugLogMiddleware, type HttpDebugLoggingOptions } from "./httpDebugLogging";

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -6,7 +6,8 @@
     "paths": {
       "@smithy/core/cbor": ["./src/submodules/cbor/index.ts"],
       "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"],
-      "@smithy/core/serde": ["./src/submodules/serde/index.ts"]
+      "@smithy/core/serde": ["./src/submodules/serde/index.ts"],
+      "@smithy/core/debug": ["./src/submodules/debug/index.ts"]
     }
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/core/tsconfig.es.json
+++ b/packages/core/tsconfig.es.json
@@ -7,7 +7,8 @@
     "paths": {
       "@smithy/core/cbor": ["./src/submodules/cbor/index.ts"],
       "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"],
-      "@smithy/core/serde": ["./src/submodules/serde/index.ts"]
+      "@smithy/core/serde": ["./src/submodules/serde/index.ts"],
+      "@smithy/core/debug": ["./src/submodules/debug/index.ts"]
     }
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/core/tsconfig.types.json
+++ b/packages/core/tsconfig.types.json
@@ -6,7 +6,8 @@
     "paths": {
       "@smithy/core/cbor": ["./src/submodules/cbor/index.ts"],
       "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"],
-      "@smithy/core/serde": ["./src/submodules/serde/index.ts"]
+      "@smithy/core/serde": ["./src/submodules/serde/index.ts"],
+      "@smithy/core/debug": ["./src/submodules/debug/index.ts"]
     }
   },
   "extends": "../../tsconfig.types.json",


### PR DESCRIPTION
PR adds a function `addHttpDebugLogMiddleware` exported from `@smithy/core/debug`, a standalone submodule that will not affect the size of existing applications.

The configurable function attaches middleware to a client or command middleware stack and logs HTTP messages. 
The level of detail can be configured, and XML and JSON formatting are supported.

```js
import { DynamoDB } from "@aws-sdk/client-dynamodb";
import { addHttpDebugLogMiddleware } from "@smithy/core/debug";

const client = new DynamoDB();

// 2nd parameter is options. It can be an object or a string with word-matches.
// See PR diff for details.
addHttpDebugLogMiddleware(client.middlewareStack, "line headers formatted");

await client
  .describeTable({
    TableName: "test",
  })
  .catch(() => {});
```

output:

```txt
200 POST DynamoDBClient DescribeTableCommand
    https://....ddb.us-west-2.amazonaws.com/
    >> Request Headers: {
      "content-type": "application/x-amz-json-1.0",
      "x-amz-target": "DynamoDB_20120810.DescribeTable",
      "content-length": "...",
      "x-amz-user-agent": "aws-sdk-js/3.767.0",
      "user-agent": "aws-sdk-js/3.767.0 ua/2.1 os/darwin#24.3.0 lang/js md/nodejs#20.18.1 api/dynamodb#3.767.0 m/E,O,P,T,i,o",
      "host": ".....ddb.us-west-2.amazonaws.com",
      "amz-sdk-invocation-id": "a0aa9a03-72a6-4b6f-8587-....",
      "amz-sdk-request": "attempt=1; max=3",
      "x-amz-date": "20250318T201446Z",
      "x-amz-security-token": "***",
      "x-amz-content-sha256": "....",
      "authorization": "AWS4-HMAC-SHA256 Credential=***/20250318/us-west-2/dynamodb/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, Signature=***"
    }
    << Response Headers: {
      "server": "Server",
      "date": "Tue, 18 Mar 2025 20:14:46 GMT",
      "content-type": "application/x-amz-json-1.0",
      "content-length": "....",
      "connection": "keep-alive",
      "x-amzn-requestid": "....",
      "x-amz-crc32": "...."
    }
    ====== Response Body Start ======
    {
      "Table": {
        "AttributeDefinitions": [
          ...
        ],
        "BillingModeSummary": {
          ...
        },
        ... 
      }
    }
    ====== Response Body End ======
```