### PR TITLE
fix(config-resolver): allow asterisk region with warning

### DIFF
--- a/.changeset/thick-mirrors-burn.md
+++ b/.changeset/thick-mirrors-burn.md
@@ -1,0 +1,5 @@
+---
+"@smithy/config-resolver": patch
+---
+
+allow \* region with warning

--- a/packages/config-resolver/src/regionConfig/checkRegion.spec.ts
+++ b/packages/config-resolver/src/regionConfig/checkRegion.spec.ts
@@ -39,7 +39,7 @@ describe("checkRegion", () => {
       "%",
       "^",
       "&",
-      "*",
+      "**",
       "(",
       ")",
       ".",
@@ -59,7 +59,14 @@ describe("checkRegion", () => {
     }
   });
 
+  it("emits a warning when asterisk region is used", () => {
+    vi.spyOn(console, "warn");
+    checkRegion("*");
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("@smithy/config-resolver WARN"));
+  });
+
   it("caches accepted regions", () => {
+    vi.spyOn(console, "warn");
     const di = {
       isValidHostLabel,
     };
@@ -73,5 +80,6 @@ describe("checkRegion", () => {
     expect(di.isValidHostLabel).toHaveBeenCalledTimes(0);
     expect(() => checkRegion("oh-canada", di.isValidHostLabel)).not.toThrow();
     expect(di.isValidHostLabel).toHaveBeenCalledTimes(1);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/config-resolver/src/regionConfig/checkRegion.ts
+++ b/packages/config-resolver/src/regionConfig/checkRegion.ts
@@ -15,7 +15,13 @@ const validRegions = new Set<string>();
  */
 export const checkRegion = (region: string, check = isValidHostLabel) => {
   if (!validRegions.has(region) && !check(region)) {
-    throw new Error(`Region not accepted: region="${region}" is not a valid hostname component.`);
+    if (region === "*") {
+      console.warn(
+        `@smithy/config-resolver WARN - Please use the caller region instead of "*". See "sigv4a" in https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md.`
+      );
+    } else {
+      throw new Error(`Region not accepted: region="${region}" is not a valid hostname component.`);
+    }
   } else {
     validRegions.add(region);
   }

--- a/private/my-local-model/src/auth/httpAuthSchemeProvider.ts
+++ b/private/my-local-model/src/auth/httpAuthSchemeProvider.ts
@@ -65,7 +65,7 @@ export const defaultXYZServiceHttpAuthSchemeProvider: XYZServiceHttpAuthSchemePr
 };
 
 /**
- * @internal
+ * @public
  */
 export interface HttpAuthSchemeInputConfig {
   /**

--- a/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthSchemeProvider.ts
@@ -66,7 +66,7 @@ export const defaultRpcV2ProtocolHttpAuthSchemeProvider: RpcV2ProtocolHttpAuthSc
 };
 
 /**
- * @internal
+ * @public
  */
 export interface HttpAuthSchemeInputConfig {
   /**

--- a/private/smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
+++ b/private/smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
@@ -66,7 +66,7 @@ export const defaultRpcV2ProtocolHttpAuthSchemeProvider: RpcV2ProtocolHttpAuthSc
 };
 
 /**
- * @internal
+ * @public
  */
 export interface HttpAuthSchemeInputConfig {
   /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemePlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemePlugin.java
@@ -222,7 +222,7 @@ public final class AddHttpAuthSchemePlugin implements HttpAuthTypeScriptIntegrat
             s.getResolveConfigFunctions();
         String serviceName = CodegenUtils.getServiceName(
             s.getSettings(), s.getModel(), s.getSymbolProvider());
-        w.writeDocs("@internal");
+        w.writeDocs("@public");
         w.writeInline("export interface HttpAuthSchemeInputConfig");
         if (!resolveConfigFunctions.isEmpty()) {
             w.writeInline(" extends ");


### PR DESCRIPTION
*Issue #, if available:*
n/a

Allow single asterisk to be set as the region, but warn that this is not the correct way to configure sigv4a. This makes the region validation less sharp-edged for people who have configured `*` unnecessarily while using sigv4a.

Documentation at the AWS SDK will be updated (https://github.com/aws/aws-sdk-js-v3/pull/7472) to refer users to the `sigv4aSigningRegionSet` and `authSchemePreference` configuration fields instead.
