### PR TITLE
fix(codegen): handle shape name collisions for exceptions and Unit

### DIFF
--- a/private/my-local-model/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model/src/commands/GetNumbersCommand.ts
@@ -66,7 +66,9 @@ export interface GetNumbersCommandOutput extends GetNumbersResponse, __MetadataB
  *
  * @throws {@link HaltError} (client fault)
  *
- * @throws {@link XYZServiceServiceException}
+ * @throws {@link XYZServiceServiceException} (client fault)
+ *
+ * @throws {@link XYZServiceSyntheticServiceException}
  * <p>Base exception class for all service exceptions from XYZService service.</p>
  *
  *

--- a/private/my-local-model/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model/src/commands/TradeEventStreamCommand.ts
@@ -73,7 +73,7 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  * @see {@link TradeEventStreamCommandOutput} for command's `response` shape.
  * @see {@link XYZServiceClientResolvedConfig | config} for XYZServiceClient's `config` shape.
  *
- * @throws {@link XYZServiceServiceException}
+ * @throws {@link XYZServiceSyntheticServiceException}
  * <p>Base exception class for all service exceptions from XYZService service.</p>
  *
  *

--- a/private/my-local-model/src/index.ts
+++ b/private/my-local-model/src/index.ts
@@ -13,4 +13,4 @@ export type { XYZServiceExtensionConfiguration } from "./extensionConfiguration"
 export * from "./commands";
 export * from "./models";
 
-export { XYZServiceServiceException } from "./models/XYZServiceServiceException";
+export { XYZServiceSyntheticServiceException } from "./models/XYZServiceSyntheticServiceException";

--- a/private/my-local-model/src/models/XYZServiceSyntheticServiceException.ts
+++ b/private/my-local-model/src/models/XYZServiceSyntheticServiceException.ts
@@ -13,12 +13,12 @@ export { __ServiceException };
  *
  * Base exception class for all service exceptions from XYZService service.
  */
-export class XYZServiceServiceException extends __ServiceException {
+export class XYZServiceSyntheticServiceException extends __ServiceException {
   /**
    * @internal
    */
   constructor(options: __ServiceExceptionOptions) {
     super(options);
-    Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
+    Object.setPrototypeOf(this, XYZServiceSyntheticServiceException.prototype);
   }
 }

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { XYZServiceServiceException as __BaseException } from "./XYZServiceServiceException";
+import { XYZServiceSyntheticServiceException as __BaseException } from "./XYZServiceSyntheticServiceException";
 import { NumericValue } from "@smithy/core/serde";
 import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
 
@@ -122,6 +122,25 @@ export class RetryableError extends __BaseException {
       ...opts,
     });
     Object.setPrototypeOf(this, RetryableError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class XYZServiceServiceException extends __BaseException {
+  readonly name: "XYZServiceServiceException" = "XYZServiceServiceException";
+  readonly $fault: "client" = "client";
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<XYZServiceServiceException, __BaseException>) {
+    super({
+      name: "XYZServiceServiceException",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
   }
 }
 

--- a/private/my-local-model/src/protocols/Rpcv2cbor.ts
+++ b/private/my-local-model/src/protocols/Rpcv2cbor.ts
@@ -1,7 +1,7 @@
 // smithy-typescript generated code
 import { GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
 import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "../commands/TradeEventStreamCommand";
-import { XYZServiceServiceException as __BaseException } from "../models/XYZServiceServiceException";
+import { XYZServiceSyntheticServiceException as __BaseException } from "../models/XYZServiceSyntheticServiceException";
 import {
   Alpha,
   CodedThrottlingError,
@@ -12,6 +12,7 @@ import {
   RetryableError,
   TradeEvents,
   Unit,
+  XYZServiceServiceException,
 } from "../models/models_0";
 import {
   dateToTag as __dateToTag,
@@ -138,6 +139,9 @@ const de_CommandError = async (output: __HttpResponse, context: __SerdeContext):
     case "RetryableError":
     case "org.xyz.v1#RetryableError":
       throw await de_RetryableErrorRes(parsedOutput, context);
+    case "XYZServiceServiceException":
+    case "org.xyz.v1#XYZServiceServiceException":
+      throw await de_XYZServiceServiceExceptionRes(parsedOutput, context);
     default:
       const parsedBody = parsedOutput.body;
       return throwDefaultError({
@@ -200,6 +204,22 @@ const de_RetryableErrorRes = async (parsedOutput: any, context: __SerdeContext):
   const body = parsedOutput.body;
   const deserialized: any = _json(body);
   const exception = new RetryableError({
+    $metadata: deserializeMetadata(parsedOutput),
+    ...deserialized,
+  });
+  return __decorateServiceException(exception, body);
+};
+
+/**
+ * deserializeRpcv2cborXYZServiceServiceExceptionRes
+ */
+const de_XYZServiceServiceExceptionRes = async (
+  parsedOutput: any,
+  context: __SerdeContext
+): Promise<XYZServiceServiceException> => {
+  const body = parsedOutput.body;
+  const deserialized: any = _json(body);
+  const exception = new XYZServiceServiceException({
     $metadata: deserializeMetadata(parsedOutput),
     ...deserialized,
   });
@@ -330,6 +350,8 @@ const de_GetNumbersResponse = (output: any, context: __SerdeContext): GetNumbers
 // de_MysteryThrottlingError omitted.
 
 // de_RetryableError omitted.
+
+// de_XYZServiceServiceException omitted.
 
 // de_Unit omitted.
 

--- a/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
@@ -148,7 +148,7 @@ import {
 
 /* eslint no-var: 0 */
 
-export var Unit = "unit" as const;
+export var __Unit = "unit" as const;
 
 export var ValidationException: StaticErrorSchema = [
   -3,
@@ -435,10 +435,10 @@ export var SparseStringMap: StaticMapSchema = [
   0,
 ];
 export var EmptyInputOutput: StaticOperationSchema = [9, n1, _EIO, 0, () => EmptyStructure, () => EmptyStructure];
-export var Float16: StaticOperationSchema = [9, n1, _Fl, 0, () => Unit, () => Float16Output];
-export var FractionalSeconds: StaticOperationSchema = [9, n1, _FS, 0, () => Unit, () => FractionalSecondsOutput];
-export var GreetingWithErrors: StaticOperationSchema = [9, n1, _GWE, 2, () => Unit, () => GreetingWithErrorsOutput];
-export var NoInputOutput: StaticOperationSchema = [9, n1, _NIO, 0, () => Unit, () => Unit];
+export var Float16: StaticOperationSchema = [9, n1, _Fl, 0, () => __Unit, () => Float16Output];
+export var FractionalSeconds: StaticOperationSchema = [9, n1, _FS, 0, () => __Unit, () => FractionalSecondsOutput];
+export var GreetingWithErrors: StaticOperationSchema = [9, n1, _GWE, 2, () => __Unit, () => GreetingWithErrorsOutput];
+export var NoInputOutput: StaticOperationSchema = [9, n1, _NIO, 0, () => __Unit, () => __Unit];
 export var OperationWithDefaults: StaticOperationSchema = [
   9,
   n1,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -352,7 +352,36 @@ public final class CodegenUtils {
         return symbolProvider.toSymbol(service).getName().replaceAll("(Client)$", "");
     }
 
+    /**
+     * The alternative should be used because the base exception may have been renamed
+     * due to a collision in the model.
+     *
+     * @deprecated use {@link #getSyntheticBaseExceptionName}.
+     */
+    @Deprecated
     public static String getServiceExceptionName(String serviceName) {
         return serviceName + "ServiceException";
+    }
+
+    /**
+     * If the service unfortunately defines a ServiceNameBaseException error,
+     * we still generate a synthetic base error for uniformity, but it must be renamed.
+     */
+    public static String getSyntheticBaseExceptionName(String serviceName, Model model) {
+        String serviceExceptionName = getServiceExceptionName(serviceName);
+        while (true) {
+            String finalServiceExceptionName = serviceExceptionName;
+            boolean namingCollision = model.getStructureShapes()
+                .stream()
+                .anyMatch(structureShape -> structureShape.getId().getName().equals(finalServiceExceptionName));
+
+            if (namingCollision) {
+                serviceExceptionName = serviceExceptionName
+                    .replaceAll("ServiceException$", "SyntheticServiceException");
+            } else {
+                break;
+            }
+        }
+        return serviceExceptionName;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -396,7 +396,7 @@ final class CommandGenerator implements Runnable {
         }
 
         String name = CodegenUtils.getServiceName(settings, model, symbolProvider);
-        buffer.append(String.format("@throws {@link %s}%n", CodegenUtils.getServiceExceptionName(name)));
+        buffer.append(String.format("@throws {@link %s}%n", CodegenUtils.getSyntheticBaseExceptionName(name, model)));
         buffer.append(String.format("<p>Base exception class for all service exceptions from %s service.</p>%n", name));
 
         return buffer.toString();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
@@ -59,7 +59,7 @@ public final class AddBaseServiceExceptionClass implements TypeScriptIntegration
         boolean isClientSdk = settings.generateClient();
         if (isClientSdk) {
             String serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
-            String serviceExceptionName = CodegenUtils.getServiceExceptionName(serviceName);
+            String serviceExceptionName = CodegenUtils.getSyntheticBaseExceptionName(serviceName, model);
             writerFactory.accept(
                     Paths.get(CodegenUtils.SOURCE_FOLDER, "models", serviceExceptionName + ".ts").toString(),
                     writer -> {
@@ -93,7 +93,7 @@ public final class AddBaseServiceExceptionClass implements TypeScriptIntegration
         boolean isClientSdk = settings.generateClient();
         if (isClientSdk) {
             String serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
-            String serviceExceptionName = CodegenUtils.getServiceExceptionName(serviceName);
+            String serviceExceptionName = CodegenUtils.getSyntheticBaseExceptionName(serviceName, model);
             writer.write("export { $1L } from \"./models/$1L\";", serviceExceptionName);
         }
     }
@@ -117,7 +117,7 @@ public final class AddBaseServiceExceptionClass implements TypeScriptIntegration
                 String baseExceptionAlias = "__BaseException";
                 SymbolReference reference;
                 if (settings.generateClient()) {
-                    String serviceExceptionName = CodegenUtils.getServiceExceptionName(serviceName);
+                    String serviceExceptionName = CodegenUtils.getSyntheticBaseExceptionName(serviceName, model);
                     String namespace = Paths.get(".", "src", "models", serviceExceptionName).toString();
                     Symbol serviceExceptionSymbol = Symbol.builder()
                             .name(serviceExceptionName)
@@ -140,5 +140,4 @@ public final class AddBaseServiceExceptionClass implements TypeScriptIntegration
             return symbol;
         };
     }
-
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -452,8 +452,11 @@ public final class HttpProtocolGeneratorUtils {
     public static SymbolReference getClientBaseException(GenerationContext context) {
         ServiceShape service = context.getService();
         SymbolProvider symbolProvider = context.getSymbolProvider();
-        String serviceExceptionName = symbolProvider.toSymbol(service).getName()
-                        .replaceAll("(Client)$", "ServiceException");
+        String serviceName = symbolProvider.toSymbol(service).getName()
+                        .replaceAll("(Client)$", "");
+        String serviceExceptionName = CodegenUtils.getSyntheticBaseExceptionName(
+            serviceName, context.getModel()
+        );
         String namespace = Paths.get(".", "src", "models", serviceExceptionName).toString();
         Symbol serviceExceptionSymbol = Symbol.builder()
                             .name(serviceExceptionName)

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerationAllowlist.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerationAllowlist.java
@@ -29,9 +29,10 @@ public abstract class SchemaGenerationAllowlist {
     }
 
     public static boolean allows(ShapeId serviceShapeId, TypeScriptSettings settings) {
+        boolean generateClient = settings.generateClient();
         boolean allowedByProtocol = PROTOCOLS.contains(settings.getProtocol());
         boolean allowedByName = ALLOWED.contains(serviceShapeId);
-        return settings.generateSchemas() && (allowedByProtocol || allowedByName);
+        return settings.generateSchemas() && generateClient && (allowedByProtocol || allowedByName);
     }
 
     @Deprecated

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
@@ -261,6 +261,9 @@ public class SchemaGenerator implements Runnable {
      * unqualified name.
      */
     private String getShapeVariableName(Shape shape) {
+        if (shape.getId().equals(ShapeId.from("smithy.api#Unit"))) {
+            return "__Unit";
+        }
         String symbolName = reservedWords.escape(shape.getId().getName());
         if (requiresNamingDeconfliction.contains(shape)) {
             symbolName += "_" + checkImportString(shape, shape.getId().getNamespace(), "n");
@@ -339,7 +342,10 @@ public class SchemaGenerator implements Runnable {
         TypeScriptWriter writer = getBaseWriter();
 
         String serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
-        String serviceExceptionName = CodegenUtils.getServiceExceptionName(serviceName);
+        String serviceExceptionName = CodegenUtils.getSyntheticBaseExceptionName(
+            serviceName, model
+        );
+
         String namespace = settings.getService(model).getId().getNamespace();
 
         String exceptionCtorSymbolName = "__" + serviceExceptionName;
@@ -554,7 +560,7 @@ public class SchemaGenerator implements Runnable {
             && shape.getId().getName().equals("Unit")) {
             // special signal value for operation input/output.
             writer.write("""
-                export var Unit = "unit" as const;
+                export var __Unit = "unit" as const;
                 """);
         } else if (!elision.isReferenceSchema(shape) && !elision.traits.hasSchemaTraits(shape)) {
             String sentinel = this.resolveSchema(model.expectShape(ShapeId.from("smithy.api#Unit")), shape);

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/main.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/main.smithy
@@ -23,6 +23,7 @@ operation GetNumbers {
         MysteryThrottlingError
         RetryableError
         HaltError
+        XYZServiceServiceException
     ]
 }
 
@@ -62,6 +63,9 @@ structure RetryableError {}
 
 @error("client")
 structure HaltError {}
+
+@error("client")
+structure XYZServiceServiceException {}
 
 operation TradeEventStream {
     input: TradeEventStreamRequest


### PR DESCRIPTION
*Issue #, if available:*
#1600 

*Description of changes:*

(prelaunch preparations)

Handle schema codegen edge cases where 

- there is an error structure with the same name as the synthetic base exception. In AWS models elastic-beanstalk has an `ElasticBeanstalkServiceException` error.

- there is a shape called "Unit" that is distinct from `smithy.api#Unit`, a special shape. There are actually several, but only `com.amazonaws.datazone#Unit` is realized, since it is the only `struct` shape of the gorup.