### PR TITLE
fix: use backticks for example strings containing doublequotes

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/documentation/DocumentationExampleGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/documentation/DocumentationExampleGenerator.java
@@ -84,6 +84,9 @@ public final class DocumentationExampleGenerator {
             }
             case STRING -> {
                 StringNode stringNode = node.expectStringNode();
+                if (stringNode.getValue().contains("\"")) {
+                    return "`" + stringNode.getValue() + "`";
+                }
                 return "\"" + stringNode.getValue() + "\"";
             }
             case NUMBER -> {


### PR DESCRIPTION
in example generation, use backtick to wrap strings containing double quotes

diff can be seen in https://github.com/aws/aws-sdk-js-v3/pull/6981