### PR TITLE
Bump smithy-plugin to 0.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 smithyVersion=1.62.0
 smithyGradleVersion=1.3.0
+smithyPluginVersion=0.7.0

--- a/smithy-typescript-protocol-test-codegen/build.gradle.kts
+++ b/smithy-typescript-protocol-test-codegen/build.gradle.kts
@@ -15,7 +15,8 @@ buildscript {
 }
 
 plugins {
-    id("software.amazon.smithy").version("0.6.0")
+    val smithyPluginVersion: String by project
+    id("software.amazon.smithy").version(smithyPluginVersion)
 }
 
 dependencies {


### PR DESCRIPTION
*Issue #, if available:*
https://plugins.gradle.org/plugin/software.amazon.smithy

*Description of changes:*
* Bumps smithy-plugin to 0.7.0
* Sets smithyPluginVersion in `gradle.properties` just like in https://github.com/aws/aws-sdk-js-v3/blob/568fe9a65619bbb51a58587f4860cefe65867c67/codegen/gradle.properties#L3

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
