### PR TITLE
chore: upgrade fast-xml-parser to 5.2.5

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -114,7 +114,7 @@ public enum TypeScriptDependency implements Dependency {
     AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@smithy/querystring-builder", false),
 
     // Conditionally added when XML parser needs to be used.
-    XML_PARSER("dependencies", "fast-xml-parser", "4.4.1", false),
+    XML_PARSER("dependencies", "fast-xml-parser", "5.2.5", false),
     HTML_ENTITIES("dependencies", "entities", "2.2.0", false),
 
     // Conditionally added when streaming blob response payload exists.


### PR DESCRIPTION
upgrades to fast-xml-parser 5.2.5 https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md

downstream: https://github.com/aws/aws-sdk-js-v3/pull/7176