### PR TITLE
fix: apply reserved word escaping to union shape names in CBOR serializer

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/CborShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/protocols/cbor/CborShapeSerVisitor.java
@@ -6,7 +6,10 @@
 package software.amazon.smithy.typescript.codegen.protocols.cbor;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
+import software.amazon.smithy.codegen.core.ReservedWords;
+import software.amazon.smithy.codegen.core.ReservedWordsBuilder;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -21,6 +24,7 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
@@ -35,6 +39,10 @@ public class CborShapeSerVisitor extends DocumentShapeSerVisitor {
      * The service model's timestampFormat is ignored in RPCv2 CBOR protocol.
      */
     private static final TimestampFormatTrait.Format TIMESTAMP_FORMAT = TimestampFormatTrait.Format.EPOCH_SECONDS;
+
+    private final ReservedWords reservedWords = new ReservedWordsBuilder()
+        .loadWords(Objects.requireNonNull(TypeScriptClientCodegenPlugin.class.getResource("reserved-words.txt")))
+        .build();
 
     public CborShapeSerVisitor(ProtocolGenerator.GenerationContext context) {
         super(context);
@@ -149,7 +157,8 @@ public class CborShapeSerVisitor extends DocumentShapeSerVisitor {
         Model model = context.getModel();
         ServiceShape serviceShape = context.getService();
 
-        writer.openBlock("return $L.visit(input, {", "});", shape.getId().getName(serviceShape), () -> {
+        writer.openBlock("return $L.visit(input, {", "});",
+            reservedWords.escape(shape.getId().getName(serviceShape)), () -> {
             Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
             members.forEach((memberName, memberShape) -> {
                 Shape target = model.expectShape(memberShape.getTarget());


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-6273

*Description of changes:*


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
