### PR TITLE
chore(deps): use gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v4
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -92,7 +92,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
*Issue #, if available:*
The https://github.com/gradle/wrapper-validation-action is archived

*Description of changes:*
Changes `gradle/wrapper-validation-action` to use `gradle/actions/wrapper-validation`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
