### PR TITLE
fix: type compatibility between command schema and type transforms

### DIFF
--- a/.changeset/fair-news-beg.md
+++ b/.changeset/fair-news-beg.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+fix Command interface compatibility with type transformers

--- a/packages/types/src/command.ts
+++ b/packages/types/src/command.ts
@@ -1,6 +1,5 @@
 import { Handler, MiddlewareStack } from "./middleware";
 import { MetadataBearer } from "./response";
-import { OperationSchema } from "./schema/schema";
 
 /**
  * @public
@@ -14,7 +13,11 @@ export interface Command<
 > extends CommandIO<InputType, OutputType> {
   readonly input: InputType;
   readonly middlewareStack: MiddlewareStack<InputType, OutputType>;
-  readonly schema?: OperationSchema;
+  /**
+   * This should be OperationSchema from @smithy/types, but would
+   * create problems with the client transform type adaptors.
+   */
+  readonly schema?: any;
 
   resolveMiddleware(
     stack: MiddlewareStack<ClientInput, ClientOutput>,


### PR DESCRIPTION
This loosens the typing of the schema object on Commands to be compatible with existing client type transformation adaptors. 

This also will publish a new version of `@smithy/types` which should address #1604