### PR TITLE
chore: stop generating re-export stubs for dist-cjs

### DIFF
--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -20,7 +20,7 @@ module.exports = class Inliner {
     this.isLib = fs.existsSync(path.join(root, "lib", pkg));
     this.isClient = !this.isPackage && !this.isLib;
     this.isCore = pkg === "core";
-    this.reExportStubs = true;
+    this.reExportStubs = false;
     this.subfolder = this.isPackage ? "packages" : this.isLib ? "lib" : "clients";
     this.verbose = process.env.DEBUG || process.argv.includes("--debug");
 


### PR DESCRIPTION
A re-export stub is a redirect of a deep `dist-cjs` path to the dist-cjs prebundled index.

Now that we have been officially discouraging deep imports for a while, and have provided no API guarantees or examples of importing deep paths in dist-cjs, we can stop shipping these stub files.