### PR TITLE
Bump uuid to ^11.0.0

### DIFF
--- a/.changeset/eight-rats-roll.md
+++ b/.changeset/eight-rats-roll.md
@@ -1,0 +1,6 @@
+---
+"@smithy/middleware-retry": patch
+"@smithy/core": patch
+---
+
+Bump uuid dependency to ^11.0.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,9 +85,8 @@
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-stream": "workspace:^",
     "@smithy/util-utf8": "workspace:^",
-    "@types/uuid": "^9.0.1",
     "tslib": "^2.6.2",
-    "uuid": "^9.0.1"
+    "uuid": "^11.0.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -41,9 +41,8 @@
     "@smithy/types": "workspace:^",
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-retry": "workspace:^",
-    "@types/uuid": "^9.0.1",
     "tslib": "^2.6.2",
-    "uuid": "^9.0.1"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@smithy/util-test": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,14 +2330,13 @@ __metadata:
     "@smithy/util-stream": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
     "@types/node": "npm:^18.11.9"
-    "@types/uuid": "npm:^9.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     json-bigint: "npm:^1.0.0"
     rimraf: "npm:3.0.2"
     tslib: "npm:^2.6.2"
     typedoc: "npm:0.23.23"
-    uuid: "npm:^9.0.1"
+    uuid: "npm:^11.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2655,13 +2654,12 @@ __metadata:
     "@smithy/util-middleware": "workspace:^"
     "@smithy/util-retry": "workspace:^"
     "@smithy/util-test": "workspace:^"
-    "@types/uuid": "npm:^9.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     rimraf: "npm:3.0.2"
     tslib: "npm:^2.6.2"
     typedoc: "npm:0.23.23"
-    uuid: "npm:^9.0.1"
+    uuid: "npm:^11.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3547,13 +3545,6 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^9.0.1":
-  version: 9.0.8
-  resolution: "@types/uuid@npm:9.0.8"
-  checksum: 10c0/b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
   languageName: node
   linkType: hard
 
@@ -10773,12 +10764,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
+"uuid@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Description of changes:*

Bump `uuid` to a version that provides types itself, allowing the removal of the dependency on `@types/uuid` which has been deprecated.

Stopped at 11 because 12.0.0 dropped CommonJS support, which this package appears to have, I assume you still want that.

I've been having issues with tools getting confused between the types from `@types/uuid` and the `uuid` package, this is one of only two projects that cause us to indirectly depend on `@types/uuid` so I'm hoping this will be the easier way to solve my issues instead of fighting the tools.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
