### PR TITLE
Bump codegen version to 0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.36.1 (2025-10-06)
+
+### Features
+
+- Allow schema-serde toggle by protocol ([#1733](https://github.com/smithy-lang/smithy-typescript/pull/1733))
+
+### Bug Fixes
+
+- Fixed CBOR eventstream codegen ([#1731](https://github.com/smithy-lang/smithy-typescript/pull/1731))
+- Escape $ character in schema generation ([#1728](https://github.com/smithy-lang/smithy-typescript/pull/1728))
+
 ## 0.36.0 (2025-09-30)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Allow schema-serde toggle by protocol ([#1733](https://github.com/smithy-lang/smithy-typescript/pull/1733))
+- Added 'pnpm' to 'PackageManager' ([#1658](https://github.com/smithy-lang/smithy-typescript/pull/1658))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,11 @@
 
 ### Features
 
-- Allow schema-serde toggle by protocol ([#1733](https://github.com/smithy-lang/smithy-typescript/pull/1733))
 - Added 'pnpm' to 'PackageManager' ([#1658](https://github.com/smithy-lang/smithy-typescript/pull/1658))
 
 ### Bug Fixes
 
 - Fixed CBOR eventstream codegen ([#1731](https://github.com/smithy-lang/smithy-typescript/pull/1731))
-- Escape $ character in schema generation ([#1728](https://github.com/smithy-lang/smithy-typescript/pull/1728))
 
 ## 0.36.0 (2025-09-30)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.36.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.36.1"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -139,7 +139,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.36.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.36.1")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.36.0"
+    version = "0.36.1"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-6274

*Description of changes:*
Bumps codegen version to 0.36.1



---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
