### PR TITLE
Enable Gradle configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 smithyVersion=1.62.0
 smithyGradleVersion=1.3.0
+org.gradle.configuration-cache=true

--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -56,19 +56,24 @@ sourceSets {
     }
 }
 
-tasks.register("set-dependency-versions") {
-    val packagesDir = project.file("../packages")
-    var smithyTsSsdkLibs = project.file("../smithy-typescript-ssdk-libs")
-
-    doLast {
-        mkdir(layout.buildDirectory.dir("generated/resources/software/amazon/smithy/typescript/codegen").get().asFile)
-        var versionsFile = layout.buildDirectory
-            .file("generated/resources/software/amazon/smithy/typescript/codegen/dependencyVersions.properties")
-            .get()
-            .asFile
-        versionsFile.printWriter().close()
-
-        val roots = packagesDir.listFiles().toMutableList() + smithyTsSsdkLibs.listFiles().toList()
+abstract class SetDependencyVersionsTask : DefaultTask() {
+    @get:InputDirectory
+    abstract val packagesDir: DirectoryProperty
+    
+    @get:InputDirectory
+    abstract val smithyTsSsdkLibs: DirectoryProperty
+    
+    @get:OutputFile
+    abstract val versionsFile: RegularFileProperty
+    
+    @TaskAction
+    fun execute() {
+        val outputFile = versionsFile.get().asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.printWriter().close()
+        
+        val roots = packagesDir.get().asFile.listFiles().toMutableList() + 
+                   smithyTsSsdkLibs.get().asFile.listFiles().toList()
         roots.forEach { packageDir ->
             val packageJsonFile = File(packageDir, "package.json")
             if (packageJsonFile.isFile()) {
@@ -77,11 +82,17 @@ tasks.register("set-dependency-versions") {
                 val packageVersion = packageJson.expectStringMember("version").getValue()
                 val isPrivate = packageJson.getBooleanMemberOrDefault("private", false)
                 if (!isPrivate) {
-                    versionsFile.appendText("$packageName=$packageVersion\n")
+                    outputFile.appendText("$packageName=$packageVersion\n")
                 }
             }
         }
     }
+}
+
+tasks.register<SetDependencyVersionsTask>("set-dependency-versions") {
+    packagesDir.set(project.file("../packages"))
+    smithyTsSsdkLibs.set(project.file("../smithy-typescript-ssdk-libs"))
+    versionsFile.set(layout.buildDirectory.file("generated/resources/software/amazon/smithy/typescript/codegen/dependencyVersions.properties"))
 }
 
 tasks["processResources"].dependsOn(tasks["set-dependency-versions"])


### PR DESCRIPTION
*Issue #, if available:*

* Doc https://docs.gradle.org/current/userguide/configuration_cache.html
* User Guide https://docs.gradle.org/9.0.0/userguide/configuration_cache_enabling.html

*Description of changes:*

Enables Gradle configuration cache for improved build performance

```console
$ smithy-typescript> ./gradlew clean build -Plog-tests
Reusing configuration cache.
...
BUILD SUCCESSFUL in 14s
33 actionable tasks: 31 executed, 2 up-to-date
Configuration cache entry reused
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
