### PR TITLE
chore(workflow): update action token for npm release

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{secrets.PUSH_TOKEN}}
+          token: ${{secrets.PR_TOKEN}}
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
*Description of changes:*
updating token to use an org-level token since the `PUSH_TOKEN` seems to have expired, and the js automation token won't work


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
