### PR TITLE
fix(cbor): copy headers when building request

### DIFF
--- a/.changeset/friendly-parents-compare.md
+++ b/.changeset/friendly-parents-compare.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+copy input headers when building RPCv2 CBOR request

--- a/packages/core/src/submodules/cbor/parseCborBody.spec.ts
+++ b/packages/core/src/submodules/cbor/parseCborBody.spec.ts
@@ -1,0 +1,32 @@
+import { buildHttpRpcRequest } from "./parseCborBody";
+
+import { describe, test as it, expect } from "vitest";
+
+describe("buildHttpRpcRequest", () => {
+  it("should copy the input headers", async () => {
+    const headers = {
+      "content-type": "application/cbor",
+      "smithy-protocol": "rpc-v2-cbor",
+      accept: "application/cbor",
+      "content-length": "0",
+    };
+
+    const request = await buildHttpRpcRequest(
+      {
+        async endpoint() {
+          return {
+            hostname: "https://localhost",
+            path: "/",
+          };
+        },
+      } as any,
+      headers,
+      "/",
+      "",
+      ""
+    );
+
+    expect(request.headers).toEqual(headers);
+    expect(request.headers).not.toBe(headers);
+  });
+});

--- a/packages/core/src/submodules/cbor/parseCborBody.ts
+++ b/packages/core/src/submodules/cbor/parseCborBody.ts
@@ -100,7 +100,10 @@ export const buildHttpRpcRequest = async (
     port,
     method: "POST",
     path: basePath.endsWith("/") ? basePath.slice(0, -1) + path : basePath + path,
-    headers,
+    headers: {
+      // intentional copy.
+      ...headers,
+    },
   };
   if (resolvedHostname !== undefined) {
     contents.hostname = resolvedHostname;


### PR DESCRIPTION
Copy headers when building RPCv2 CBOR request. This is because some requests use the shared headers object and sigv4 signing mutates the request instead of returning a new one.

Rather than changing sigv4 behavior, which is more likely to have accidental reliance on the mutation, I am changing the request creation in the affected protocol.
