### PR TITLE
Use gradle/actions/setup-gradle for setting up gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-write-only: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
@@ -59,6 +60,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-write-only: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
@@ -110,6 +112,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-write-only: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Install dependencies
         run: |
           yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/actions/wrapper-validation@v5
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
@@ -43,7 +42,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/actions/wrapper-validation@v5
       - uses: actions/setup-node@v5
         with:
           node-version: 18
@@ -100,7 +98,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
-      - uses: gradle/actions/wrapper-validation@v5
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-write-only: true
 
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
@@ -55,6 +57,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-write-only: true
 
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
@@ -104,6 +108,8 @@ jobs:
           distribution: "corretto"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-write-only: true
       - name: Install dependencies
         run: |
           yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
-          cache-write-only: true
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: clean and build
@@ -59,7 +58,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
-          cache-write-only: true
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: clean and build
@@ -111,7 +109,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
-          cache-write-only: true
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'corretto'
-          cache: gradle
+          distribution: "corretto"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
@@ -39,7 +41,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
       - uses: actions/setup-node@v5
         with:
           node-version: 18
@@ -49,8 +51,10 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'corretto'
-          cache: gradle
+          distribution: "corretto"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
@@ -80,7 +84,7 @@ jobs:
   test-typescript:
     runs-on: smithy-typescript_ubuntu-latest_8-core
     name: TypeScript Test ${{ matrix.node }}
-    needs: ['ensure-typescript-packages-have-changesets', 'lint-typescript', 'ensure-typescript-formatted']
+    needs: ["ensure-typescript-packages-have-changesets", "lint-typescript", "ensure-typescript-formatted"]
     strategy:
       fail-fast: false
       matrix:
@@ -92,13 +96,14 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'corretto'
-          cache: gradle
+          java-version: "17"
+          distribution: "corretto"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
       - name: Install dependencies
         run: |
           yarn

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 smithyVersion=1.62.0
 smithyGradleVersion=1.3.0
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=build/jreleaser/marker.txt


### PR DESCRIPTION
*Issue #, if available:*
The first party `gradle/actions/setup-gradle` is better, as it does configuration caching
Details in https://github.com/actions/setup-java/issues/588

*Description of changes:*
Replaces `cache: gradle` in `actions/setup-java` with `gradle/actions/setup-gradle`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
