### PR TITLE
fix(core): set sideEffects metadata

### DIFF
--- a/.changeset/yellow-frogs-run.md
+++ b/.changeset/yellow-frogs-run.md
@@ -1,0 +1,6 @@
+---
+"@smithy/signature-v4a": patch
+"@smithy/core": patch
+---
+
+set sideEffects bundler metadata

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,6 +68,7 @@
     "url": "https://smithy.io"
   },
   "license": "Apache-2.0",
+  "sideEffects": false,
   "dependencies": {
     "@smithy/middleware-serde": "workspace:^",
     "@smithy/protocol-http": "workspace:^",

--- a/packages/signature-v4a/package.json
+++ b/packages/signature-v4a/package.json
@@ -24,6 +24,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
+  "sideEffects": true,
   "dependencies": {
     "@smithy/signature-v4": "workspace:^",
     "@smithy/types": "workspace:^",


### PR DESCRIPTION
set the bundler metadata flag `sideEffects` to false in core and true in signature-v4a.

- core is set to false to be explicit, since it has many submodules that should be tree-shaken as much as possible
- sigv4a is set to true because it has module level code that injects an implementation into a container checked by signature-v4-multi-region