### PR TITLE
Add explicit dependency on 'set-dependency-versions'

### DIFF
--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -96,3 +96,4 @@ tasks.register<SetDependencyVersionsTask>("set-dependency-versions") {
 }
 
 tasks["processResources"].dependsOn(tasks["set-dependency-versions"])
+tasks["sourcesJar"].dependsOn(tasks["set-dependency-versions"])


### PR DESCRIPTION
*Issue #, if available:*
* Missed in https://github.com/smithy-lang/smithy-typescript/pull/1722
* Noticed while attempting to use it in https://github.com/aws/aws-sdk-js-v3/pull/7396

*Description of changes:*
Adds explicit dependency on 'set-dependency-versions' in 'sourcesJar'

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
