### PR TITLE
fix(codegen): escape $ character in schema generation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
@@ -535,12 +535,12 @@ public class SchemaGenerator implements Runnable {
         TypeScriptWriter writer = getWriter(context.getId());
         boolean useImportedStrings = !groupingIndex.isBaseGroup(context);
 
-        writer.write(
-            new SchemaTraitWriter(
-                shape, elision,
-                useImportedStrings ? store.useSchemaWriter(writer) : store
-            ).toString()
-        );
+        String traitCode = new SchemaTraitWriter(
+            shape, elision,
+            useImportedStrings ? store.useSchemaWriter(writer) : store
+        ).toString();
+
+        writer.write(traitCode.replace("$", "$$"));
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
#1600 

brings in a fix from https://github.com/smithy-lang/smithy-typescript/pull/1704 experimentation branch

in very rare cases, trait data has the `$` character in it. When passing to TypeScriptWriter::write, this should be escaped to `$$`.
