### PR TITLE
Remove usage of deprecated APIs

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -18,7 +18,7 @@ package software.amazon.smithy.typescript.codegen.integration;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
-import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.BlobShape;
@@ -234,8 +234,9 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
 
     @Override
     public String timestampShape(TimestampShape shape) {
-        HttpBindingIndex httpIndex = HttpBindingIndex.of(context.getModel());
-        Format format = httpIndex.determineTimestampFormat(shape, Location.DOCUMENT, defaultTimestampFormat);
+        Format format = shape.getTrait(TimestampFormatTrait.class)
+                .map(trait -> Format.fromString(trait.getValue()))
+                .orElse(defaultTimestampFormat);
         return HttpProtocolGeneratorUtils.getTimestampInputParam(context, dataSource, shape, format);
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -17,8 +17,6 @@ package software.amazon.smithy.typescript.codegen.integration;
 
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.model.knowledge.HttpBinding.Location;
-import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.BlobShape;
@@ -43,6 +41,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/knowledge/SerdeElisionIndex.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/knowledge/SerdeElisionIndex.java
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
@@ -28,7 +29,7 @@ import software.amazon.smithy.utils.MapUtils;
  */
 public class SerdeElisionIndex implements KnowledgeIndex {
     private final Map<ShapeId, Boolean> elisionBinding = new HashMap<>();
-    private final Map<String, Class> mutatingTraits = MapUtils.of(
+    private final Map<String, Class<? extends Trait>> mutatingTraits = MapUtils.of(
             "jsonName", JsonNameTrait.class,
             "streaming", StreamingTrait.class,
             "mediaType", MediaTypeTrait.class,
@@ -58,7 +59,7 @@ public class SerdeElisionIndex implements KnowledgeIndex {
     }
 
     private boolean hasMutatingTraits(Shape shape, Model model) {
-        for (Map.Entry<String, Class> entry : mutatingTraits.entrySet()) {
+        for (Map.Entry<String, Class<? extends Trait>> entry : mutatingTraits.entrySet()) {
             if (shape.hasTrait(entry.getValue())) {
                 return true;
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/knowledge/SerdeElisionIndex.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/knowledge/SerdeElisionIndex.java
@@ -13,12 +13,12 @@ import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ToShapeId;
-import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.MapUtils;
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Removes usage of deprecated APIs

### Before

```console
$ smithy-typescript> ./gradlew publishToMavenLocal

> Task :smithy-typescript-codegen:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

[Incubating] Problems report is available at: file:///local/home/trivikr/workspace/smithy-typescript/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 3s
```

### After

```console
$ smithy-typescript> ./gradlew publishToMavenLocal

BUILD SUCCESSFUL in 7s
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
