### PR TITLE
fix(middleware-serde): add response metadata to deserialization errors

### DIFF
--- a/.changeset/tiny-otters-talk.md
+++ b/.changeset/tiny-otters-talk.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-serde": patch
+---
+
+add response metadata to deserializer errors

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -25,6 +25,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/protocol-http": "workspace:^",
     "@smithy/types": "workspace:^",
     "tslib": "^2.6.2"
   },

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -66,7 +66,7 @@ export const deserializerMiddleware =
         try {
           // if the deserializer failed, then $metadata may still be set
           // by taking information from the response.
-          if (HttpResponse.isInstance(response) && typeof response.statusCode === "number") {
+          if (HttpResponse.isInstance(response)) {
             const { headers = {} } = response;
             const headerEntries = Object.entries(headers);
             (error as MetadataBearer).$metadata = {

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -1,9 +1,11 @@
+import { HttpResponse } from "@smithy/protocol-http";
 import {
   DeserializeHandler,
   DeserializeHandlerArguments,
   DeserializeHandlerOutput,
   DeserializeMiddleware,
   HandlerExecutionContext,
+  MetadataBearer,
   ResponseDeserializer,
   SerdeContext,
   SerdeFunctions,
@@ -60,8 +62,35 @@ export const deserializerMiddleware =
             error.$response.body = error.$responseBodyText;
           }
         }
+
+        try {
+          // if the deserializer failed, then $metadata may still be set
+          // by taking information from the response.
+          if (HttpResponse.isInstance(response) && typeof response.statusCode === "number") {
+            const { headers = {} } = response;
+            const headerEntries = Object.entries(headers);
+            (error as MetadataBearer).$metadata = {
+              httpStatusCode: response.statusCode,
+              requestId: findHeader(/^x-[\w-]+-request-?id$/, headerEntries),
+              extendedRequestId: findHeader(/^x-[\w-]+-id-2$/, headerEntries),
+              cfId: findHeader(/^x-[\w-]+-cf-id$/, headerEntries),
+            };
+          }
+        } catch (e) {
+          // ignored, error object was not writable.
+        }
       }
 
       throw error;
     }
   };
+
+/**
+ * @internal
+ * @returns header value where key matches regex.
+ */
+const findHeader = (pattern: RegExp, headers: [string, string][]): string | undefined => {
+  return (headers.find(([k]) => {
+    return k.match(pattern);
+  }) || [void 0, void 1])[1];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,6 +2791,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/middleware-serde@workspace:packages/middleware-serde"
   dependencies:
+    "@smithy/protocol-http": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/util-test": "workspace:^"
     concurrently: "npm:7.0.0"


### PR DESCRIPTION
This adds the `error.$metadata` field to deserialization errors, so that the (earlier in order) retry middleware can decide to retry the error if the response code is retryable, regardless of the format of the error.

This scenario can happen when a server origin response is supposed to be e.g. JSON but its load balancer is XML or does not reach the point of checking the correct response format. If the LB sheds a request with a retryable error code but unparsable body, the parsing error should be treated as non-terminal, retryable.