### PR TITLE
Bump codegen version to 0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.29.1 (2025-04-24)
+
+### Features
+- Created SignatureV4a JavaScript implementation ([#1319](https://github.com/smithy-lang/smithy-typescript/pull/1319))
+
+### Documentation
+- Fixed broken links for ts-ssdk related content ([#1568](https://github.com/smithy-lang/smithy-typescript/pull/1568))
+
 ## 0.29.0 (2025-04-11)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 ## 0.29.1 (2025-04-24)
 
-### Features
-- Created SignatureV4a JavaScript implementation ([#1319](https://github.com/smithy-lang/smithy-typescript/pull/1319))
-
-### Documentation
-- Fixed broken links for ts-ssdk related content ([#1568](https://github.com/smithy-lang/smithy-typescript/pull/1568))
+### Chores
+- Bumped version to match release of smithy-aws-typescript-codegen
 
 ## 0.29.0 (2025-04-11)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.1"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -139,7 +139,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.1")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.29.0"
+    version = "0.29.1"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5859

*Description of changes:*
Bumps the codegen version from 0.29.0 to 0.29.1


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
