### PR TITLE
fix(core/cbor): set explicit return type to de-genericize alloc fn

### DIFF
--- a/.changeset/swift-garlics-notice.md
+++ b/.changeset/swift-garlics-notice.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+set explicit return type for cbor alloc

--- a/packages/core/src/submodules/cbor/cbor-types.ts
+++ b/packages/core/src/submodules/cbor/cbor-types.ts
@@ -64,7 +64,7 @@ export const extendedFloat64 = 27; // 0b11011
 
 export const minorIndefinite = 31; // 0b11111
 
-export function alloc(size: number) {
+export function alloc(size: number): Uint8Array {
   return typeof Buffer !== "undefined" ? Buffer.alloc(size) : new Uint8Array(size);
 }
 


### PR DESCRIPTION
Issue https://github.com/smithy-lang/smithy-typescript/issues/1675

Sets an explicit return type for the internal `alloc` cbor function so that the type compilation does not produce a generic parameter for `Uint8Array`. 

Though our target language level includes TypeScript built-in declarations of Uint8Array having a type parameter, for greater compatibility we should avoid using it.