### PR TITLE
Update SmithyVersion to 1.56.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.55.0
+smithyVersion=1.56.0
 smithyGradleVersion=1.2.0

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1079,13 +1079,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         // Use a ! since we already validated the input member is defined above.
                         String headerValue = getInputValue(context, binding.getLocation(),
                                 memberLocation + "![suffix]", binding.getMember(), target);
-                        String headerKey = binding.getLocationName().toLowerCase(Locale.US) + "${suffix.toLowerCase()}";
-                        writer.write("const headerKey = `$L`;", headerKey);
-                        writer.write("if (!Object.keys(headers).some(key => {");
-                        writer.write("  return key.toLowerCase() === headerKey.toLowerCase();");
-                        writer.write("})) {");
-                        writer.write("  acc[headerKey] = $L;", headerValue);
-                        writer.write("}");
+                        // Append the prefix to key.
+                        writer.write("acc[`$L$${suffix.toLowerCase()}`] = $L;",
+                                binding.getLocationName().toLowerCase(Locale.US), headerValue);
                         writer.write("return acc;");
                     });
             }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/pull/7045

Description
Upgrades the smithy cli to 1.56.0 and fix the order of precedence for the prefix headers


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
