### PR TITLE
chore: use smithy synthetic namespace for service base exceptions

### DIFF
--- a/.changeset/funny-pigs-kiss.md
+++ b/.changeset/funny-pigs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+use smithy synthetic namespace for base errors

--- a/packages/core/src/submodules/schema/TypeRegistry.spec.ts
+++ b/packages/core/src/submodules/schema/TypeRegistry.spec.ts
@@ -7,12 +7,15 @@ import { struct } from "./schemas/StructureSchema";
 import { TypeRegistry } from "./TypeRegistry";
 
 describe(TypeRegistry.name, () => {
-  const [List, Map, Struct] = [list("ack", "List", { sparse: 1 }, 0), map("ack", "Map", 0, 0, 1), () => schema];
-  const schema = struct("ack", "Structure", {}, ["list", "map", "struct"], [List, Map, Struct]);
-
-  const tr = TypeRegistry.for("ack");
+  const [List, Map, Struct] = [
+    list("NAMESPACE", "List", { sparse: 1 }, 0),
+    map("NAMESPACE", "Map", 0, 0, 1),
+    () => schema,
+  ];
+  const schema = struct("NAMESPACE", "Structure", {}, ["list", "map", "struct"], [List, Map, Struct]);
 
   it("stores and retrieves schema objects", () => {
+    const tr = TypeRegistry.for("NAMESPACE");
     expect(tr.getSchema("List")).toBe(List);
     expect(tr.getSchema("Map")).toBe(Map);
     expect(tr.getSchema("Structure")).toBe(schema);
@@ -20,8 +23,8 @@ describe(TypeRegistry.name, () => {
 
   it("has a helper method to retrieve a synthetic base exception", () => {
     // the service namespace is appended to the synthetic prefix.
-    const err = error("smithyts.client.synthetic.ack", "UhOhServiceException", 0, [], [], Error);
-    const tr = TypeRegistry.for("smithyts.client.synthetic.ack");
-    expect(tr.getBaseException()).toEqual(err);
+    const err = error("smithy.ts.sdk.synthetic.NAMESPACE", "UhOhServiceException", 0, [], [], Error);
+    const tr = TypeRegistry.for("smithy.ts.sdk.synthetic.NAMESPACE");
+    expect(tr.getBaseException()).toBe(err);
   });
 });

--- a/packages/core/src/submodules/schema/TypeRegistry.ts
+++ b/packages/core/src/submodules/schema/TypeRegistry.ts
@@ -65,7 +65,7 @@ export class TypeRegistry {
    */
   public getBaseException(): ErrorSchema | undefined {
     for (const [id, schema] of this.schemas.entries()) {
-      if (id.startsWith("smithyts.client.synthetic.") && id.endsWith("ServiceException")) {
+      if (id.startsWith("smithy.ts.sdk.synthetic.") && id.endsWith("ServiceException")) {
         return schema as ErrorSchema;
       }
     }


### PR DESCRIPTION
Followup to https://github.com/smithy-lang/smithy-typescript/pull/1611/, for the JS runtime code.