### PR TITLE
fix(service-error-classification): add TypeError as transient error

### DIFF
--- a/.changeset/large-donkeys-notice.md
+++ b/.changeset/large-donkeys-notice.md
@@ -1,0 +1,5 @@
+---
+"@smithy/service-error-classification": patch
+---
+
+add browser connection issues as transient errors to retry on

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -36,6 +36,7 @@ export const isTransientError = (error: SdkError, depth = 0): boolean =>
   TRANSIENT_ERROR_CODES.includes(error.name) ||
   NODEJS_TIMEOUT_ERROR_CODES.includes((error as { code?: string })?.code || "") ||
   TRANSIENT_ERROR_STATUS_CODES.includes(error.$metadata?.httpStatusCode || 0) ||
+  error instanceof TypeError ||
   (error.cause !== undefined && depth <= 10 && isTransientError(error.cause, depth + 1));
 
 export const isServerError = (error: SdkError) => {


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5890

*Description of changes:*
fetch API surfaces connectivity errors as TypeErrors, example: `TypeError: Failed to fetch` in Chrome. 

For browsers, we should retry for connectivity issues (offline), this is a fix to retry on TypeErrors then. Since we don't want to retry for `TypeErrors` that *aren't* network errors, I've paired this check with the actual error messages that different browsers surface (not an exhaustive list, but covers some major ones). 

Fetch has an open issue about this: https://github.com/whatwg/fetch/issues/526

additional resources
- https://stackoverflow.com/questions/61113344/fetch-api-how-to-determine-if-an-error-is-a-network-error

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
