### PR TITLE
chore(builds): skip typecheck for cjs/es artifacts

### DIFF
--- a/private/smithy-rpcv2-cbor/tsconfig.cjs.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist-cjs"
+    "outDir": "dist-cjs",
+    "noCheck": true
   }
 }

--- a/private/smithy-rpcv2-cbor/tsconfig.es.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.es.json
@@ -4,6 +4,7 @@
     "lib": ["dom"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "outDir": "dist-es"
+    "outDir": "dist-es",
+    "noCheck": true
   }
 }

--- a/private/smithy-rpcv2-cbor/tsconfig.types.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.types.json
@@ -4,7 +4,8 @@
     "removeComments": false,
     "declaration": true,
     "declarationDir": "dist-types",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "noCheck": false
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.cjs.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist-cjs"
+    "outDir": "dist-cjs",
+    "noCheck": true
   }
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
@@ -4,6 +4,7 @@
     "lib": ["dom"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "outDir": "dist-es"
+    "outDir": "dist-es",
+    "noCheck": true
   }
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
@@ -4,7 +4,8 @@
     "removeComments": false,
     "declaration": true,
     "declarationDir": "dist-types",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "noCheck": false
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -5,6 +5,6 @@
     "module": "commonjs",
     "noEmitHelpers": false,
     "target": "ES2018",
-    "strict": true
+    "noCheck": true
   }
 }

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -6,6 +6,6 @@
     "moduleResolution": "bundler",
     "noEmitHelpers": false,
     "target": "ES2020",
-    "strict": true
+    "noCheck": true
   }
 }


### PR DESCRIPTION
Type checking is not necessary for the CJS and ES build configurations.

This is because the dist-types build checks all types, including code inside functions that do not appear in the API type declarations. I have verified this.

Skipping type checks will improve build times and avoid redundant compilation errors printed to the console. Because all 3 dist builds run concurrently in the "build" scripts of packages, any existing type error is printed to the console 3 times in interleaved lines, resulting in a hard to read output.

savings in CI:
build packages step ~6m40s -> ~4m42s