### PR TITLE
fix: locate event stream member more carefully

### DIFF
--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGeneratorTest.java
@@ -1,0 +1,115 @@
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventStreamGeneratorTest {
+    @Test
+    void getEventStreamMember(
+        @Mock ProtocolGenerator.GenerationContext context,
+        @Mock Model model,
+        @Mock StructureShape struct,
+        @Mock MemberShape eventStreamMember1,
+        @Mock ShapeId streamingMember1ShapeId,
+        @Mock UnionShape streamingTarget1
+    ) {
+        when(struct.members()).thenReturn(List.of(eventStreamMember1));
+        when(eventStreamMember1.getTarget()).thenReturn(streamingMember1ShapeId);
+        when(context.getModel()).thenReturn(model);
+        when(model.expectShape(streamingMember1ShapeId)).thenReturn(streamingTarget1);
+
+        when(streamingTarget1.hasTrait(StreamingTrait.class)).thenReturn(true);
+        when(streamingTarget1.isUnionShape()).thenReturn(true);
+        when(eventStreamMember1.hasTrait(StreamingTrait.class)).thenReturn(false);
+        when(eventStreamMember1.hasTrait(HttpPayloadTrait.class)).thenReturn(true);
+
+        MemberShape eventStreamMember = EventStreamGenerator.getEventStreamMember(
+            context,
+            struct
+        );
+
+        assertEquals(eventStreamMember1, eventStreamMember);
+    }
+
+    @Test
+    void getEventStreamMemberTooFew(
+        @Mock ProtocolGenerator.GenerationContext context,
+        @Mock StructureShape struct
+    ) {
+        when(struct.members()).thenReturn(List.of());
+        when(struct.getId()).thenReturn(ShapeId.from("namespace#Shape"));
+
+        try {
+            MemberShape eventStreamMember = EventStreamGenerator.getEventStreamMember(
+                context,
+                struct
+            );
+        } catch (CodegenException e) {
+            assertEquals(
+                "No event stream member found in " + struct.getId().toString(),
+                e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    void getEventStreamMemberTooMany(
+        @Mock ProtocolGenerator.GenerationContext context,
+        @Mock Model model,
+        @Mock StructureShape struct,
+        @Mock MemberShape eventStreamMember1,
+        @Mock ShapeId streamingMember1ShapeId,
+        @Mock UnionShape streamingTarget1,
+        @Mock MemberShape eventStreamMember2,
+        @Mock ShapeId streamingMember2ShapeId,
+        @Mock UnionShape streamingTarget2
+    ) {
+        when(struct.members()).thenReturn(List.of(
+            eventStreamMember1,
+            eventStreamMember2
+        ));
+        when(context.getModel()).thenReturn(model);
+        when(struct.getId()).thenReturn(ShapeId.from("namespace#Shape"));
+
+        when(eventStreamMember1.getTarget()).thenReturn(streamingMember1ShapeId);
+        when(model.expectShape(streamingMember1ShapeId)).thenReturn(streamingTarget1);
+        when(streamingTarget1.hasTrait(StreamingTrait.class)).thenReturn(true);
+        when(streamingTarget1.isUnionShape()).thenReturn(true);
+        when(eventStreamMember1.hasTrait(StreamingTrait.class)).thenReturn(false);
+        when(eventStreamMember1.hasTrait(HttpPayloadTrait.class)).thenReturn(true);
+
+        when(eventStreamMember2.getTarget()).thenReturn(streamingMember2ShapeId);
+        when(model.expectShape(streamingMember2ShapeId)).thenReturn(streamingTarget2);
+        when(streamingTarget2.hasTrait(StreamingTrait.class)).thenReturn(true);
+        when(streamingTarget2.isUnionShape()).thenReturn(true);
+        when(eventStreamMember2.hasTrait(StreamingTrait.class)).thenReturn(false);
+        when(eventStreamMember2.hasTrait(HttpPayloadTrait.class)).thenReturn(true);
+
+        try {
+            MemberShape eventStreamMember = EventStreamGenerator.getEventStreamMember(
+                context,
+                struct
+            );
+        } catch (CodegenException e) {
+            assertEquals(
+                "More than one event stream member in " + struct.getId().toString(),
+                e.getMessage()
+            );
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/smithy-lang/smithy-typescript/issues/1051

- adds validation defensive checking during the selection of the event stream member so the wrong member isn't selected
- tested codegen against sample given in https://github.com/smithy-lang/smithy-typescript/issues/1051
- tested codgen against multiple event stream AWS SDK clients
- added unit tests