### PR TITLE
chore(codegen): generate client.initConfig reference for tracking config object custody

### DIFF
--- a/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
@@ -247,11 +247,12 @@ export class RpcV2ProtocolClient extends __Client<
 
   constructor(...[configuration]: __CheckOptionalClientConfig<RpcV2ProtocolClientConfig>) {
     let _config_0 = __getRuntimeConfig(configuration || {});
+    super(_config_0 as any);
+    this.initConfig = _config_0;
     let _config_1 = resolveCustomEndpointsConfig(_config_0);
     let _config_2 = resolveRetryConfig(_config_1);
     let _config_3 = resolveHttpAuthSchemeConfig(_config_2);
     let _config_4 = resolveRuntimeExtensions(_config_3, configuration?.extensions || []);
-    super(_config_4);
     this.config = _config_4;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));

--- a/private/smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
+++ b/private/smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
@@ -104,7 +104,5 @@ export interface HttpAuthSchemeResolvedConfig {
 export const resolveHttpAuthSchemeConfig = <T>(
   config: T & HttpAuthSchemeInputConfig
 ): T & HttpAuthSchemeResolvedConfig => {
-  return {
-    ...config,
-  } as T & HttpAuthSchemeResolvedConfig;
+  return Object.assign(config, {}) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/private/smithy-rpcv2-cbor/src/runtimeExtensions.ts
+++ b/private/smithy-rpcv2-cbor/src/runtimeExtensions.ts
@@ -18,24 +18,22 @@ export interface RuntimeExtensionsConfig {
   extensions: RuntimeExtension[];
 }
 
-const asPartial = <T extends Partial<RpcV2ProtocolExtensionConfiguration>>(t: T) => t;
-
 /**
  * @internal
  */
 export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: RuntimeExtension[]) => {
-  const extensionConfiguration: RpcV2ProtocolExtensionConfiguration = {
-    ...asPartial(getDefaultExtensionConfiguration(runtimeConfig)),
-    ...asPartial(getHttpHandlerExtensionConfiguration(runtimeConfig)),
-    ...asPartial(getHttpAuthExtensionConfiguration(runtimeConfig)),
-  };
+  const extensionConfiguration: RpcV2ProtocolExtensionConfiguration = Object.assign(
+    getDefaultExtensionConfiguration(runtimeConfig),
+    getHttpHandlerExtensionConfiguration(runtimeConfig),
+    getHttpAuthExtensionConfiguration(runtimeConfig)
+  );
 
   extensions.forEach((extension) => extension.configure(extensionConfiguration));
 
-  return {
-    ...runtimeConfig,
-    ...resolveDefaultRuntimeConfig(extensionConfiguration),
-    ...resolveHttpHandlerRuntimeConfig(extensionConfiguration),
-    ...resolveHttpAuthRuntimeConfig(extensionConfiguration),
-  };
+  return Object.assign(
+    runtimeConfig,
+    resolveDefaultRuntimeConfig(extensionConfiguration),
+    resolveHttpHandlerRuntimeConfig(extensionConfiguration),
+    resolveHttpAuthRuntimeConfig(extensionConfiguration)
+  );
 };

--- a/private/smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
+++ b/private/smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
@@ -829,7 +829,7 @@ it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async () => {
     expect(r.headers["smithy-protocol"]).toBe("rpc-v2-cbor");
 
     expect(r.body).toBeDefined();
-    const bodyString = `v2hkZWZhdWx0c79tZGVmYXVsdFN0cmluZ2JoaW5kZWZhdWx0Qm9vbGVhbvVrZGVmYXVsdExpc3Sf/3BkZWZhdWx0VGltZXN0YW1wwQBrZGVmYXVsdEJsb2JjYWJja2RlZmF1bHRCeXRlAWxkZWZhdWx0U2hvcnQBbmRlZmF1bHRJbnRlZ2VyCmtkZWZhdWx0TG9uZxhkbGRlZmF1bHRGbG9hdPo/gAAAbWRlZmF1bHREb3VibGX6P4AAAGpkZWZhdWx0TWFwv/9rZGVmYXVsdEVudW1jRk9PbmRlZmF1bHRJbnRFbnVtAWtlbXB0eVN0cmluZ2BsZmFsc2VCb29sZWFu9GllbXB0eUJsb2JgaHplcm9CeXRlAGl6ZXJvU2hvcnQAa3plcm9JbnRlZ2VyAGh6ZXJvTG9uZwBpemVyb0Zsb2F0+gAAAABqemVyb0RvdWJsZfoAAAAA//8=`;
+    const bodyString = `v2hkZWZhdWx0c79tZGVmYXVsdFN0cmluZ2JoaW5kZWZhdWx0Qm9vbGVhbvVrZGVmYXVsdExpc3Sf/3BkZWZhdWx0VGltZXN0YW1wwQBrZGVmYXVsdEJsb2JDYWJja2RlZmF1bHRCeXRlAWxkZWZhdWx0U2hvcnQBbmRlZmF1bHRJbnRlZ2VyCmtkZWZhdWx0TG9uZxhkbGRlZmF1bHRGbG9hdPo/gAAAbWRlZmF1bHREb3VibGX6P4AAAGpkZWZhdWx0TWFwv/9rZGVmYXVsdEVudW1jRk9PbmRlZmF1bHRJbnRFbnVtAWtlbXB0eVN0cmluZ2BsZmFsc2VCb29sZWFu9GllbXB0eUJsb2JAaHplcm9CeXRlAGl6ZXJvU2hvcnQAa3plcm9JbnRlZ2VyAGh6ZXJvTG9uZwBpemVyb0Zsb2F0+gAAAABqemVyb0RvdWJsZfoAAAAA//8`;
     const unequalParts: any = compareEquivalentCborBodies(bodyString, r.body);
     expect(unequalParts).toBeUndefined();
   }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeExtensionsGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeExtensionsGenerator.java
@@ -86,7 +86,7 @@ public class RuntimeExtensionsGenerator {
             writer.indent().onSection("getPartialExtensionConfigurations", original -> {
                 for (TypeScriptIntegration integration : integrations) {
                     integration.getExtensionConfigurationInterfaces(model, settings).forEach(configurationInterface -> {
-                        writer.indent(2).write("...asPartial($L(runtimeConfig)),",
+                        writer.indent(2).write("$L(runtimeConfig),",
                                 configurationInterface.getExtensionConfigurationFn().left);
                         writer.dedent(2);
                     });
@@ -97,7 +97,7 @@ public class RuntimeExtensionsGenerator {
             writer.indent().onSection("resolvePartialRuntimeConfigs", original -> {
                 for (TypeScriptIntegration integration : integrations) {
                     integration.getExtensionConfigurationInterfaces(model, settings).forEach(configurationInterface -> {
-                        writer.indent(2).write("...$L(extensionConfiguration),",
+                        writer.indent(2).write("$L(extensionConfiguration),",
                                 configurationInterface.resolveRuntimeConfigFn().left);
                         writer.dedent(2);
                     });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -375,8 +375,11 @@ public final class ServiceBareBonesClientGenerator implements Runnable {
                 .build());
 
             int configVariable = 0;
+            String initialConfigVar = generateConfigVariable(configVariable);
             writer.write("let $L = __getRuntimeConfig(configuration || {});",
-                    generateConfigVariable(configVariable));
+                initialConfigVar);
+            writer.write("super($L as any);", initialConfigVar);
+            writer.write("this.initConfig = $L;", initialConfigVar);
 
             if (service.hasTrait(EndpointRuleSetTrait.class)) {
                 configVariable++;
@@ -429,7 +432,6 @@ public final class ServiceBareBonesClientGenerator implements Runnable {
                 generateConfigVariable(configVariable),
                 generateConfigVariable(configVariable - 1));
 
-            writer.write("super($L);", generateConfigVariable(configVariable));
             writer.write("this.config = $L;", generateConfigVariable(configVariable));
 
             // Add runtime plugins that contain middleware to the middleware stack

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -146,8 +146,7 @@ public final class EndpointsV2Generator implements Runnable {
                         + "): T & ClientResolvedEndpointParameters => {",
                     "}",
                     () -> {
-                        writer.openBlock("return {", "}", () -> {
-                            writer.write("...options,");
+                        writer.openBlock("return Object.assign(options, {", "});", () -> {
                             ObjectNode ruleSet = endpointRuleSetTrait.getRuleSet().expectObjectNode();
                             ruleSet.getObjectMember("parameters").ifPresent(parameters -> {
                                 parameters.accept(new RuleSetParametersVisitor(writer, true));

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/resolveRuntimeExtensions1.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/resolveRuntimeExtensions1.template
@@ -14,8 +14,6 @@ export interface RuntimeExtensionsConfig {
     extensions: RuntimeExtension[]
 }
 
-const asPartial = <T extends Partial<${extensionConfigName}>>(t: T) => t;
-
 /**
  * @internal
  */
@@ -23,8 +21,8 @@ export const resolveRuntimeExtensions = (
     runtimeConfig: any,
     extensions: RuntimeExtension[]
 ) => {
-  const extensionConfiguration: ${extensionConfigName} = {
+  const extensionConfiguration: ${extensionConfigName} = Object.assign(
 ${getPartialExtensionConfigurations}
-  };
+  );
 
   extensions.forEach(extension => extension.configure(extensionConfiguration));

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/resolveRuntimeExtensions2.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/resolveRuntimeExtensions2.template
@@ -1,5 +1,4 @@
-  return {
-    ...runtimeConfig,
+  return Object.assign(runtimeConfig,
 ${resolvePartialRuntimeConfigs}
-  };
+  );
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeExtensions2.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeExtensions2.template
@@ -1,5 +1,4 @@
-  return {
-    ...runtimeConfig,
+  return Object.assign(runtimeConfig,
 ${resolvePartialRuntimeConfigs}
-  };
+  );
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2GeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2GeneratorTest.java
@@ -50,11 +50,10 @@ public class EndpointsV2GeneratorTest {
         String endpointParameters = manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/endpoint/EndpointParameters.ts").get();
 
         assertThat(endpointParameters, containsString(
-                "  return {\n" +
-                "    ...options,\n" +
+                "  return Object.assign(options, {\n" +
                 "    stage: options.stage ?? \"production\",\n" +
                 "    defaultSigningName: \"\",\n" +
-                "  }\n"));
+                "  });\n"));
         assertThat(endpointParameters, containsString(
                 "export interface ClientInputEndpointParameters {\n" +
                 "  region?: string|Provider<string>;\n" +


### PR DESCRIPTION
part 2 of https://github.com/smithy-lang/smithy-typescript/pull/1552