### PR TITLE
Cache gradle in GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
+          cache: gradle
 
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
@@ -97,6 +98,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'corretto'
+          cache: gradle
       - name: Install dependencies
         run: |
           yarn


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/actions/setup-java#caching-packages-dependencies

*Description of changes:*
Caches gradle in GitHub workflow

### Before

Gradle build took 1m46s
https://github.com/smithy-lang/smithy-typescript/actions/runs/17648314510/job/50152154402?pr=1683

Gradle is downloaded from network
```
Downloading https://services.gradle.org/distributions/gradle-8.13-bin.zip
.............10%.............20%.............30%.............40%.............50%.............60%.............70%.............80%.............90%.............100%
```

### After

Gradle build takes 1m12s
https://github.com/smithy-lang/smithy-typescript/actions/runs/17649752971/job/50157264534?pr=1684

Gradle is used from cache
```
Creating settings.xml with server-id: github
Writing to /home/runner/.m2/settings.xml
Cache hit for: setup-java-Linux-x64-gradle-2e13ff8106ccc1e0ce397be1aaebe20988f6fb151851049941ec849ad1b6e377
Received 197132288 of 430972625 (45.7%), 187.8 MBs/sec
Received 402653184 of 430972625 (93.4%), 190.0 MBs/sec
Received 430972625 of 430972625 (100.0%), 183.2 MBs/sec
Cache Size: ~411 MB (430972625 B)
/usr/bin/tar -xf /home/runner/work/_temp/b7e66163-0e52-4ee7-8791-bdf00c4eb1e0/cache.tzst -P -C /home/runner/work/smithy-typescript/smithy-typescript --use-compress-program unzstd
Cache restored successfully
Cache restored from key: setup-java-Linux-x64-gradle-2e13ff8106ccc1e0ce397be1aaebe20988f6fb151851049941ec849ad1b6e377
```

Caches: https://github.com/smithy-lang/smithy-typescript/actions/caches

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
