### PR TITLE
fix(core/protocols): allow http prefix header and http header to read same value

### DIFF
--- a/.changeset/big-hounds-jog.md
+++ b/.changeset/big-hounds-jog.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+allow http prefix header and header to read from same binding

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
@@ -207,15 +207,7 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
       response.headers[header.toLowerCase()] = value;
     }
 
-    const headerBindings = new Set<string>(
-      Object.values(ns.getMemberSchemas())
-        .map((schema) => {
-          return schema.getMergedTraits().httpHeader;
-        })
-        .filter(Boolean) as string[]
-    );
-
-    const nonHttpBindingMembers = await this.deserializeHttpMessage(ns, context, response, headerBindings, dataObject);
+    const nonHttpBindingMembers = await this.deserializeHttpMessage(ns, context, response, dataObject);
 
     if (nonHttpBindingMembers.length) {
       const bytes: Uint8Array = await collectBody(response.body, context);

--- a/packages/core/src/submodules/protocols/HttpProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/HttpProtocol.spec.ts
@@ -1,0 +1,55 @@
+import { map, SCHEMA, struct } from "@smithy/core/schema";
+import { HandlerExecutionContext, HttpResponse as IHttpResponse, Schema, SerdeFunctions } from "@smithy/types";
+import { describe, expect, test as it } from "vitest";
+
+import { HttpProtocol } from "./HttpProtocol";
+import { FromStringShapeDeserializer } from "./serde/FromStringShapeDeserializer";
+
+describe(HttpProtocol.name, () => {
+  it("can deserialize a prefix header binding and header binding from the same header", async () => {
+    type TestSignature = (
+      schema: Schema,
+      context: HandlerExecutionContext & SerdeFunctions,
+      response: IHttpResponse,
+      dataObject: any
+    ) => Promise<string[]>;
+    const deserializeHttpMessage = ((HttpProtocol.prototype as any).deserializeHttpMessage as TestSignature).bind({
+      deserializer: new FromStringShapeDeserializer({
+        httpBindings: true,
+        timestampFormat: {
+          useTrait: true,
+          default: SCHEMA.TIMESTAMP_EPOCH_SECONDS,
+        },
+      }),
+    });
+    const httpResponse: IHttpResponse = {
+      statusCode: 200,
+      headers: {
+        "my-header": "header-value",
+      },
+    };
+
+    const dataObject = {};
+    await deserializeHttpMessage(
+      struct(
+        "",
+        "Struct",
+        0,
+        ["prefixHeaders", "header"],
+        [
+          [map("", "Map", 0, 0, 0), { httpPrefixHeaders: "my-" }],
+          [0, { httpHeader: "my-header" }],
+        ]
+      ),
+      {} as any,
+      httpResponse,
+      dataObject
+    );
+    expect(dataObject).toEqual({
+      prefixHeaders: {
+        header: "header-value",
+      },
+      header: "header-value",
+    });
+  });
+});

--- a/packages/core/src/submodules/protocols/HttpProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpProtocol.ts
@@ -147,7 +147,6 @@ export abstract class HttpProtocol implements ClientProtocol<IHttpRequest, IHttp
     schema: Schema,
     context: HandlerExecutionContext & SerdeFunctions,
     response: IHttpResponse,
-    headerBindings: Set<string>,
     dataObject: any
   ): Promise<string[]> {
     const deserializer = this.deserializer;
@@ -222,7 +221,7 @@ export abstract class HttpProtocol implements ClientProtocol<IHttpRequest, IHttp
       } else if (memberTraits.httpPrefixHeaders !== undefined) {
         dataObject[memberName] = {};
         for (const [header, value] of Object.entries(response.headers)) {
-          if (!headerBindings.has(header) && header.startsWith(memberTraits.httpPrefixHeaders)) {
+          if (header.startsWith(memberTraits.httpPrefixHeaders)) {
             dataObject[memberName][header.slice(memberTraits.httpPrefixHeaders.length)] = await deserializer.read(
               [memberSchema.getValueSchema(), { httpHeader: header }],
               value


### PR DESCRIPTION
Previously, when deserializing http bindings, a prefix header and header could not be created from the same actual header. This fixes that to satisfy a specific protocol test.