### PR TITLE
chore(codegen): use 'include' in tsconfig.types.json

### DIFF
--- a/private/my-local-model/tsconfig.types.json
+++ b/private/my-local-model/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/smithy-rpcv2-cbor-schema/tsconfig.types.json
+++ b/private/smithy-rpcv2-cbor-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/smithy-rpcv2-cbor/tsconfig.types.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }


### PR DESCRIPTION
*Issue #, if available:*

Noticed while attempting to bump vitest in https://github.com/smithy-lang/smithy-typescript/pull/1663

*Description of changes:*

The exclude was historically added to ensure `build:types` is able to run again.
However, is any additional `*.ts` file is added outside of `src` folder (like `vitest.config.ts`), it needs to be excluded.
A better solution it to include `src` as it's done in this PR


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
