### PR TITLE
fix argument positioning in schema generator

### DIFF
--- a/.changeset/hungry-mayflies-confess.md
+++ b/.changeset/hungry-mayflies-confess.md
@@ -1,6 +1,0 @@
----
-"@smithy/core": patch
-"@smithy/types": patch
----
-
-fix ordering of static simple schema type

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
@@ -278,13 +278,13 @@ public class SchemaGenerator implements Runnable {
             writer.addImport("StaticSimpleSchema", null, TypeScriptDependency.SMITHY_TYPES);
             writer.openBlock("""
                     export var $L: StaticSimpleSchema = [0, $L, $L,""",
-                ", $L];",
+                "",
                 getShapeVariableName(shape),
                 checkImportString(shape, shape.getId().getNamespace(), "n"),
                 checkImportString(shape, shape.getId().getName()),
-                resolveSimpleSchema(shape, shape),
                 () -> {
                     writeTraits(shape);
+                    writer.writeInline(", $L];", resolveSimpleSchema(shape, shape));
                 }
             );
         }


### PR DESCRIPTION
an interpolated variable cannot appear in the block textAfterNewline argument, I think