### PR TITLE
convert empty structure payloads to null

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2486,6 +2486,14 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         Location.PAYLOAD, "data", binding.getMember(), target));
                 }
             );
+        } else if (target instanceof StructureShape) {
+            writer.write("contents.$L = $L;", binding.getMemberName(), getOutputValue(context,
+                Location.PAYLOAD, "data", binding.getMember(), target));
+            // Handle empty objects for structure shapes - convert to null
+            writer.write("if (contents.$L && Object.keys(contents.$L).length === 0) {",
+                binding.getMemberName(), binding.getMemberName());
+            writer.write("  contents.$L = null;", binding.getMemberName());
+            writer.write("}");
         } else {
             writer.write("contents.$L = $L;", binding.getMemberName(), getOutputValue(context,
                 Location.PAYLOAD, "data", binding.getMember(), target));


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/7169

*Description of changes:*
Empty response bodies should deserialize structure payloads as null instead of empty objects to maintain consistency with Smithy model expectations.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
