### PR TITLE
fix(middleware-endpoint): return undefined for endpointParam=endpoint when isCustomEndpoint is false

### DIFF
--- a/.changeset/sharp-ducks-happen.md
+++ b/.changeset/sharp-ducks-happen.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+return undefined for endpointParam "endpoint" if isCustomEndpoint is false

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
@@ -42,6 +42,9 @@ export const createConfigValueProvider = <Config extends Record<string, unknown>
 
   if (configKey === "endpoint" || canonicalEndpointParamKey === "endpoint") {
     return async () => {
+      if (config.isCustomEndpoint === false) {
+        return undefined;
+      }
       const endpoint = await configProvider();
       if (endpoint && typeof endpoint === "object") {
         if ("url" in endpoint) {

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
@@ -38,7 +38,7 @@ export const getEndpointFromInstructions = async <
   clientConfig: Partial<EndpointResolvedConfig<T>> & Config,
   context?: HandlerExecutionContext
 ): Promise<EndpointV2> => {
-  if (!clientConfig.endpoint) {
+  if (!clientConfig.isCustomEndpoint) {
     let endpointFromConfig: string | undefined;
 
     // This field is guaranteed by the type indicated by the config resolver, but is new

--- a/packages/middleware-endpoint/src/endpointMiddleware.ts
+++ b/packages/middleware-endpoint/src/endpointMiddleware.ts
@@ -39,7 +39,7 @@ export const endpointMiddleware = <T extends EndpointParameters>({
       context: HandlerExecutionContext
     ): SerializeHandler<any, Output> =>
     async (args: SerializeHandlerArguments<any>): Promise<SerializeHandlerOutput<Output>> => {
-      if (config.endpoint) {
+      if (config.isCustomEndpoint) {
         setFeature(context, "ENDPOINT_OVERRIDE", "N");
       }
 

--- a/packages/middleware-endpoint/src/resolveEndpointConfig.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointConfig.ts
@@ -64,7 +64,7 @@ interface PreviouslyResolved<T extends EndpointParameters = EndpointParameters> 
 /**
  * @internal
  *
- * This supercedes the similarly named EndpointsResolvedConfig (no parametric types)
+ * This supersedes the similarly named EndpointsResolvedConfig (no parametric types)
  * from resolveEndpointsConfig.ts in \@smithy/config-resolver.
  */
 export interface EndpointResolvedConfig<T extends EndpointParameters = EndpointParameters> {
@@ -85,8 +85,11 @@ export interface EndpointResolvedConfig<T extends EndpointParameters = EndpointP
 
   /**
    * Whether the endpoint is specified by caller.
+   * This should be used over checking the existence of `endpoint`, since
+   * that may have been set by other means, such as the default regional
+   * endpoint provider function.
+   *
    * @internal
-   * @deprecated
    */
   isCustomEndpoint?: boolean;
 


### PR DESCRIPTION
during endpoint resolution, client.config values are mapped into the endpoint resolver function.

In the case of `config.endpoint`, there will be a new case where this function is populated but is not considered a custom endpoint. This is for backwards compatibility with the pre-endpointRuleSet era AWS clients, where you could instantiate a client with no custom endpoint, and still retrieve `await client.config.endpoint()` without a null-check for `config.endpoint`. This was due to endpoints.json providing a sort of default regional endpoint for the given service.

