### PR TITLE
fix(core/schema): allow structiterator call on unit schema

### DIFF
--- a/.changeset/serious-waves-cheat.md
+++ b/.changeset/serious-waves-cheat.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+allow struct iterator acquisition on unit schema

--- a/packages/core/src/submodules/schema/schemas/NormalizedSchema.spec.ts
+++ b/packages/core/src/submodules/schema/schemas/NormalizedSchema.spec.ts
@@ -185,6 +185,11 @@ describe(NormalizedSchema.name, () => {
         expect(schema.getMergedTraits()).toEqual(entrySchema.getMergedTraits());
       }
     });
+
+    it("can acquire structIterator on the unit schema type and its iteration is empty", () => {
+      const iteration = Array.from(NormalizedSchema.of("unit").structIterator());
+      expect(iteration.length).toBe(0);
+    });
   });
 
   describe("traits", () => {

--- a/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
+++ b/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
@@ -401,6 +401,9 @@ export class NormalizedSchema implements INormalizedSchema {
    * This avoids the overhead of calling Object.entries(ns.getMemberSchemas()).
    */
   public *structIterator(): Generator<[string, NormalizedSchema], undefined, undefined> {
+    if (this.isUnitSchema()) {
+      return;
+    }
     if (!this.isStructSchema()) {
       throw new Error("@smithy/core/schema - cannot acquire structIterator on non-struct schema.");
     }


### PR DESCRIPTION
currently the structIterator on NormalizedSchema can only be acquired when it is of the structure schema type. 
This allows it to be called when it is the unit type and the iterator will be empty. 

Operation input/output are always structures, with the exception of the special unit type https://smithy.io/2.0/spec/model.html#unit-type. 