### PR TITLE
fix(core/cbor): read error code case-insensitively

### DIFF
--- a/.changeset/smooth-masks-think.md
+++ b/.changeset/smooth-masks-think.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+read code property of errors case-insensitively

--- a/packages/core/src/submodules/cbor/parseCborBody.spec.ts
+++ b/packages/core/src/submodules/cbor/parseCborBody.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test as it } from "vitest";
 
-import { buildHttpRpcRequest } from "./parseCborBody";
+import { buildHttpRpcRequest, loadSmithyRpcV2CborErrorCode } from "./parseCborBody";
 
 describe("buildHttpRpcRequest", () => {
   it("should copy the input headers", async () => {
@@ -28,5 +28,17 @@ describe("buildHttpRpcRequest", () => {
 
     expect(request.headers).toEqual(headers);
     expect(request.headers).not.toBe(headers);
+  });
+});
+
+describe(loadSmithyRpcV2CborErrorCode.name, () => {
+  it("should read the code field case-insensitively", () => {
+    const code = loadSmithyRpcV2CborErrorCode(
+      { statusCode: 200, headers: {} },
+      {
+        cOdE: "OhNoException:Sender",
+      }
+    );
+    expect(code).toEqual("OhNoException");
   });
 });

--- a/packages/core/src/submodules/cbor/parseCborBody.ts
+++ b/packages/core/src/submodules/cbor/parseCborBody.ts
@@ -69,8 +69,9 @@ export const loadSmithyRpcV2CborErrorCode = (output: HttpResponse, data: any): s
     return sanitizeErrorCode(data["__type"]);
   }
 
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
+  const codeKey = Object.keys(data).find((key) => key.toLowerCase() === "code");
+  if (codeKey && data[codeKey] !== undefined) {
+    return sanitizeErrorCode(data[codeKey]);
   }
 };
 


### PR DESCRIPTION
Changes `loadSmithyRpcV2CborErrorCode` to read any field matching `code` case-insensitively instead of just `code` (lowercase). 