### PR TITLE
migrate from nexus2 to maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -281,7 +281,7 @@ jreleaser {
         maven {
             mavenCentral {
                 create("maven-central") {
-                    active = 'ACTIVE.ALWAYS'
+                    active = Active.ALWAYS
                     url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepositories.add("${rootProject.buildDir}/staging")
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -280,7 +280,7 @@ jreleaser {
     deploy {
         maven {
             mavenCentral {
-                create("maven-central") {
+                sonatype {
                     active = Active.ALWAYS
                     url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepositories.add("${rootProject.buildDir}/staging")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -279,13 +279,10 @@ jreleaser {
     // https://jreleaser.org/guide/latest/examples/maven/maven-central.html#_gradle
     deploy {
         maven {
-            nexus2 {
+            mavenCentral {
                 create("maven-central") {
                     active = Active.ALWAYS
-                    url = "https://aws.oss.sonatype.org/service/local"
-                    snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-                    closeRepository.set(true)
-                    releaseRepository.set(true)
+                    url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepositories.add("${rootProject.buildDir}/staging")
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     checkstyle
     jacoco
     id("com.github.spotbugs") version "6.0.8"
-    id("org.jreleaser") version "1.9.0"
+    id("org.jreleaser") version "1.18.0"
 }
 
 allprojects {
@@ -280,8 +280,8 @@ jreleaser {
     deploy {
         maven {
             mavenCentral {
-                sonatype {
-                    active = Active.ALWAYS
+                create("maven-central") {
+                    active = 'ACTIVE.ALWAYS'
                     url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepositories.add("${rootProject.buildDir}/staging")
                 }


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-5954
v3 codegen PR: https://github.com/aws/aws-sdk-js-v3/pull/7150

*Description of changes:*
This change migrates from Nexus2 to Central Portal Deployer due to Nexus2 deprecation and upcoming sunset.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
