### PR TITLE
chore(node-config-provider): pass options with signing name to environment variable selector

### DIFF
--- a/.changeset/rotten-chairs-float.md
+++ b/.changeset/rotten-chairs-float.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-config-provider": minor
+---
+
+Pass options with signing name to environment variable selector

--- a/packages/node-config-provider/src/configLoader.spec.ts
+++ b/packages/node-config-provider/src/configLoader.spec.ts
@@ -39,7 +39,7 @@ describe("loadConfig", () => {
       configuration
     );
     expect(fromEnv).toHaveBeenCalledTimes(1);
-    expect(fromEnv).toHaveBeenCalledWith(envVarSelector);
+    expect(fromEnv).toHaveBeenCalledWith(envVarSelector, undefined);
     expect(fromSharedConfigFiles).toHaveBeenCalledTimes(1);
     expect(fromSharedConfigFiles).toHaveBeenCalledWith(configKey, configuration);
     expect(fromStatic).toHaveBeenCalledTimes(1);
@@ -61,5 +61,27 @@ describe("loadConfig", () => {
     const mockMemoizeReturn = "mockMemoizeReturn";
     vi.mocked(memoize).mockReturnValueOnce(mockMemoizeReturn);
     expect(loadConfig({} as any)).toEqual(mockMemoizeReturn);
+  });
+
+  it("passes signingName in options object of fromEnv()", () => {
+    const configWithSigningName = {
+      ...configuration,
+      signingName: "signingName",
+    };
+    const envVarSelector = (env: Record<string, string | undefined>) => env["AWS_CONFIG_FOO"];
+    const configKey = (profile: Profile) => profile["aws_config_foo"];
+    const defaultValue = "foo-value";
+
+    loadConfig(
+      {
+        environmentVariableSelector: envVarSelector,
+        configFileSelector: configKey,
+        default: defaultValue,
+      },
+      configWithSigningName
+    );
+
+    expect(fromEnv).toHaveBeenCalledTimes(1);
+    expect(fromEnv).toHaveBeenCalledWith(envVarSelector, { signingName: configWithSigningName.signingName });
   });
 });

--- a/packages/node-config-provider/src/configLoader.ts
+++ b/packages/node-config-provider/src/configLoader.ts
@@ -1,14 +1,14 @@
 import { chain, memoize } from "@smithy/property-provider";
 import { Provider } from "@smithy/types";
 
-import { fromEnv, GetterFromEnv } from "./fromEnv";
+import { ClientOptions, fromEnv, GetterFromEnv } from "./fromEnv";
 import { fromSharedConfigFiles, GetterFromConfig, SharedConfigInit } from "./fromSharedConfigFiles";
 import { fromStatic, FromStaticConfig } from "./fromStatic";
 
 /**
  * @internal
  */
-export type LocalConfigOptions = SharedConfigInit;
+export type LocalConfigOptions = SharedConfigInit & ClientOptions;
 
 /**
  * @internal
@@ -39,7 +39,7 @@ export const loadConfig = <T = string>(
 ): Provider<T> =>
   memoize(
     chain(
-      fromEnv(environmentVariableSelector),
+      fromEnv(environmentVariableSelector, { signingName: configuration.signingName }),
       fromSharedConfigFiles(configFileSelector, configuration),
       fromStatic(defaultValue)
     )

--- a/packages/node-config-provider/src/configLoader.ts
+++ b/packages/node-config-provider/src/configLoader.ts
@@ -1,14 +1,14 @@
 import { chain, memoize } from "@smithy/property-provider";
 import { Provider } from "@smithy/types";
 
-import { ClientOptions, fromEnv, GetterFromEnv } from "./fromEnv";
+import { EnvOptions, fromEnv, GetterFromEnv } from "./fromEnv";
 import { fromSharedConfigFiles, GetterFromConfig, SharedConfigInit } from "./fromSharedConfigFiles";
 import { fromStatic, FromStaticConfig } from "./fromStatic";
 
 /**
  * @internal
  */
-export type LocalConfigOptions = SharedConfigInit & ClientOptions;
+export type LocalConfigOptions = SharedConfigInit & EnvOptions;
 
 /**
  * @internal
@@ -36,11 +36,13 @@ export interface LoadedConfigSelectors<T> {
 export const loadConfig = <T = string>(
   { environmentVariableSelector, configFileSelector, default: defaultValue }: LoadedConfigSelectors<T>,
   configuration: LocalConfigOptions = {}
-): Provider<T> =>
-  memoize(
+): Provider<T> => {
+  const envOptions = configuration.signingName ? { signingName: configuration.signingName } : undefined;
+  return memoize(
     chain(
-      fromEnv(environmentVariableSelector, { signingName: configuration.signingName }),
+      fromEnv(environmentVariableSelector, envOptions),
       fromSharedConfigFiles(configFileSelector, configuration),
       fromStatic(defaultValue)
     )
   );
+};

--- a/packages/node-config-provider/src/fromEnv.spec.ts
+++ b/packages/node-config-provider/src/fromEnv.spec.ts
@@ -1,19 +1,26 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { afterAll, beforeEach, describe, expect, test as it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
-import { fromEnv, GetterFromEnv } from "./fromEnv";
+import { fromEnv } from "./fromEnv";
 
 describe("fromEnv", () => {
   describe("with env var getter", () => {
     const ENV_VAR_NAME = "ENV_VAR_NAME";
 
-    // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
-    const envVarGetter: GetterFromEnv<string> = (env: Record<string, string | undefined>) => env[ENV_VAR_NAME]!;
+    const envVarGetter = vi.fn();
     const envVarValue = process.env[ENV_VAR_NAME];
     const mockEnvVarValue = "mockEnvVarValue";
 
     beforeEach(() => {
+      envVarGetter.mockImplementation((env: Record<string, string>) => {
+        if (env[ENV_VAR_NAME]) return env[ENV_VAR_NAME];
+        throw new CredentialsProviderError(`Not found in ENV: ${ENV_VAR_NAME}`);
+      });
       delete process.env[ENV_VAR_NAME];
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
     });
 
     afterAll(() => {
@@ -27,9 +34,17 @@ describe("fromEnv", () => {
       });
     });
 
-    it(`returns string value in '${ENV_VAR_NAME}' env var when set`, () => {
+    it(`returns string value in '${ENV_VAR_NAME}' env var when set`, async () => {
       process.env[ENV_VAR_NAME] = mockEnvVarValue;
-      return expect(fromEnv(envVarGetter)()).resolves.toBe(mockEnvVarValue);
+      await expect(fromEnv(envVarGetter)()).resolves.toBe(mockEnvVarValue);
+      expect(envVarGetter).toHaveBeenCalledWith(process.env, undefined);
+    });
+
+    it(`passes options to envVarSelector if it's set`, async () => {
+      process.env[ENV_VAR_NAME] = mockEnvVarValue;
+      const options = { signingName: "signingName" };
+      await expect(fromEnv(envVarGetter, options)()).resolves.toBe(mockEnvVarValue);
+      expect(envVarGetter).toHaveBeenCalledWith(process.env, options);
     });
 
     it("return complex value from the getter", () => {

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -3,7 +3,10 @@ import { Provider } from "@smithy/types";
 
 import { getSelectorName } from "./getSelectorName";
 
-export interface ClientOptions {
+/**
+ * @internal
+ */
+export interface EnvOptions {
   /**
    * The SigV4 service signing name.
    */
@@ -11,14 +14,14 @@ export interface ClientOptions {
 }
 
 // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
-export type GetterFromEnv<T> = (env: Record<string, string | undefined>, options?: ClientOptions) => T | undefined;
+export type GetterFromEnv<T> = (env: Record<string, string | undefined>, options?: EnvOptions) => T | undefined;
 
 /**
  * Get config value given the environment variable name or getter from
  * environment variable.
  */
 export const fromEnv =
-  <T = string>(envVarSelector: GetterFromEnv<T>, options?: ClientOptions): Provider<T> =>
+  <T = string>(envVarSelector: GetterFromEnv<T>, options?: EnvOptions): Provider<T> =>
   async () => {
     try {
       const config = envVarSelector(process.env, options);

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,28 +1,34 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { Logger, Provider } from "@smithy/types";
+import { Provider } from "@smithy/types";
 
 import { getSelectorName } from "./getSelectorName";
 
+export interface ClientOptions {
+  /**
+   * The SigV4 service signing name.
+   */
+  signingName?: string;
+}
+
 // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
-export type GetterFromEnv<T> = (env: Record<string, string | undefined>) => T | undefined;
+export type GetterFromEnv<T> = (env: Record<string, string | undefined>, options?: ClientOptions) => T | undefined;
 
 /**
  * Get config value given the environment variable name or getter from
  * environment variable.
  */
 export const fromEnv =
-  <T = string>(envVarSelector: GetterFromEnv<T>, logger?: Logger): Provider<T> =>
+  <T = string>(envVarSelector: GetterFromEnv<T>, options?: ClientOptions): Provider<T> =>
   async () => {
     try {
-      const config = envVarSelector(process.env);
+      const config = envVarSelector(process.env, options);
       if (config === undefined) {
         throw new Error();
       }
       return config as T;
     } catch (e) {
       throw new CredentialsProviderError(
-        e.message || `Not found in ENV: ${getSelectorName(envVarSelector.toString())}`,
-        { logger }
+        e.message || `Not found in ENV: ${getSelectorName(envVarSelector.toString())}`
       );
     }
   };


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5860

*Description of changes:*
Gets configuration with optional signingName in loadConfig, and passes it to environment variable selector

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
