### PR TITLE
fix(core): add script to prevent byte array type parameter from being generated by compiler

### DIFF
--- a/.changeset/shiny-donuts-invite.md
+++ b/.changeset/shiny-donuts-invite.md
@@ -1,0 +1,6 @@
+---
+"@smithy/util-stream": patch
+"@smithy/core": patch
+---
+
+prevent compilation from inserting Uint8Array type parameter

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ test-types:
 	npx tsc -p tsconfig.test.json
 
 test-integration:
+	node ./scripts/validation/no-generic-byte-arrays.js
 	make test-browser
 	yarn g:vitest run -c vitest.config.integ.mts
 	make test-types

--- a/packages/core/src/submodules/cbor/cbor.ts
+++ b/packages/core/src/submodules/cbor/cbor.ts
@@ -12,11 +12,11 @@ import { encode, resize, toUint8Array } from "./cbor-encode";
  * @see https://github.com/kriszyp/cbor-x
  */
 export const cbor = {
-  deserialize(payload: Uint8Array) {
+  deserialize(payload: Uint8Array): any {
     setPayload(payload);
     return decode(0, payload.length);
   },
-  serialize(input: any) {
+  serialize(input: any): Uint8Array {
     try {
       encode(input);
       return toUint8Array();

--- a/packages/util-stream/src/ByteArrayCollector.ts
+++ b/packages/util-stream/src/ByteArrayCollector.ts
@@ -13,7 +13,7 @@ export class ByteArrayCollector {
     this.byteLength += byteArray.byteLength;
   }
 
-  public flush() {
+  public flush(): Uint8Array {
     if (this.byteArrays.length === 1) {
       const bytes = this.byteArrays[0];
       this.reset();

--- a/scripts/validation/no-generic-byte-arrays.js
+++ b/scripts/validation/no-generic-byte-arrays.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * Runs after a full build to assert that Uint8Array was not generated with a type parameter
+ * by TypeScript, which is only compatible with TypeScript 5.7.
+ */
+
+const walk = require("../utils/walk");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..", "..");
+
+const packages = path.join(root, "packages");
+
+(async () => {
+  const errors = [];
+  for (const folder of fs.readdirSync(packages)) {
+    const packagePath = path.join(packages, folder);
+    const distTypes = path.join(packagePath, "dist-types");
+    if (fs.existsSync(distTypes)) {
+      for await (const file of walk(distTypes)) {
+        const contents = fs.readFileSync(file, "utf-8");
+        if (contents.includes("Uint8Array<")) {
+          errors.push(file);
+        }
+      }
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `The following files used Uint8Array in a generic way, only compatible with TypeScript 5.7:\n\t${errors.join(
+        "\n\t"
+      )}`
+    );
+  } else {
+    console.log(`✅ No Uint8Arrays with type parameters.`);
+  }
+})();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
