### PR TITLE
chore(core/schema): use schema log filter when available

### DIFF
--- a/.changeset/lemon-wasps-itch.md
+++ b/.changeset/lemon-wasps-itch.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": minor
+---
+
+default schema log filter

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -20,6 +20,8 @@ import type {
 } from "@smithy/types";
 import { SMITHY_CONTEXT_KEY } from "@smithy/types";
 
+import { schemaLogFilter } from "./schemaLogFilter";
+
 /**
  * @public
  */
@@ -130,8 +132,8 @@ class ClassBuilder<
   private _clientName = "";
   private _additionalContext = {} as HandlerExecutionContext;
   private _smithyContext = {} as Record<string, unknown>;
-  private _inputFilterSensitiveLog = (_: any) => _;
-  private _outputFilterSensitiveLog = (_: any) => _;
+  private _inputFilterSensitiveLog: any = undefined;
+  private _outputFilterSensitiveLog: any = undefined;
   private _serializer: (input: I, context: SerdeContext | any) => Promise<IHttpRequest> = null as any;
   private _deserializer: (output: IHttpResponse, context: SerdeContext | any) => Promise<O> = null as any;
   private _operationSchema?: OperationSchema;
@@ -268,8 +270,12 @@ class ClassBuilder<
           middlewareFn: closure._middlewareFn,
           clientName: closure._clientName,
           commandName: closure._commandName,
-          inputFilterSensitiveLog: closure._inputFilterSensitiveLog,
-          outputFilterSensitiveLog: closure._outputFilterSensitiveLog,
+          inputFilterSensitiveLog:
+            closure._inputFilterSensitiveLog ??
+            (closure._operationSchema ? schemaLogFilter.bind(null, closure._operationSchema!.input) : (_) => _),
+          outputFilterSensitiveLog:
+            closure._outputFilterSensitiveLog ??
+            (closure._operationSchema ? schemaLogFilter.bind(null, closure._operationSchema!.output) : (_) => _),
           smithyContext: closure._smithyContext,
           additionalContext: closure._additionalContext,
         });

--- a/packages/smithy-client/src/schemaLogFilter.spec.ts
+++ b/packages/smithy-client/src/schemaLogFilter.spec.ts
@@ -1,0 +1,88 @@
+import { list, map, SCHEMA, sim, struct } from "@smithy/core/schema";
+import { describe, expect, test as it } from "vitest";
+
+import { schemaLogFilter } from "./schemaLogFilter";
+
+describe(schemaLogFilter.name, () => {
+  it("should filter sensitive trait-marked fields", () => {
+    const sensitiveString = sim("ns", "SensitiveString", 0, { sensitive: 1 });
+
+    const schema = struct(
+      "ns",
+      "Struct",
+      0,
+      ["a", "b", "sensitive", "nestedSensitive", "various"],
+      [
+        SCHEMA.STRING,
+        SCHEMA.STRING,
+        sensitiveString,
+        struct("ns", "NestedSensitiveStruct", 0, ["sensitive"], [sensitiveString]),
+        struct(
+          "ns",
+          "Various",
+          0,
+          ["boolean", "number", "struct", "list-s", "list", "map-s", "map"],
+          [
+            sim("ns", "Boolean", SCHEMA.BOOLEAN, { sensitive: 1 }),
+            sim("ns", "Numeric", SCHEMA.NUMERIC, { sensitive: 1 }),
+            struct("ns", "SensitiveStruct", { sensitive: 1 }, [], []),
+            list("ns", "List", 0, sensitiveString),
+            list("ns", "List", 0, SCHEMA.STRING),
+            map("ns", "Map", 0, sensitiveString, SCHEMA.STRING),
+            map("ns", "Map", 0, SCHEMA.STRING, SCHEMA.STRING),
+          ]
+        ),
+      ]
+    );
+
+    expect(
+      schemaLogFilter(schema, {
+        a: "a",
+        b: "b",
+        sensitive: "xyz",
+        nestedSensitive: {
+          sensitive: "xyz",
+        },
+        various: {
+          boolean: false,
+          number: 1,
+          struct: {
+            q: "rf",
+          },
+          "list-s": [1, 2, 3],
+          list: [4, 5, 6],
+          "map-s": {
+            a: "a",
+            b: "b",
+            c: "c",
+          },
+          map: {
+            a: "d",
+            b: "e",
+            c: "f",
+          },
+        },
+      })
+    ).toEqual({
+      a: "a",
+      b: "b",
+      sensitive: "***SensitiveInformation***",
+      nestedSensitive: {
+        sensitive: "***SensitiveInformation***",
+      },
+      various: {
+        boolean: "***SensitiveInformation***",
+        number: "***SensitiveInformation***",
+        struct: "***SensitiveInformation***",
+        "list-s": "***SensitiveInformation***",
+        list: [4, 5, 6],
+        "map-s": "***SensitiveInformation***",
+        map: {
+          a: "d",
+          b: "e",
+          c: "f",
+        },
+      },
+    });
+  });
+});

--- a/packages/smithy-client/src/schemaLogFilter.ts
+++ b/packages/smithy-client/src/schemaLogFilter.ts
@@ -1,0 +1,46 @@
+import { NormalizedSchema } from "@smithy/core/schema";
+import type { SchemaRef } from "@smithy/types";
+
+const SENSITIVE_STRING = "***SensitiveInformation***";
+
+/**
+ * Redacts sensitive parts of any data object using its schema, for logging.
+ *
+ * @internal
+ * @param schema - with filtering traits.
+ * @param data - to be logged.
+ */
+export function schemaLogFilter(schema: SchemaRef, data: unknown): any {
+  if (data == null) {
+    return data;
+  }
+  const ns = NormalizedSchema.of(schema);
+  if (ns.getMergedTraits().sensitive) {
+    return SENSITIVE_STRING;
+  }
+
+  if (ns.isListSchema()) {
+    const isSensitive = !!ns.getValueSchema().getMergedTraits().sensitive;
+    if (isSensitive) {
+      return SENSITIVE_STRING;
+    }
+  } else if (ns.isMapSchema()) {
+    const isSensitive =
+      !!ns.getKeySchema().getMergedTraits().sensitive || !!ns.getValueSchema().getMergedTraits().sensitive;
+    if (isSensitive) {
+      return SENSITIVE_STRING;
+    }
+  } else if (ns.isStructSchema() && typeof data === "object") {
+    const object = data as Record<string, unknown>;
+
+    const newObject = {} as any;
+    for (const [member, memberNs] of ns.structIterator()) {
+      if (object[member] != null) {
+        newObject[member] = schemaLogFilter(memberNs, object[member]);
+      }
+    }
+    return newObject;
+  }
+
+  return data;
+}

--- a/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
@@ -66,7 +66,6 @@ export class EmptyInputOutputCommand extends $Command
   })
   .s("RpcV2Protocol", "EmptyInputOutput", {})
   .n("RpcV2ProtocolClient", "EmptyInputOutputCommand")
-  .f(void 0, void 0)
   .sc(EmptyInputOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
@@ -68,7 +68,6 @@ export class Float16Command extends $Command
   })
   .s("RpcV2Protocol", "Float16", {})
   .n("RpcV2ProtocolClient", "Float16Command")
-  .f(void 0, void 0)
   .sc(Float16)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
@@ -68,7 +68,6 @@ export class FractionalSecondsCommand extends $Command
   })
   .s("RpcV2Protocol", "FractionalSeconds", {})
   .n("RpcV2ProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
   .sc(FractionalSeconds)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -81,7 +81,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("RpcV2Protocol", "GreetingWithErrors", {})
   .n("RpcV2ProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
@@ -65,7 +65,6 @@ export class NoInputOutputCommand extends $Command
   })
   .s("RpcV2Protocol", "NoInputOutput", {})
   .n("RpcV2ProtocolClient", "NoInputOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
@@ -134,7 +134,6 @@ export class OperationWithDefaultsCommand extends $Command
   })
   .s("RpcV2Protocol", "OperationWithDefaults", {})
   .n("RpcV2ProtocolClient", "OperationWithDefaultsCommand")
-  .f(void 0, void 0)
   .sc(OperationWithDefaults)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
@@ -70,7 +70,6 @@ export class OptionalInputOutputCommand extends $Command
   })
   .s("RpcV2Protocol", "OptionalInputOutput", {})
   .n("RpcV2ProtocolClient", "OptionalInputOutputCommand")
-  .f(void 0, void 0)
   .sc(OptionalInputOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
@@ -94,7 +94,6 @@ export class RecursiveShapesCommand extends $Command
   })
   .s("RpcV2Protocol", "RecursiveShapes", {})
   .n("RpcV2ProtocolClient", "RecursiveShapesCommand")
-  .f(void 0, void 0)
   .sc(RecursiveShapes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -111,7 +111,6 @@ export class RpcV2CborDenseMapsCommand extends $Command
   })
   .s("RpcV2Protocol", "RpcV2CborDenseMaps", {})
   .n("RpcV2ProtocolClient", "RpcV2CborDenseMapsCommand")
-  .f(void 0, void 0)
   .sc(RpcV2CborDenseMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
@@ -149,7 +149,6 @@ export class RpcV2CborListsCommand extends $Command
   })
   .s("RpcV2Protocol", "RpcV2CborLists", {})
   .n("RpcV2ProtocolClient", "RpcV2CborListsCommand")
-  .f(void 0, void 0)
   .sc(RpcV2CborLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -111,7 +111,6 @@ export class RpcV2CborSparseMapsCommand extends $Command
   })
   .s("RpcV2Protocol", "RpcV2CborSparseMaps", {})
   .n("RpcV2ProtocolClient", "RpcV2CborSparseMapsCommand")
-  .f(void 0, void 0)
   .sc(RpcV2CborSparseMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -88,7 +88,6 @@ export class SimpleScalarPropertiesCommand extends $Command
   })
   .s("RpcV2Protocol", "SimpleScalarProperties", {})
   .n("RpcV2ProtocolClient", "SimpleScalarPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
@@ -80,7 +80,6 @@ export class SparseNullsOperationCommand extends $Command
   })
   .s("RpcV2Protocol", "SparseNullsOperation", {})
   .n("RpcV2ProtocolClient", "SparseNullsOperationCommand")
-  .f(void 0, void 0)
   .sc(SparseNullsOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -364,12 +364,16 @@ final class DirectedTypeScriptCodegen
     public void generateStructure(GenerateStructureDirective<TypeScriptCodegenContext, TypeScriptSettings> directive) {
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
             StructureGenerator generator = new StructureGenerator(
-                    directive.model(),
-                    directive.symbolProvider(),
-                    writer,
-                    directive.shape(),
-                    directive.settings().generateServerSdk(),
-                    directive.settings().getRequiredMemberMode()
+                directive.model(),
+                directive.symbolProvider(),
+                writer,
+                directive.shape(),
+                directive.settings().generateServerSdk(),
+                directive.settings().getRequiredMemberMode(),
+                SchemaGenerationAllowlist.allows(
+                    directive.settings().getService(),
+                    directive.settings()
+                )
             );
             generator.run();
         });
@@ -379,12 +383,16 @@ final class DirectedTypeScriptCodegen
     public void generateError(GenerateErrorDirective<TypeScriptCodegenContext, TypeScriptSettings> directive) {
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
             StructureGenerator generator = new StructureGenerator(
-                    directive.model(),
-                    directive.symbolProvider(),
-                    writer,
-                    directive.shape(),
-                    directive.settings().generateServerSdk(),
-                    directive.settings().getRequiredMemberMode()
+                directive.model(),
+                directive.symbolProvider(),
+                writer,
+                directive.shape(),
+                directive.settings().generateServerSdk(),
+                directive.settings().getRequiredMemberMode(),
+                SchemaGenerationAllowlist.allows(
+                    directive.settings().getService(),
+                    directive.settings()
+                )
             );
             generator.run();
         });
@@ -394,11 +402,15 @@ final class DirectedTypeScriptCodegen
     public void generateUnion(GenerateUnionDirective<TypeScriptCodegenContext, TypeScriptSettings> directive) {
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
             UnionGenerator generator = new UnionGenerator(
-                    directive.model(),
-                    directive.symbolProvider(),
-                    writer,
-                    directive.shape(),
-                    directive.settings().generateServerSdk()
+                directive.model(),
+                directive.symbolProvider(),
+                writer,
+                directive.shape(),
+                directive.settings().generateServerSdk(),
+                SchemaGenerationAllowlist.allows(
+                    directive.settings().getService(),
+                    directive.settings()
+                )
             );
             generator.run();
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -74,6 +74,7 @@ final class StructureGenerator implements Runnable {
     private final boolean includeValidation;
     private final RequiredMemberMode requiredMemberMode;
     private final SensitiveDataFinder sensitiveDataFinder;
+    private final boolean schemaMode;
 
     /**
      * sets 'includeValidation' to 'false' and requiredMemberMode
@@ -81,7 +82,7 @@ final class StructureGenerator implements Runnable {
      */
     StructureGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, StructureShape shape) {
         this(model, symbolProvider, writer, shape, false,
-                RequiredMemberMode.NULLABLE);
+                RequiredMemberMode.NULLABLE, false);
     }
 
     StructureGenerator(Model model,
@@ -89,7 +90,8 @@ final class StructureGenerator implements Runnable {
             TypeScriptWriter writer,
             StructureShape shape,
             boolean includeValidation,
-            RequiredMemberMode requiredMemberMode) {
+            RequiredMemberMode requiredMemberMode,
+            boolean schemaMode) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.writer = writer;
@@ -97,6 +99,7 @@ final class StructureGenerator implements Runnable {
         this.includeValidation = includeValidation;
         this.requiredMemberMode = requiredMemberMode;
         sensitiveDataFinder = new SensitiveDataFinder(model);
+        this.schemaMode = schemaMode;
     }
 
     @Override
@@ -190,7 +193,7 @@ final class StructureGenerator implements Runnable {
         Symbol symbol = symbolProvider.toSymbol(shape);
         String objectParam = "obj";
 
-        if (sensitiveDataFinder.findsSensitiveDataIn(shape)) {
+        if (sensitiveDataFinder.findsSensitiveDataIn(shape) && !schemaMode) {
             writer.writeDocs("@internal");
             writer.openBlock("export const $LFilterSensitiveLog = ($L: $L): any => ({", "})",
                     symbol.getName(),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -142,19 +142,21 @@ final class UnionGenerator implements Runnable {
     private final Map<String, String> variantMap;
     private final boolean includeValidation;
     private final SensitiveDataFinder sensitiveDataFinder;
+    private final boolean schemaMode;
 
     /**
      * sets 'includeValidation' to 'false' for backwards compatibility.
      */
     UnionGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, UnionShape shape) {
-        this(model, symbolProvider, writer, shape, false);
+        this(model, symbolProvider, writer, shape, false, false);
     }
 
     UnionGenerator(Model model,
             SymbolProvider symbolProvider,
             TypeScriptWriter writer,
             UnionShape shape,
-            boolean includeValidation) {
+            boolean includeValidation,
+            boolean schemaMode) {
         this.shape = shape;
         this.symbol = symbolProvider.toSymbol(shape);
         this.model = model;
@@ -168,6 +170,7 @@ final class UnionGenerator implements Runnable {
             String variant = StringUtils.capitalize(symbolProvider.toMemberName(member)) + "Member";
             variantMap.put(member.getMemberName(), variant);
         }
+        this.schemaMode = schemaMode;
     }
 
     @Override
@@ -253,7 +256,7 @@ final class UnionGenerator implements Runnable {
     }
 
     private void writeFilterSensitiveLog(String namespace) {
-        if (sensitiveDataFinder.findsSensitiveDataIn(shape)) {
+        if (sensitiveDataFinder.findsSensitiveDataIn(shape) && !schemaMode) {
             String objectParam = "obj";
             writer.writeDocs("@internal");
             writer.openBlock("export const $LFilterSensitiveLog = ($L: $L): any => {", "}",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitFilterIndex.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitFilterIndex.java
@@ -61,7 +61,6 @@ final class SchemaTraitFilterIndex implements KnowledgeIndex {
         // (wrapped for mutability)
         SetUtils.of(
             SparseTrait.ID, // Shape serde
-            // todo(schema) needs schema logger implementation
             SensitiveTrait.ID,
             IdempotencyTokenTrait.ID,
             JsonNameTrait.ID, // Shape serde


### PR DESCRIPTION
part of https://github.com/smithy-lang/smithy-typescript/issues/1600

- Use the operation schema to create the sensitive log i/o filter instead of generating functions for every sensitive shape, *WHEN* schema serde mode is on.