### PR TITLE
fix: allow overwriting a protocol's priority when selecting protocol

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -141,6 +141,8 @@ final class DirectedTypeScriptCodegen
 
         for (TypeScriptIntegration integration : integrations) {
             for (ProtocolGenerator generator : integration.getProtocolGenerators()) {
+                // allow overrides of the same protocol ShapeId to change the order.
+                generators.remove(generator.getProtocol());
                 generators.put(generator.getProtocol(), generator);
             }
         }


### PR DESCRIPTION
Allow the later addition of a protocol with the same ShapeId as an existing protocol to change its order in the priority list.