### PR TITLE
feat: replace uuid.v4 with crypto.randomUUID()

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -79,7 +79,12 @@ public enum TypeScriptDependency implements Dependency {
 
     NODE_CONFIG_PROVIDER("dependencies", "@smithy/node-config-provider", false),
 
+    /**
+     * @deprecated use crypto.randomUUID().
+     */
+    @Deprecated
     UUID_TYPES("dependencies", "@types/uuid", "^9.0.1", false),
+    @Deprecated
     UUID("dependencies", "uuid", "^9.0.1", false),
 
     // Conditionally added when httpChecksumRequired trait exists

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -873,13 +873,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Shape target = model.expectShape(binding.getMember().getTarget());
 
         boolean isIdempotencyToken = binding.getMember().hasTrait(IdempotencyTokenTrait.class);
-        if (isIdempotencyToken) {
-            writer
-                .addDependency(TypeScriptDependency.UUID_TYPES)
-                .addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
-        }
         boolean isRequired = binding.getMember().isRequired();
-        String idempotencyComponent = (isIdempotencyToken && !isRequired) ? " ?? generateIdempotencyToken()" : "";
+        String idempotencyComponent = (isIdempotencyToken && !isRequired) ? " ?? crypto.randomUUID()" : "";
         String memberAssertionComponent = (idempotencyComponent.isEmpty() ? "!" : "");
 
         String queryValue = getInputValue(
@@ -1005,11 +1000,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             target
         );
         boolean isIdempotencyToken = binding.getMember().hasTrait(IdempotencyTokenTrait.class);
-        if (isIdempotencyToken) {
-            context.getWriter()
-                .addDependency(TypeScriptDependency.UUID_TYPES)
-                .addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
-        }
 
         boolean headerAssertion = headerValue.endsWith("!");
         String headerBaseValue = (headerAssertion
@@ -1022,7 +1012,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 String s = headerBuffer.get(headerKey);
                 defaultValue = " || " + s.substring(s.indexOf(": ") + 2, s.length() - 1);
             } else if (isIdempotencyToken) {
-                defaultValue = " ?? generateIdempotencyToken()";
+                defaultValue = " ?? crypto.randomUUID()";
             }
 
             String headerValueExpression = headerAssertion && !defaultValue.isEmpty()
@@ -1046,7 +1036,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 String s = headerBuffer.get(headerKey);
                 constructedHeaderValue += " || " + s.substring(s.indexOf(": ") + 2, s.length() - 1);
             } else if (isIdempotencyToken) {
-                constructedHeaderValue += " ?? generateIdempotencyToken()";
+                constructedHeaderValue += " ?? crypto.randomUUID()";
             } else {
                 constructedHeaderValue = headerValue;
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/CborShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/CborShapeSerVisitor.java
@@ -127,11 +127,7 @@ public class CborShapeSerVisitor extends DocumentShapeSerVisitor {
                 boolean isUnaryCall = UnaryFunctionCall.check(valueExpression);
 
                 if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
-                    writer
-                        .addDependency(TypeScriptDependency.UUID_TYPES)
-                        .addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
-
-                    writer.write("'$L': [true, _ => _ ?? generateIdempotencyToken()],", memberName);
+                    writer.write("'$L': [true, _ => _ ?? crypto.randomUUID()],", memberName);
                 } else {
                     if (valueProvider.equals("_ => _")) {
                         writer.write("'$1L': [],", memberName);


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/7212

replace uuid v4 with crypto.randomUUID()

execution environments without global crypto.randomUUID will need a replacement polyfill. 
