### PR TITLE
chore: use 'include' in tsconfig.json

### DIFF
--- a/private/my-local-model/tsconfig.json
+++ b/private/my-local-model/tsconfig.json
@@ -9,5 +9,5 @@
     "rootDir": "src",
     "useUnknownInCatchVariables": false
   },
-  "exclude": ["test/"]
+  "include": ["src"]
 }

--- a/private/my-local-model/tsconfig.types.json
+++ b/private/my-local-model/tsconfig.types.json
@@ -6,6 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true,
     "noCheck": false
-  },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  }
 }

--- a/private/smithy-rpcv2-cbor-schema/tsconfig.json
+++ b/private/smithy-rpcv2-cbor-schema/tsconfig.json
@@ -9,5 +9,5 @@
     "rootDir": "src",
     "useUnknownInCatchVariables": false
   },
-  "exclude": ["test/"]
+  "include": ["src"]
 }

--- a/private/smithy-rpcv2-cbor-schema/tsconfig.types.json
+++ b/private/smithy-rpcv2-cbor-schema/tsconfig.types.json
@@ -6,6 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true,
     "noCheck": false
-  },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  }
 }

--- a/private/smithy-rpcv2-cbor/tsconfig.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.json
@@ -9,5 +9,5 @@
     "rootDir": "src",
     "useUnknownInCatchVariables": false
   },
-  "exclude": ["test/"]
+  "include": ["src"]
 }

--- a/private/smithy-rpcv2-cbor/tsconfig.types.json
+++ b/private/smithy-rpcv2-cbor/tsconfig.types.json
@@ -6,6 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true,
     "noCheck": false
-  },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  }
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -9,5 +9,5 @@
     "rootDir": "src",
     "useUnknownInCatchVariables": false
   },
-  "exclude": ["test/"]
+  "include": ["src"]
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
@@ -6,6 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true,
     "noCheck": false
-  },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*

* Noticed while attempting to bump vitest in https://github.com/smithy-lang/smithy-typescript/pull/1663
* Alternative to https://github.com/smithy-lang/smithy-typescript/pull/1667

*Description of changes:*

The exclude was historically added to ensure `build:types` is able to run again.
However, is any additional `*.ts` file is added outside of `src` folder (like `vitest.config.ts`), it needs to be excluded.
A better solution it to include `src` as it's done in this PR

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
