### PR TITLE
fix(codegen): avoid using model.getServiceShapes() for endpoint generation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/AddDefaultEndpointRuleSet.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/AddDefaultEndpointRuleSet.java
@@ -15,6 +15,7 @@ import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
@@ -109,15 +110,14 @@ public class AddDefaultEndpointRuleSet implements TypeScriptIntegration {
     public Model preprocessModel(Model model, TypeScriptSettings settings) {
         Model.Builder modelBuilder = model.toBuilder();
 
-        model.getServiceShapes().forEach(serviceShape -> {
-            if (!serviceShape.hasTrait(EndpointRuleSetTrait.class)) {
-                usesDefaultEndpointRuleset = true;
-                modelBuilder.removeShape(serviceShape.toShapeId());
-                modelBuilder.addShape(serviceShape.toBuilder()
-                    .addTrait(DEFAULT_RULESET)
-                    .build());
-            }
-        });
+        ServiceShape serviceShape = settings.getService(model);
+        if (!serviceShape.hasTrait(EndpointRuleSetTrait.class)) {
+            usesDefaultEndpointRuleset = true;
+            modelBuilder.removeShape(serviceShape.toShapeId());
+            modelBuilder.addShape(serviceShape.toBuilder()
+                .addTrait(DEFAULT_RULESET)
+                .build());
+        }
 
         return modelBuilder.build();
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
@@ -259,7 +259,7 @@ public class SchemaGenerator implements Runnable {
     private void writeBaseError() {
         String serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
         String serviceExceptionName = CodegenUtils.getServiceExceptionName(serviceName);
-        String namespace = model.getServiceShapes().stream().findFirst().get().getId().getNamespace();
+        String namespace = settings.getService(model).getId().getNamespace();
 
         String exceptionCtorSymbolName = "__" + serviceExceptionName;
         writer.addImportSubmodule("error", "error", TypeScriptDependency.SMITHY_CORE, "/schema");


### PR DESCRIPTION
Applies the same fix from https://github.com/aws/aws-sdk-js-v3/pull/7184 to use the primary service shape instead of all model services.

No known use case at the moment, but is a correctness issue.