### PR TITLE
fix(node-http-handler): shift http1 expect 100-continue requests to isolated http Agents

### DIFF
--- a/.changeset/chilled-apples-arrive.md
+++ b/.changeset/chilled-apples-arrive.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+shfit http1 calls with expect 100-continue header to isolated http Agents

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -261,6 +261,34 @@ describe("NodeHttpHandler", () => {
         await nodeHttpHandler.handle(httpRequest as any);
         expect(vi.mocked(hRequest as any).mock.calls[0][0]?.host).toEqual("host");
       });
+
+      it("creates a new http(s) Agent if the request has expect: 100-continue header", async () => {
+        const nodeHttpHandler = new NodeHttpHandler({});
+        {
+          const httpRequest = {
+            protocol: "http:",
+            hostname: "[host]",
+            path: "/some/path",
+            headers: {
+              expect: "100-continue",
+            },
+          };
+          await nodeHttpHandler.handle(httpRequest as any);
+          expect(vi.mocked(hRequest as any).mock.calls[0][0]?.agent).not.toBe(
+            (nodeHttpHandler as any).config.httpAgent
+          );
+        }
+        {
+          const httpRequest = {
+            protocol: "http:",
+            hostname: "[host]",
+            path: "/some/path",
+            headers: {},
+          };
+          await nodeHttpHandler.handle(httpRequest as any);
+          expect(vi.mocked(hRequest as any).mock.calls[1][0]?.agent).toBe((nodeHttpHandler as any).config.httpAgent);
+        }
+      });
     });
   });
 

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -20,7 +20,7 @@ export async function writeRequestBody(
   maxContinueTimeoutMs = MIN_WAIT_TIME
 ): Promise<void> {
   const headers = request.headers ?? {};
-  const expect = headers["Expect"] || headers["expect"];
+  const expect = headers.Expect || headers.expect;
 
   let timeoutId = -1;
   let sendBody = true;


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-js-v3/issues/6940

This pairs with https://github.com/aws/aws-sdk-js-v3/pull/7450 which allows the criteria of the expect 100-continue header to be configured by the S3 Client owner. 

*Description of changes:*

This PR moves http1.1 requests having header `expect: 100-continue` to separate http(s) Agent instances. The presence of the header causes a confusion (crossed streams style) in the transmission of http headers and bodies in the Node.js http/https modules when using shared Agent instances and Buffer/Uint8Array payloads under conditions described in the linked issue.

This is despite referential consistency in how the requests are invoked and no stray mutations in the user code, so at this point I suspect a bug or at least undocumented behavior in http(s) Agent sockets. It also only happens with Buffers and not strings. This shouldn't be related to shared Buffer memory misuse either, since I tried copying standalone Uint8Arrays at the call sites synchronously.

----

As a side effect of using isolated Agents, these requests will not be subject to the socket limits nor socket reuse intentions placed on the NodeHttpHandler's Agent by the downstream consumer. 
