### PR TITLE
docs: add type information for client config to Command examples

### DIFF
--- a/private/my-local-model/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model/src/commands/GetNumbersCommand.ts
@@ -34,6 +34,8 @@ export interface GetNumbersCommandOutput extends GetNumbersResponse, __MetadataB
  * ```javascript
  * import { XYZServiceClient, GetNumbersCommand } from "xyz"; // ES Modules import
  * // const { XYZServiceClient, GetNumbersCommand } = require("xyz"); // CommonJS import
+ * // import type { XYZServiceClientConfig } from "xyz";
+ * const config = {}; // type is XYZServiceClientConfig
  * const client = new XYZServiceClient(config);
  * const input = { // GetNumbersRequest
  *   bigDecimal: Number("bigdecimal"),

--- a/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
@@ -33,6 +33,8 @@ export interface EmptyInputOutputCommandOutput extends EmptyStructure, __Metadat
  * ```javascript
  * import { RpcV2ProtocolClient, EmptyInputOutputCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, EmptyInputOutputCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new EmptyInputOutputCommand(input);

--- a/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
@@ -33,6 +33,8 @@ export interface Float16CommandOutput extends Float16Output, __MetadataBearer {}
  * ```javascript
  * import { RpcV2ProtocolClient, Float16Command } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, Float16Command } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new Float16Command(input);

--- a/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
@@ -33,6 +33,8 @@ export interface FractionalSecondsCommandOutput extends FractionalSecondsOutput,
  * ```javascript
  * import { RpcV2ProtocolClient, FractionalSecondsCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, FractionalSecondsCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new FractionalSecondsCommand(input);

--- a/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -39,6 +39,8 @@ export interface GreetingWithErrorsCommandOutput extends GreetingWithErrorsOutpu
  * ```javascript
  * import { RpcV2ProtocolClient, GreetingWithErrorsCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, GreetingWithErrorsCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new GreetingWithErrorsCommand(input);

--- a/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
@@ -32,6 +32,8 @@ export interface NoInputOutputCommandOutput extends __MetadataBearer {}
  * ```javascript
  * import { RpcV2ProtocolClient, NoInputOutputCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, NoInputOutputCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new NoInputOutputCommand(input);

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
@@ -33,6 +33,8 @@ export interface OperationWithDefaultsCommandOutput extends OperationWithDefault
  * ```javascript
  * import { RpcV2ProtocolClient, OperationWithDefaultsCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, OperationWithDefaultsCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // OperationWithDefaultsInput
  *   defaults: { // Defaults

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
@@ -33,6 +33,8 @@ export interface OptionalInputOutputCommandOutput extends SimpleStructure, __Met
  * ```javascript
  * import { RpcV2ProtocolClient, OptionalInputOutputCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, OptionalInputOutputCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // SimpleStructure
  *   value: "STRING_VALUE",

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
@@ -33,6 +33,8 @@ export interface RecursiveShapesCommandOutput extends RecursiveShapesInputOutput
  * ```javascript
  * import { RpcV2ProtocolClient, RecursiveShapesCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, RecursiveShapesCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RecursiveShapesInputOutput
  *   nested: { // RecursiveShapesInputOutputNested1

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -32,6 +32,8 @@ export interface RpcV2CborDenseMapsCommandOutput extends RpcV2CborDenseMapsInput
  * ```javascript
  * import { RpcV2ProtocolClient, RpcV2CborDenseMapsCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, RpcV2CborDenseMapsCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RpcV2CborDenseMapsInputOutput
  *   denseStructMap: { // DenseStructMap

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
@@ -38,6 +38,8 @@ export interface RpcV2CborListsCommandOutput extends RpcV2CborListInputOutput, _
  * ```javascript
  * import { RpcV2ProtocolClient, RpcV2CborListsCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, RpcV2CborListsCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RpcV2CborListInputOutput
  *   stringList: [ // StringList

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -33,6 +33,8 @@ export interface RpcV2CborSparseMapsCommandOutput extends RpcV2CborSparseMapsInp
  * ```javascript
  * import { RpcV2ProtocolClient, RpcV2CborSparseMapsCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, RpcV2CborSparseMapsCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RpcV2CborSparseMapsInputOutput
  *   sparseStructMap: { // SparseStructMap

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -33,6 +33,8 @@ export interface SimpleScalarPropertiesCommandOutput extends SimpleScalarStructu
  * ```javascript
  * import { RpcV2ProtocolClient, SimpleScalarPropertiesCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, SimpleScalarPropertiesCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // SimpleScalarStructure
  *   trueBooleanValue: true || false,

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
@@ -33,6 +33,8 @@ export interface SparseNullsOperationCommandOutput extends SparseNullsOperationI
  * ```javascript
  * import { RpcV2ProtocolClient, SparseNullsOperationCommand } from "@smithy/smithy-rpcv2-cbor-schema"; // ES Modules import
  * // const { RpcV2ProtocolClient, SparseNullsOperationCommand } = require("@smithy/smithy-rpcv2-cbor-schema"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor-schema";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // SparseNullsOperationInputOutput
  *   sparseStringList: [ // SparseStringList

--- a/private/smithy-rpcv2-cbor/src/commands/EmptyInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/EmptyInputOutputCommand.ts
@@ -34,6 +34,8 @@ export interface EmptyInputOutputCommandOutput extends EmptyStructure, __Metadat
  * ```javascript
  * import { RpcV2ProtocolClient, EmptyInputOutputCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, EmptyInputOutputCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new EmptyInputOutputCommand(input);

--- a/private/smithy-rpcv2-cbor/src/commands/Float16Command.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/Float16Command.ts
@@ -34,6 +34,8 @@ export interface Float16CommandOutput extends Float16Output, __MetadataBearer {}
  * ```javascript
  * import { RpcV2ProtocolClient, Float16Command } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, Float16Command } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new Float16Command(input);

--- a/private/smithy-rpcv2-cbor/src/commands/FractionalSecondsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/FractionalSecondsCommand.ts
@@ -34,6 +34,8 @@ export interface FractionalSecondsCommandOutput extends FractionalSecondsOutput,
  * ```javascript
  * import { RpcV2ProtocolClient, FractionalSecondsCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, FractionalSecondsCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new FractionalSecondsCommand(input);

--- a/private/smithy-rpcv2-cbor/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/GreetingWithErrorsCommand.ts
@@ -40,6 +40,8 @@ export interface GreetingWithErrorsCommandOutput extends GreetingWithErrorsOutpu
  * ```javascript
  * import { RpcV2ProtocolClient, GreetingWithErrorsCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, GreetingWithErrorsCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new GreetingWithErrorsCommand(input);

--- a/private/smithy-rpcv2-cbor/src/commands/NoInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/NoInputOutputCommand.ts
@@ -33,6 +33,8 @@ export interface NoInputOutputCommandOutput extends __MetadataBearer {}
  * ```javascript
  * import { RpcV2ProtocolClient, NoInputOutputCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, NoInputOutputCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = {};
  * const command = new NoInputOutputCommand(input);

--- a/private/smithy-rpcv2-cbor/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/OperationWithDefaultsCommand.ts
@@ -34,6 +34,8 @@ export interface OperationWithDefaultsCommandOutput extends OperationWithDefault
  * ```javascript
  * import { RpcV2ProtocolClient, OperationWithDefaultsCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, OperationWithDefaultsCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // OperationWithDefaultsInput
  *   defaults: { // Defaults

--- a/private/smithy-rpcv2-cbor/src/commands/OptionalInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/OptionalInputOutputCommand.ts
@@ -34,6 +34,8 @@ export interface OptionalInputOutputCommandOutput extends SimpleStructure, __Met
  * ```javascript
  * import { RpcV2ProtocolClient, OptionalInputOutputCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, OptionalInputOutputCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // SimpleStructure
  *   value: "STRING_VALUE",

--- a/private/smithy-rpcv2-cbor/src/commands/RecursiveShapesCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RecursiveShapesCommand.ts
@@ -34,6 +34,8 @@ export interface RecursiveShapesCommandOutput extends RecursiveShapesInputOutput
  * ```javascript
  * import { RpcV2ProtocolClient, RecursiveShapesCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, RecursiveShapesCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RecursiveShapesInputOutput
  *   nested: { // RecursiveShapesInputOutputNested1

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -33,6 +33,8 @@ export interface RpcV2CborDenseMapsCommandOutput extends RpcV2CborDenseMapsInput
  * ```javascript
  * import { RpcV2ProtocolClient, RpcV2CborDenseMapsCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, RpcV2CborDenseMapsCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RpcV2CborDenseMapsInputOutput
  *   denseStructMap: { // DenseStructMap

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborListsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborListsCommand.ts
@@ -39,6 +39,8 @@ export interface RpcV2CborListsCommandOutput extends RpcV2CborListInputOutput, _
  * ```javascript
  * import { RpcV2ProtocolClient, RpcV2CborListsCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, RpcV2CborListsCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RpcV2CborListInputOutput
  *   stringList: [ // StringList

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -34,6 +34,8 @@ export interface RpcV2CborSparseMapsCommandOutput extends RpcV2CborSparseMapsInp
  * ```javascript
  * import { RpcV2ProtocolClient, RpcV2CborSparseMapsCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, RpcV2CborSparseMapsCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // RpcV2CborSparseMapsInputOutput
  *   sparseStructMap: { // SparseStructMap

--- a/private/smithy-rpcv2-cbor/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/SimpleScalarPropertiesCommand.ts
@@ -34,6 +34,8 @@ export interface SimpleScalarPropertiesCommandOutput extends SimpleScalarStructu
  * ```javascript
  * import { RpcV2ProtocolClient, SimpleScalarPropertiesCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, SimpleScalarPropertiesCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // SimpleScalarStructure
  *   trueBooleanValue: true || false,

--- a/private/smithy-rpcv2-cbor/src/commands/SparseNullsOperationCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/SparseNullsOperationCommand.ts
@@ -34,6 +34,8 @@ export interface SparseNullsOperationCommandOutput extends SparseNullsOperationI
  * ```javascript
  * import { RpcV2ProtocolClient, SparseNullsOperationCommand } from "@smithy/smithy-rpcv2-cbor"; // ES Modules import
  * // const { RpcV2ProtocolClient, SparseNullsOperationCommand } = require("@smithy/smithy-rpcv2-cbor"); // CommonJS import
+ * // import type { RpcV2ProtocolClientConfig } from "@smithy/smithy-rpcv2-cbor";
+ * const config = {}; // type is RpcV2ProtocolClientConfig
  * const client = new RpcV2ProtocolClient(config);
  * const input = { // SparseNullsOperationInputOutput
  *   sparseStringList: [ // SparseStringList

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -272,7 +272,7 @@ final class CommandGenerator implements Runnable {
             + String.format("// const { %s, %s } = require(\"%s\"); // CommonJS import%n", serviceName, commandName,
                     packageName)
             + String.format("// import type { %sConfig } from \"%s\";%n", serviceName, packageName)
-            + String.format("const config = {}; // type is %sConfig%n", serviceName)                    
+            + String.format("const config = {}; // type is %sConfig%n", serviceName)
             + String.format("const client = new %s(config);%n", serviceName)
             + String.format("const input = %s%n",
                     StructureExampleGenerator.generateStructuralHintDocumentation(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -271,6 +271,8 @@ final class CommandGenerator implements Runnable {
                     packageName)
             + String.format("// const { %s, %s } = require(\"%s\"); // CommonJS import%n", serviceName, commandName,
                     packageName)
+            + String.format("// import type { %sConfig } from \"%s\";%n", serviceName, packageName)
+            + String.format("const config = {}; // type is %sConfig%n", serviceName)                    
             + String.format("const client = new %s(config);%n", serviceName)
             + String.format("const input = %s%n",
                     StructureExampleGenerator.generateStructuralHintDocumentation(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -225,9 +225,9 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
                         DeprecatedTrait deprecatedTrait = shape.expectTrait(DeprecatedTrait.class);
                         String deprecationMessage = deprecatedTrait.getMessage()
-                            .map(msg -> " " + msg)
-                            .orElse("");
-                        String deprecationString = "@deprecated" + deprecationMessage;
+                            .map(msg -> " " + msg) 
+                            .orElse(" see description");
+                        String deprecationString = deprecatedTrait.getMessage().isPresent() ? "@deprecated" + deprecationMessage : "@deprecated"; 
                         docs = docs + "\n\n" + deprecationString;
                     }
                     docs = preprocessor.apply(docs);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -225,9 +225,9 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
                         DeprecatedTrait deprecatedTrait = shape.expectTrait(DeprecatedTrait.class);
                         String deprecationMessage = deprecatedTrait.getMessage()
-                            .map(msg -> " " + msg) 
-                            .orElse(" see description");
-                        String deprecationString = deprecatedTrait.getMessage().isPresent() ? "@deprecated" + deprecationMessage : "@deprecated"; 
+                            .map(msg -> " " + msg)
+                            .orElse("");
+                        String deprecationString = "@deprecated" + deprecationMessage;
                         docs = docs + "\n\n" + deprecationString;
                     }
                     docs = preprocessor.apply(docs);


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/aws/aws-sdk-js-v3/issues/6858

Previously asked by users:
- https://github.com/aws/aws-sdk-js-v3/issues/6083
- https://github.com/aws/aws-sdk-js-v3/issues/6097
- https://github.com/aws/aws-sdk-js-v3/issues/6624
- https://github.com/aws/aws-sdk-js-v3/issues/6854
- https://github.com/aws/aws-sdk-js-v3/issues/6070
- https://github.com/aws/aws-sdk-js-v3/issues/5944
- https://github.com/aws/aws-sdk-js-v3/issues/5603
- https://github.com/aws/aws-sdk-js-v3/issues/5417
- https://github.com/aws/aws-sdk-js-v3/issues/5326
- https://github.com/aws/aws-sdk-js-v3/issues/5260
- https://github.com/aws/aws-sdk-js-v3/issues/5019
- https://github.com/aws/aws-sdk-js-v3/issues/4452

*Description of changes:*

Fixing it by adding explicit clientConfig import type and config object for reference
- **add client config option reference**
- **add client constructor type to command docs**



---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
