### PR TITLE
chore: replace 'uuid' with '@smithy/uuid'

### DIFF
--- a/.changeset/pretty-cows-remember.md
+++ b/.changeset/pretty-cows-remember.md
@@ -1,0 +1,6 @@
+---
+"@smithy/middleware-retry": minor
+"@smithy/core": minor
+---
+
+Replace 'uuid' with '@smithy/uuid'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,9 +85,8 @@
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-stream": "workspace:^",
     "@smithy/util-utf8": "workspace:^",
-    "@types/uuid": "^9.0.1",
-    "tslib": "^2.6.2",
-    "uuid": "^9.0.1"
+    "@smithy/uuid": "workspace:^",
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/core/src/submodules/serde/generateIdempotencyToken.ts
+++ b/packages/core/src/submodules/serde/generateIdempotencyToken.ts
@@ -1,3 +1,3 @@
-import { v4 as generateIdempotencyToken } from "uuid";
+import { v4 as generateIdempotencyToken } from "@smithy/uuid";
 
 export { generateIdempotencyToken };

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -41,9 +41,8 @@
     "@smithy/types": "workspace:^",
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-retry": "workspace:^",
-    "@types/uuid": "^9.0.1",
-    "tslib": "^2.6.2",
-    "uuid": "^9.0.1"
+    "@smithy/uuid": "workspace:^",
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/util-test": "workspace:^",

--- a/packages/middleware-retry/src/StandardRetryStrategy.spec.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.spec.ts
@@ -7,7 +7,7 @@ import {
   RETRY_MODES,
   THROTTLING_RETRY_DELAY_BASE,
 } from "@smithy/util-retry";
-import { v4 } from "uuid";
+import { v4 } from "@smithy/uuid";
 import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
@@ -21,7 +21,7 @@ vi.mock("./delayDecider");
 vi.mock("./retryDecider");
 vi.mock("./defaultRetryQuota");
 vi.mock("@smithy/protocol-http");
-vi.mock("uuid");
+vi.mock("@smithy/uuid");
 
 describe("defaultStrategy", () => {
   let next: any; // variable for next mock function in utility methods

--- a/packages/middleware-retry/src/StandardRetryStrategy.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.ts
@@ -11,7 +11,7 @@ import {
   RETRY_MODES,
   THROTTLING_RETRY_DELAY_BASE,
 } from "@smithy/util-retry";
-import { v4 } from "uuid";
+import { v4 } from "@smithy/uuid";
 
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { defaultDelayDecider } from "./delayDecider";

--- a/packages/middleware-retry/src/retryMiddleware.spec.ts
+++ b/packages/middleware-retry/src/retryMiddleware.spec.ts
@@ -2,14 +2,14 @@ import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { isServerError, isThrottlingError, isTransientError } from "@smithy/service-error-classification";
 import type { FinalizeHandlerArguments, HandlerExecutionContext, MiddlewareStack } from "@smithy/types";
 import { INVOCATION_ID_HEADER, REQUEST_HEADER } from "@smithy/util-retry";
-import { v4 } from "uuid";
+import { v4 } from "@smithy/uuid";
 import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { getRetryPlugin, retryMiddleware, retryMiddlewareOptions } from "./retryMiddleware";
 
 vi.mock("@smithy/service-error-classification");
 vi.mock("@smithy/protocol-http");
-vi.mock("uuid");
+vi.mock("@smithy/uuid");
 
 describe(getRetryPlugin.name, () => {
   const mockClientStack = {

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -18,7 +18,7 @@ import type {
   SdkError,
 } from "@smithy/types";
 import { INVOCATION_ID_HEADER, REQUEST_HEADER } from "@smithy/util-retry";
-import { v4 } from "uuid";
+import { v4 } from "@smithy/uuid";
 
 import type { RetryResolvedConfig } from "./configurations";
 import { isStreamingPayload } from "./isStreamingPayload/isStreamingPayload";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,15 +2329,14 @@ __metadata:
     "@smithy/util-middleware": "workspace:^"
     "@smithy/util-stream": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
+    "@smithy/uuid": "workspace:^"
     "@types/node": "npm:^18.11.9"
-    "@types/uuid": "npm:^9.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     json-bigint: "npm:^1.0.0"
     rimraf: "npm:3.0.2"
     tslib: "npm:^2.6.2"
     typedoc: "npm:0.23.23"
-    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -2655,13 +2654,12 @@ __metadata:
     "@smithy/util-middleware": "workspace:^"
     "@smithy/util-retry": "workspace:^"
     "@smithy/util-test": "workspace:^"
-    "@types/uuid": "npm:^9.0.1"
+    "@smithy/uuid": "workspace:^"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     rimraf: "npm:3.0.2"
     tslib: "npm:^2.6.2"
     typedoc: "npm:0.23.23"
-    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -3283,7 +3281,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@smithy/uuid@workspace:packages/uuid":
+"@smithy/uuid@workspace:^, @smithy/uuid@workspace:packages/uuid":
   version: 0.0.0-use.local
   resolution: "@smithy/uuid@workspace:packages/uuid"
   dependencies:
@@ -3560,13 +3558,6 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^9.0.1":
-  version: 9.0.8
-  resolution: "@types/uuid@npm:9.0.8"
-  checksum: 10c0/b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
   languageName: node
   linkType: hard
 
@@ -10783,15 +10774,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Issue #, if available:*
Missed in https://github.com/smithy-lang/smithy-typescript/pull/1702

*Description of changes:*
Replaces 'uuid' with '@smithy/uuid' in javascript packages

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
