### PR TITLE
fix(node-config-provider): pass logger to environment variable selector

### DIFF
--- a/.changeset/calm-socks-end.md
+++ b/.changeset/calm-socks-end.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-config-provider": patch
+---
+
+Pass logger to environment variable selector

--- a/packages/node-config-provider/src/configLoader.spec.ts
+++ b/packages/node-config-provider/src/configLoader.spec.ts
@@ -39,7 +39,7 @@ describe("loadConfig", () => {
       configuration
     );
     expect(fromEnv).toHaveBeenCalledTimes(1);
-    expect(fromEnv).toHaveBeenCalledWith(envVarSelector, undefined);
+    expect(fromEnv).toHaveBeenCalledWith(envVarSelector, {});
     expect(fromSharedConfigFiles).toHaveBeenCalledTimes(1);
     expect(fromSharedConfigFiles).toHaveBeenCalledWith(configKey, configuration);
     expect(fromStatic).toHaveBeenCalledTimes(1);
@@ -83,5 +83,27 @@ describe("loadConfig", () => {
 
     expect(fromEnv).toHaveBeenCalledTimes(1);
     expect(fromEnv).toHaveBeenCalledWith(envVarSelector, { signingName: configWithSigningName.signingName });
+  });
+
+  it("passes logger in options object of fromEnv()", () => {
+    const configWithSigningName = {
+      ...configuration,
+      logger: console,
+    };
+    const envVarSelector = (env: Record<string, string | undefined>) => env["AWS_CONFIG_FOO"];
+    const configKey = (profile: Profile) => profile["aws_config_foo"];
+    const defaultValue = "foo-value";
+
+    loadConfig(
+      {
+        environmentVariableSelector: envVarSelector,
+        configFileSelector: configKey,
+        default: defaultValue,
+      },
+      configWithSigningName
+    );
+
+    expect(fromEnv).toHaveBeenCalledTimes(1);
+    expect(fromEnv).toHaveBeenCalledWith(envVarSelector, { logger: configWithSigningName.logger });
   });
 });

--- a/packages/node-config-provider/src/configLoader.ts
+++ b/packages/node-config-provider/src/configLoader.ts
@@ -37,7 +37,15 @@ export const loadConfig = <T = string>(
   { environmentVariableSelector, configFileSelector, default: defaultValue }: LoadedConfigSelectors<T>,
   configuration: LocalConfigOptions = {}
 ): Provider<T> => {
-  const envOptions = configuration.signingName ? { signingName: configuration.signingName } : undefined;
+  const envOptions: EnvOptions = {};
+
+  if (configuration.signingName !== undefined) {
+    envOptions.signingName = configuration.signingName;
+  }
+  if (configuration.logger !== undefined) {
+    envOptions.logger = configuration.logger;
+  }
+
   return memoize(
     chain(
       fromEnv(environmentVariableSelector, envOptions),

--- a/packages/node-config-provider/src/configLoader.ts
+++ b/packages/node-config-provider/src/configLoader.ts
@@ -37,14 +37,8 @@ export const loadConfig = <T = string>(
   { environmentVariableSelector, configFileSelector, default: defaultValue }: LoadedConfigSelectors<T>,
   configuration: LocalConfigOptions = {}
 ): Provider<T> => {
-  const envOptions: EnvOptions = {};
-
-  if (configuration.signingName !== undefined) {
-    envOptions.signingName = configuration.signingName;
-  }
-  if (configuration.logger !== undefined) {
-    envOptions.logger = configuration.logger;
-  }
+  const { signingName, logger } = configuration;
+  const envOptions: EnvOptions = { signingName, logger };
 
   return memoize(
     chain(

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,5 +1,5 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { Provider } from "@smithy/types";
+import { Logger, Provider } from "@smithy/types";
 
 import { getSelectorName } from "./getSelectorName";
 
@@ -11,6 +11,11 @@ export interface EnvOptions {
    * The SigV4 service signing name.
    */
   signingName?: string;
+
+  /**
+   * For credential resolution trace logging.
+   */
+  logger?: Logger;
 }
 
 // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
@@ -31,7 +36,8 @@ export const fromEnv =
       return config as T;
     } catch (e) {
       throw new CredentialsProviderError(
-        e.message || `Not found in ENV: ${getSelectorName(envVarSelector.toString())}`
+        e.message || `Not found in ENV: ${getSelectorName(envVarSelector.toString())}`,
+        { logger: options?.logger }
       );
     }
   };


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/smithy-lang/smithy-typescript/pull/1583/files#r2076091590

*Description of changes:*
Passes logger to environment variable selector

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
