### PR TITLE
fix: event stream serialization

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -387,7 +387,7 @@ public class EventStreamGenerator {
                     writer.write("body = input.$L;", payloadMemberName);
                 } else if (payloadShape instanceof StringShape) {
                     writer.write("body = context.utf8Decoder(input.$L);", payloadMemberName);
-                } else if (payloadShape instanceof BlobShape || payloadShape instanceof StringShape) {
+                } else if (payloadShape instanceof StructureShape || payloadShape instanceof UnionShape) {
                     Symbol symbol = getSymbol(context, payloadShape);
                     String serFunctionName = ProtocolGenerator.getSerFunctionShortName(symbol);
                     boolean mayElide = serdeElisionIndex.mayElide(payloadShape);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.knowledge.SerdeElisionIndex;
 import software.amazon.smithy.utils.OptionalUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -107,7 +108,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             getDocumentContentType(),
             () -> {
                 TypeScriptWriter writer = context.getWriter();
-                writer.write("body = context.utf8Decoder(body);");
+                serializeEventStreamBodyToBytes(writer);
             },
             serializingDocumentShapes
         );
@@ -604,6 +605,17 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      */
     protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
         return outputLocation;
+    }
+
+    /**
+     * Allows RPC protocols to designate how to convert the body into bytes.
+     *
+     * @deprecated superseded by schema-serde.
+     */
+    @Deprecated
+    @SmithyInternalApi
+    protected void serializeEventStreamBodyToBytes(TypeScriptWriter writer) {
+        writer.write("body = context.utf8Decoder(JSON.stringify(body));");
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/SmithyRpcV2Cbor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/SmithyRpcV2Cbor.java
@@ -67,7 +67,11 @@ public class SmithyRpcV2Cbor extends HttpRpcProtocolGenerator {
             service,
             getDocumentContentType(),
             () -> {
-                writer.write("body = context.utf8Decoder(body);");
+                writer.addImportSubmodule(
+                    "cbor", null,
+                    TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CBOR
+                );
+                writer.write("body = cbor.encode(body);");
             },
             serializingDocumentShapes
         );


### PR DESCRIPTION
internal P291987404

Fixes event stream serialization when the `@eventStreamPayload` member is a string. 

This case is not present in current AWS models.