### PR TITLE
fix: criteria for event stream member detection

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -39,7 +39,6 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.EventHeaderTrait;
 import software.amazon.smithy.model.traits.EventPayloadTrait;
-import software.amazon.smithy.model.traits.HttpPayloadTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
@@ -90,9 +89,7 @@ public class EventStreamGenerator {
                 Shape target = context.getModel().expectShape(shape.getTarget());
                 boolean targetStreaming = target.hasTrait(StreamingTrait.class);
                 boolean targetUnion = target.isUnionShape();
-                boolean memberStreaming = shape.hasTrait(StreamingTrait.class);
-                boolean memberPayload = shape.hasTrait(HttpPayloadTrait.class);
-                return memberPayload && targetUnion && (targetStreaming || memberStreaming);
+                return targetUnion && targetStreaming;
             }).toList();
 
         if (eventStreamMembers.isEmpty()) {
@@ -454,7 +451,7 @@ public class EventStreamGenerator {
                             });
                         });
                     });
-                    writer.write("return {$$unknown: output};");
+                    writer.write("return {$$unknown: event as any};");
                 });
             });
         });

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGeneratorTest.java
@@ -35,8 +35,6 @@ class EventStreamGeneratorTest {
 
         when(streamingTarget1.hasTrait(StreamingTrait.class)).thenReturn(true);
         when(streamingTarget1.isUnionShape()).thenReturn(true);
-        when(eventStreamMember1.hasTrait(StreamingTrait.class)).thenReturn(false);
-        when(eventStreamMember1.hasTrait(HttpPayloadTrait.class)).thenReturn(true);
 
         MemberShape eventStreamMember = EventStreamGenerator.getEventStreamMember(
             context,
@@ -90,15 +88,11 @@ class EventStreamGeneratorTest {
         when(model.expectShape(streamingMember1ShapeId)).thenReturn(streamingTarget1);
         when(streamingTarget1.hasTrait(StreamingTrait.class)).thenReturn(true);
         when(streamingTarget1.isUnionShape()).thenReturn(true);
-        when(eventStreamMember1.hasTrait(StreamingTrait.class)).thenReturn(false);
-        when(eventStreamMember1.hasTrait(HttpPayloadTrait.class)).thenReturn(true);
 
         when(eventStreamMember2.getTarget()).thenReturn(streamingMember2ShapeId);
         when(model.expectShape(streamingMember2ShapeId)).thenReturn(streamingTarget2);
         when(streamingTarget2.hasTrait(StreamingTrait.class)).thenReturn(true);
         when(streamingTarget2.isUnionShape()).thenReturn(true);
-        when(eventStreamMember2.hasTrait(StreamingTrait.class)).thenReturn(false);
-        when(eventStreamMember2.hasTrait(HttpPayloadTrait.class)).thenReturn(true);
 
         try {
             MemberShape eventStreamMember = EventStreamGenerator.getEventStreamMember(


### PR DESCRIPTION
corrects the criteria from https://github.com/smithy-lang/smithy-typescript/pull/1623

http payload trait is not required and the member itself will not have the streaming trait.