### PR TITLE
fix(core/cbor): omit undefined in shape deserialization

### DIFF
--- a/.changeset/old-moles-grab.md
+++ b/.changeset/old-moles-grab.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+omit undefined values in cbor deserialization

--- a/packages/core/src/submodules/cbor/CborCodec.spec.ts
+++ b/packages/core/src/submodules/cbor/CborCodec.spec.ts
@@ -70,4 +70,23 @@ describe(CborShapeSerializer.name, () => {
       }
     });
   });
+
+  describe("deserialization", () => {
+    it("should not create undefined values", async () => {
+      const struct = [3, "ns", "Struct", 0, ["sessionId", "tokenId"], [0, 0]] satisfies StaticStructureSchema;
+      const deserializer = codec.createDeserializer();
+
+      const data = cbor.serialize({
+        sessionId: "abcd",
+      });
+
+      const deserialized = deserializer.read(struct, data);
+
+      expect(deserialized).toEqual({
+        sessionId: "abcd",
+      });
+
+      expect("tokenId" in deserialized).toEqual(false);
+    });
+  });
 });

--- a/packages/core/src/submodules/cbor/CborCodec.ts
+++ b/packages/core/src/submodules/cbor/CborCodec.ts
@@ -193,7 +193,10 @@ export class CborShapeDeserializer extends SerdeContext implements ShapeDeserial
         }
       } else if (ns.isStructSchema()) {
         for (const [key, memberSchema] of ns.structIterator()) {
-          newObject[key] = this.readValue(memberSchema, value[key]);
+          const v = this.readValue(memberSchema, value[key]);
+          if (v != null) {
+            newObject[key] = v;
+          }
         }
       }
       return newObject;


### PR DESCRIPTION
*Issue #, if available:*
#1600

fix: omit undefined schema member values from deserialized objects

I noticed this while testing https://github.com/aws/aws-sdk-js-v3/pull/7484
