### PR TITLE
Bump codegen version to 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.29.0 (2025-04-11)
+
+### Features
+- Upgraded smithy version to 1.55.0 ([#1560](https://github.com/smithy-lang/smithy-typescript/pull/1560))
+
+### Bug Fixes
+- Fixed bug with JMESPath flatten level codegen ([#1559](https://github.com/smithy-lang/smithy-typescript/pull/1559))
+
 ## 0.28.0 (2025-04-01)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.28.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.0"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -139,7 +139,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.28.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.28.0"
+    version = "0.29.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-5832

*Description of changes:*

Bumps the codegen version from 0.28.0 to 0.29.0

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
