### PR TITLE
Bump codegen version to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.28.0 (2025-04-01)
+
+### Bug Fixes
+- Used backticks for example strings containing doublequotes ([#1556](https://github.com/smithy-lang/smithy-typescript/pull/1556))
+- Generated client.initConfig reference for tracking config object custody ([#1550](https://github.com/smithy-lang/smithy-typescript/pull/1550))
+- Used generic type for client config ([#1549](https://github.com/smithy-lang/smithy-typescript/pull/1549))
+- Allowed authscheme resolver to access client ref ([#1548](https://github.com/smithy-lang/smithy-typescript/pull/1548))
+
+### Documentation
+- Added doc examples to operations ([#1078](https://github.com/smithy-lang/smithy-typescript/pull/1078))
+- Replaced GitHub org from 'awslabs' to 'smithy-lang' ([#1545](https://github.com/smithy-lang/smithy-typescript/pull/1545))
+
 ## 0.27.0 (2025-03-04)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.27.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.28.0"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -139,7 +139,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.27.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.28.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.27.0"
+    version = "0.28.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*
JS-5804

*Description of changes:*
Bumps the codegen version from 0.27 to 0.28

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
