### PR TITLE
test(shared-ini-file-loader): add external file cache mock controls

### DIFF
--- a/.changeset/light-kiwis-teach.md
+++ b/.changeset/light-kiwis-teach.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": minor
+---
+
+add mock controls to file loader

--- a/packages/shared-ini-file-loader/src/externalDataInterceptor.spec.ts
+++ b/packages/shared-ini-file-loader/src/externalDataInterceptor.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test as it } from "vitest";
+
+import { externalDataInterceptor } from "./externalDataInterceptor";
+import { getSSOTokenFromFile } from "./getSSOTokenFromFile";
+import { slurpFile } from "./slurpFile";
+
+describe("fileMockController", () => {
+  it("intercepts slurpFile", async () => {
+    externalDataInterceptor.interceptFile("abcd", "contents");
+
+    expect(await slurpFile("abcd")).toEqual("contents");
+    expect(externalDataInterceptor.getFileRecord()).toEqual({
+      abcd: Promise.resolve("contents"),
+    });
+    expect(await externalDataInterceptor.getFileRecord().abcd).toEqual("contents");
+  });
+
+  it("intercepts getSSOTokenFromFile", async () => {
+    externalDataInterceptor.interceptToken("TOKEN", "token-contents");
+
+    expect(await getSSOTokenFromFile("TOKEN")).toEqual("token-contents");
+
+    expect(externalDataInterceptor.getTokenRecord()).toEqual({
+      TOKEN: "token-contents",
+    });
+  });
+});

--- a/packages/shared-ini-file-loader/src/externalDataInterceptor.ts
+++ b/packages/shared-ini-file-loader/src/externalDataInterceptor.ts
@@ -1,0 +1,20 @@
+import { tokenIntercept } from "./getSSOTokenFromFile";
+import { fileIntercept } from "./slurpFile";
+
+/**
+ * @internal
+ */
+export const externalDataInterceptor = {
+  getFileRecord() {
+    return fileIntercept;
+  },
+  interceptFile(path: string, contents: string) {
+    fileIntercept[path] = Promise.resolve(contents);
+  },
+  getTokenRecord() {
+    return tokenIntercept;
+  },
+  interceptToken(id: string, contents: any) {
+    tokenIntercept[id] = contents;
+  },
+};

--- a/packages/shared-ini-file-loader/src/getSSOTokenFromFile.ts
+++ b/packages/shared-ini-file-loader/src/getSSOTokenFromFile.ts
@@ -55,10 +55,18 @@ export interface SSOToken {
 
 /**
  * @internal
+ */
+export const tokenIntercept = {} as Record<string, any>;
+
+/**
+ * @internal
  * @param id - can be either a start URL or the SSO session name.
  * Returns the SSO token from the file system.
  */
 export const getSSOTokenFromFile = async (id: string) => {
+  if (tokenIntercept[id]) {
+    return tokenIntercept[id];
+  }
   const ssoTokenFilepath = getSSOTokenFilepath(id);
   const ssoTokenText = await readFile(ssoTokenFilepath, "utf8");
   return JSON.parse(ssoTokenText) as SSOToken;

--- a/packages/shared-ini-file-loader/src/index.ts
+++ b/packages/shared-ini-file-loader/src/index.ts
@@ -1,8 +1,9 @@
 export * from "./getHomeDir";
 export * from "./getProfileName";
 export * from "./getSSOTokenFilepath";
-export * from "./getSSOTokenFromFile";
+export { getSSOTokenFromFile, SSOToken } from "./getSSOTokenFromFile";
 export * from "./loadSharedConfigFiles";
 export * from "./loadSsoSessionData";
 export * from "./parseKnownFiles";
+export { externalDataInterceptor } from "./externalDataInterceptor";
 export * from "./types";

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -3,13 +3,17 @@ import { promises as fsPromises } from "fs";
 
 const { readFile } = fsPromises;
 
-const filePromisesHash: Record<string, Promise<string>> = {};
+export const filePromisesHash: Record<string, Promise<string>> = {};
+export const fileIntercept: Record<string, Promise<string>> = {};
 
 interface SlurpFileOptions {
   ignoreCache?: boolean;
 }
 
 export const slurpFile = (path: string, options?: SlurpFileOptions) => {
+  if (fileIntercept[path] !== undefined) {
+    return fileIntercept[path];
+  }
   if (!filePromisesHash[path] || options?.ignoreCache) {
     filePromisesHash[path] = readFile(path, "utf8");
   }


### PR DESCRIPTION
I tried vitest's mocking instructions, and the memfs & fs-mock NPM packages. Nothing works by default in combination with our file system reads to retrieve the AWS configuration. 

I concluded that the easiest solution would be to offer an internal API from our own package for ourselves. 