### PR TITLE
fix: add EndpointRequired config resolver to replace CustomEndpoint

### DIFF
--- a/.changeset/wicked-squids-pretend.md
+++ b/.changeset/wicked-squids-pretend.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+add resolveEndpointRequiredConfig resolver

--- a/packages/middleware-endpoint/src/index.ts
+++ b/packages/middleware-endpoint/src/index.ts
@@ -11,6 +11,7 @@ export * from "./endpointMiddleware";
  */
 export * from "./getEndpointPlugin";
 export * from "./resolveEndpointConfig";
+export * from "./resolveEndpointRequiredConfig";
 /**
  * @internal
  */

--- a/packages/middleware-endpoint/src/resolveEndpointRequiredConfig.spec.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointRequiredConfig.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test as it } from "vitest";
+
+import { resolveEndpointRequiredConfig } from "./resolveEndpointRequiredConfig";
+
+describe(resolveEndpointRequiredConfig.name, () => {
+  it("creates a default endpoint resolver function", async () => {
+    const config = resolveEndpointRequiredConfig({
+      endpoint: undefined as any,
+    });
+
+    expect(() => config.endpoint()).rejects.toThrow();
+  });
+});

--- a/packages/middleware-endpoint/src/resolveEndpointRequiredConfig.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointRequiredConfig.ts
@@ -1,0 +1,47 @@
+import { Endpoint, EndpointV2, Provider } from "@smithy/types";
+
+/**
+ * This is an additional config resolver layer for clients using the default
+ * endpoints ruleset. It modifies the input and output config types to make
+ * the endpoint configuration property required.
+ *
+ * It must be placed after the `resolveEndpointConfig`
+ * resolver. This replaces the "CustomEndpoints" config resolver, which was used
+ * prior to default endpoint rulesets.
+ *
+ * @public
+ */
+export interface EndpointRequiredInputConfig {
+  endpoint: string | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
+}
+
+/**
+ * @internal
+ */
+interface PreviouslyResolved {
+  endpoint?: Provider<Endpoint>;
+}
+
+/**
+ * @internal
+ */
+export interface EndpointRequiredResolvedConfig {
+  endpoint: Provider<Endpoint>;
+}
+
+/**
+ * @internal
+ */
+export const resolveEndpointRequiredConfig = <T>(
+  input: T & EndpointRequiredInputConfig & PreviouslyResolved
+): T & EndpointRequiredResolvedConfig => {
+  const { endpoint } = input;
+  if (endpoint === undefined) {
+    input.endpoint = async () => {
+      throw new Error(
+        "@smithy/middleware-endpoint: (default endpointRuleSet) endpoint is not set - you must configure an endpoint."
+      );
+    };
+  }
+  return input as T & EndpointRequiredResolvedConfig;
+};

--- a/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
@@ -48,7 +48,14 @@ import {
 } from "@smithy/core";
 import { getSchemaSerdePlugin } from "@smithy/core/schema";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
-import { EndpointInputConfig, EndpointResolvedConfig, resolveEndpointConfig } from "@smithy/middleware-endpoint";
+import {
+  EndpointInputConfig,
+  EndpointRequiredInputConfig,
+  EndpointRequiredResolvedConfig,
+  EndpointResolvedConfig,
+  resolveEndpointConfig,
+  resolveEndpointRequiredConfig,
+} from "@smithy/middleware-endpoint";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@smithy/middleware-retry";
 import { HttpHandlerUserInput as __HttpHandlerUserInput } from "@smithy/protocol-http";
 import {
@@ -227,6 +234,7 @@ export type RpcV2ProtocolClientConfigType = Partial<__SmithyConfiguration<__Http
   ClientDefaults &
   RetryInputConfig &
   EndpointInputConfig<EndpointParameters> &
+  EndpointRequiredInputConfig &
   HttpAuthSchemeInputConfig &
   ClientInputEndpointParameters;
 /**
@@ -244,6 +252,7 @@ export type RpcV2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguratio
   RuntimeExtensionsConfig &
   RetryResolvedConfig &
   EndpointResolvedConfig<EndpointParameters> &
+  EndpointRequiredResolvedConfig &
   HttpAuthSchemeResolvedConfig &
   ClientResolvedEndpointParameters;
 /**
@@ -274,9 +283,10 @@ export class RpcV2ProtocolClient extends __Client<
     let _config_1 = resolveClientEndpointParameters(_config_0);
     let _config_2 = resolveRetryConfig(_config_1);
     let _config_3 = resolveEndpointConfig(_config_2);
-    let _config_4 = resolveHttpAuthSchemeConfig(_config_3);
-    let _config_5 = resolveRuntimeExtensions(_config_4, configuration?.extensions || []);
-    this.config = _config_5;
+    let _config_4 = resolveEndpointRequiredConfig(_config_3);
+    let _config_5 = resolveHttpAuthSchemeConfig(_config_4);
+    let _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
+    this.config = _config_6;
     this.middlewareStack.use(getSchemaSerdePlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));

--- a/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
@@ -47,7 +47,14 @@ import {
   getHttpSigningPlugin,
 } from "@smithy/core";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
-import { EndpointInputConfig, EndpointResolvedConfig, resolveEndpointConfig } from "@smithy/middleware-endpoint";
+import {
+  EndpointInputConfig,
+  EndpointRequiredInputConfig,
+  EndpointRequiredResolvedConfig,
+  EndpointResolvedConfig,
+  resolveEndpointConfig,
+  resolveEndpointRequiredConfig,
+} from "@smithy/middleware-endpoint";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@smithy/middleware-retry";
 import { HttpHandlerUserInput as __HttpHandlerUserInput } from "@smithy/protocol-http";
 import {
@@ -213,6 +220,7 @@ export type RpcV2ProtocolClientConfigType = Partial<__SmithyConfiguration<__Http
   ClientDefaults &
   RetryInputConfig &
   EndpointInputConfig<EndpointParameters> &
+  EndpointRequiredInputConfig &
   HttpAuthSchemeInputConfig &
   ClientInputEndpointParameters;
 /**
@@ -230,6 +238,7 @@ export type RpcV2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguratio
   RuntimeExtensionsConfig &
   RetryResolvedConfig &
   EndpointResolvedConfig<EndpointParameters> &
+  EndpointRequiredResolvedConfig &
   HttpAuthSchemeResolvedConfig &
   ClientResolvedEndpointParameters;
 /**
@@ -260,9 +269,10 @@ export class RpcV2ProtocolClient extends __Client<
     let _config_1 = resolveClientEndpointParameters(_config_0);
     let _config_2 = resolveRetryConfig(_config_1);
     let _config_3 = resolveEndpointConfig(_config_2);
-    let _config_4 = resolveHttpAuthSchemeConfig(_config_3);
-    let _config_5 = resolveRuntimeExtensions(_config_4, configuration?.extensions || []);
-    this.config = _config_5;
+    let _config_4 = resolveEndpointRequiredConfig(_config_3);
+    let _config_5 = resolveHttpAuthSchemeConfig(_config_4);
+    let _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
+    this.config = _config_6;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(


### PR DESCRIPTION
in https://github.com/smithy-lang/smithy-typescript/pull/1589, I added a "default endpoint ruleset" for all clients. This aligned all codegen for consistency and removed edge cases not covered by AWS SDK testing (AWS SDKs all have endpoint rulesets). 

In EP2.0, the endpoint input is not required. This makes client calls to `await client.config.endpoint()` fail a typecheck, because prior to #1589, a resolver layer called "CustomEndpoint" marked the endpoint input as required when not in the endpoints-ruleset code generation mode.

This PR adds backwards compatibility with the `CustomEndpoint` resolver layer without bringing it back. Here, I add a `EndpointRequired` config resolver layer when using the default endpoint ruleset. 