### PR TITLE
Bump codegen version to 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.33.0 (2025-07-10)
+
+### Features
+- Upgraded smithy version to 1.60.3 ([#1640](https://github.com/smithy-lang/smithy-typescript/pull/1640))
+- Upgraded fast-xml-parser to 5.2.5 ([#1641](https://github.com/smithy-lang/smithy-typescript/pull/1641))
+
+### Bug Fixes
+- Avoided using model.getServiceShapes() for endpoint generation ([#1642](https://github.com/smithy-lang/smithy-typescript/pull/1642))
+
 ## 0.32.0 (2025-06-26)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.32.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.33.0"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -139,7 +139,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.32.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.33.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.32.0"
+    version = "0.33.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6058

*Description of changes:*

Bumps codegen version to 0.33.0

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
