### PR TITLE
chore: apply eslint rule for import paths

### DIFF
--- a/.changeset/chilled-pets-hammer.md
+++ b/.changeset/chilled-pets-hammer.md
@@ -1,0 +1,6 @@
+---
+"@smithy/types": patch
+"@smithy/core": patch
+---
+
+export used types

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,4 +36,22 @@ module.exports = {
     "simple-import-sort/imports": "error",
     "@typescript-eslint/consistent-type-imports": "error",
   },
+  overrides: [
+    {
+      files: ["packages/*/src/**/*.ts"],
+      excludedFiles: ["packages/*/src/**/*.spec.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            patterns: [
+              {
+                group: ["*src*", "*dist-*"],
+              },
+            ],
+          },
+        ],
+      }
+    },
+  ],
 };

--- a/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
+++ b/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
@@ -30,7 +30,7 @@ import type {
   TimestampEpochSecondsSchema,
   UnitSchema,
 } from "@smithy/types";
-import type { IdempotencyTokenBitMask, TraitBitVector } from "@smithy/types/src/schema/traits";
+import type { IdempotencyTokenBitMask, TraitBitVector } from "@smithy/types";
 
 import { deref } from "../deref";
 import { translateTraits } from "./translateTraits";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,6 +22,7 @@ export * from "./profile";
 export * from "./response";
 export * from "./retry";
 export * from "./schema/schema";
+export * from "./schema/traits";
 export * from "./schema/schema-deprecated";
 export * from "./schema/sentinels";
 export * from "./schema/static-schemas";


### PR DESCRIPTION
applies an eslint import rule to avoid IDE auto-imports from finding incorrect paths such as the src folder of another package, or dist-*. 