### PR TITLE
chore(core/schema): separate error schema and error ctor

### DIFF
--- a/.changeset/short-dodos-cover.md
+++ b/.changeset/short-dodos-cover.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+separate error schema objects from error ctor

--- a/packages/core/src/submodules/cbor/SmithyRpcV2CborProtocol.ts
+++ b/packages/core/src/submodules/cbor/SmithyRpcV2CborProtocol.ts
@@ -111,17 +111,19 @@ export class SmithyRpcV2CborProtocol extends RpcProtocol {
       if (dataObject.Message) {
         dataObject.message = dataObject.Message;
       }
-      const baseExceptionSchema = TypeRegistry.for("smithy.ts.sdk.synthetic." + namespace).getBaseException();
+      const synthetic = TypeRegistry.for("smithy.ts.sdk.synthetic." + namespace);
+      const baseExceptionSchema = synthetic.getBaseException();
       if (baseExceptionSchema) {
-        const ErrorCtor = baseExceptionSchema.ctor;
+        const ErrorCtor = synthetic.getErrorCtor(baseExceptionSchema);
         throw Object.assign(new ErrorCtor({ name: errorName }), errorMetadata, dataObject);
       }
       throw Object.assign(new Error(errorName), errorMetadata, dataObject);
     }
 
     const ns = NormalizedSchema.of(errorSchema);
+    const ErrorCtor = registry.getErrorCtor(errorSchema);
     const message = dataObject.message ?? dataObject.Message ?? "Unknown";
-    const exception = new errorSchema.ctor(message);
+    const exception = new ErrorCtor(message);
 
     const output = {} as any;
     for (const [name, member] of ns.structIterator()) {

--- a/packages/core/src/submodules/schema/schemas/ErrorSchema.ts
+++ b/packages/core/src/submodules/schema/schemas/ErrorSchema.ts
@@ -1,6 +1,5 @@
 import type { SchemaRef, SchemaTraits } from "@smithy/types";
 
-import { TypeRegistry } from "../TypeRegistry";
 import { Schema } from "./Schema";
 import { StructureSchema } from "./StructureSchema";
 
@@ -14,6 +13,9 @@ import { StructureSchema } from "./StructureSchema";
  */
 export class ErrorSchema extends StructureSchema {
   public static readonly symbol = Symbol.for("@smithy/err");
+  /**
+   * @deprecated - field unused.
+   */
   public ctor!: any;
   protected readonly symbol = ErrorSchema.symbol;
 }
@@ -36,7 +38,10 @@ export const error = (
   traits: SchemaTraits,
   memberNames: string[],
   memberList: SchemaRef[],
-  ctor: any
+  /**
+   * @deprecated - field unused.
+   */
+  ctor?: any
 ): ErrorSchema =>
   Schema.assign(new ErrorSchema(), {
     name,
@@ -44,5 +49,5 @@ export const error = (
     traits,
     memberNames,
     memberList,
-    ctor,
+    ctor: null,
   });

--- a/packages/core/src/submodules/schema/schemas/schemas.spec.ts
+++ b/packages/core/src/submodules/schema/schemas/schemas.spec.ts
@@ -34,20 +34,19 @@ describe("schemas", () => {
   });
 
   describe(ErrorSchema.name, () => {
-    const schema = error("ack", "Error", 0, [], [], Error);
+    const schema = error("ack", "Error", 0, [], []);
 
     it("is a StructureSchema", () => {
       expect(schema).toBeInstanceOf(StructureSchema);
       expect(schema).toBeInstanceOf(ErrorSchema);
     });
 
-    it("additionally defines an error constructor", () => {
-      expect(schema.ctor).toBeInstanceOf(Function);
-      expect(new schema.ctor()).toBeInstanceOf(schema.ctor);
+    it("deprecated reference to the error constructor", () => {
+      expect(schema.ctor).toBe(null);
     });
 
     it("has a factory and the factory registers the schema", () => {
-      expect(error("ack", "Error", 0, [], [], Error)).toEqual(schema);
+      expect(error("ack", "Error", 0, [], [])).toEqual(schema);
       expect(TypeRegistry.for("ack").getSchema(schema.name)).toEqual(schema);
     });
 

--- a/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
@@ -105,6 +105,7 @@ export const _p = "path";
 export const _rM = "recursiveMember";
 export const _s = "sparse";
 export const _sBM = "sparseBooleanMap";
+export const _sC = "smithy.ts.sdk.synthetic.smithy.protocoltests.rpcv2Cbor";
 export const _sL = "stringList";
 export const _sLt = "structureList";
 export const _sNM = "sparseNumberMap";
@@ -131,15 +132,9 @@ export const n2 = "smithy.protocoltests.shared";
 
 // smithy-typescript generated code
 import { RpcV2ProtocolServiceException as __RpcV2ProtocolServiceException } from "../models/RpcV2ProtocolServiceException";
-import { error } from "@smithy/core/schema";
+import { TypeRegistry, error } from "@smithy/core/schema";
 
 /* eslint no-var: 0 */
 
-export var RpcV2ProtocolServiceException = error(
-  "smithy.ts.sdk.synthetic.smithy.protocoltests.rpcv2Cbor",
-  "RpcV2ProtocolServiceException",
-  0,
-  [],
-  [],
-  __RpcV2ProtocolServiceException
-);
+export var RpcV2ProtocolServiceException = error(_sC, "RpcV2ProtocolServiceException", 0, [], [], null);
+TypeRegistry.for(_sC).registerError(RpcV2ProtocolServiceException, __RpcV2ProtocolServiceException);

--- a/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_1_Rpc.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_1_Rpc.ts
@@ -128,7 +128,7 @@ import {
   n1,
   n2,
 } from "./schemas_0";
-import { error, list, map, op, struct } from "@smithy/core/schema";
+import { TypeRegistry, error, list, map, op, struct } from "@smithy/core/schema";
 
 /* eslint no-var: 0 */
 
@@ -142,9 +142,10 @@ export var ValidationException = error(
   },
   [_m, _fL],
   [0, () => ValidationExceptionFieldList],
-
-  __ValidationException
+  null
 );
+TypeRegistry.for(n0).registerError(ValidationException, __ValidationException);
+
 export var ValidationExceptionField = struct(n0, _VEF, 0, [_p, _m], [0, 0]);
 export var ClientOptionalDefaults = struct(n1, _COD, 0, [_me], [1]);
 export var ComplexError = error(
@@ -155,9 +156,10 @@ export var ComplexError = error(
   },
   [_TL, _N],
   [0, () => ComplexNestedErrorData],
-
-  __ComplexError
+  null
 );
+TypeRegistry.for(n1).registerError(ComplexError, __ComplexError);
+
 export var ComplexNestedErrorData = struct(n1, _CNED, 0, [_F], [0]);
 export var Defaults = struct(
   n1,
@@ -199,9 +201,10 @@ export var InvalidGreeting = error(
   },
   [_M],
   [0],
-
-  __InvalidGreeting
+  null
 );
+TypeRegistry.for(n1).registerError(InvalidGreeting, __InvalidGreeting);
+
 export var OperationWithDefaultsInput = struct(
   n1,
   _OWDI,


### PR DESCRIPTION
This is a minor update to adhere to the letter of the specification.

The schema object should not have information on how to construct the target data type, for various reasons that are laid out in the internal specification document. 

This PR severs the reference from the error schema to the error ctor. Instead, the TypeRegistry is used to link the two objects.