### PR TITLE
chore: separate interfaces and runtime symbols in the models directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ generate-protocol-tests:
 	npx prettier --write ./private/my-local-model
 	npx prettier --write ./private/my-local-model-schema
 	yarn
+	(cd ./private/smithy-rpcv2-cbor && npm run build)
+	(cd ./private/smithy-rpcv2-cbor-schema && npm run build)
+	(cd ./private/my-local-model && npm run build)
 
 test-protocols:
 	(cd ./private/smithy-rpcv2-cbor && npx vitest run --globals)

--- a/private/my-local-model-schema/src/index.ts
+++ b/private/my-local-model-schema/src/index.ts
@@ -11,6 +11,8 @@ export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
-export * from "./models";
+
+export * from "./models/errors";
+export type * from "./models/models_0";
 
 export { XYZServiceSyntheticServiceException } from "./models/XYZServiceSyntheticServiceException";

--- a/private/my-local-model-schema/src/models/errors.ts
+++ b/private/my-local-model-schema/src/models/errors.ts
@@ -1,0 +1,105 @@
+// smithy-typescript generated code
+import { XYZServiceSyntheticServiceException as __BaseException } from "./XYZServiceSyntheticServiceException";
+import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
+
+/**
+ * @public
+ */
+export class CodedThrottlingError extends __BaseException {
+  readonly name = "CodedThrottlingError" as const;
+  readonly $fault = "client" as const;
+  $retryable = {
+    throttling: true,
+  };
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<CodedThrottlingError, __BaseException>) {
+    super({
+      name: "CodedThrottlingError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, CodedThrottlingError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class HaltError extends __BaseException {
+  readonly name = "HaltError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<HaltError, __BaseException>) {
+    super({
+      name: "HaltError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, HaltError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class MysteryThrottlingError extends __BaseException {
+  readonly name = "MysteryThrottlingError" as const;
+  readonly $fault = "client" as const;
+  $retryable = {
+    throttling: true,
+  };
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<MysteryThrottlingError, __BaseException>) {
+    super({
+      name: "MysteryThrottlingError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, MysteryThrottlingError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class RetryableError extends __BaseException {
+  readonly name = "RetryableError" as const;
+  readonly $fault = "client" as const;
+  $retryable = {};
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<RetryableError, __BaseException>) {
+    super({
+      name: "RetryableError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, RetryableError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class XYZServiceServiceException extends __BaseException {
+  readonly name = "XYZServiceServiceException" as const;
+  readonly $fault = "client" as const;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<XYZServiceServiceException, __BaseException>) {
+    super({
+      name: "XYZServiceServiceException",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
+  }
+}

--- a/private/my-local-model-schema/src/models/index.ts
+++ b/private/my-local-model-schema/src/models/index.ts
@@ -1,2 +1,0 @@
-// smithy-typescript generated code
-export * from "./models_0";

--- a/private/my-local-model-schema/src/models/models_0.ts
+++ b/private/my-local-model-schema/src/models/models_0.ts
@@ -1,7 +1,5 @@
 // smithy-typescript generated code
-import { XYZServiceSyntheticServiceException as __BaseException } from "./XYZServiceSyntheticServiceException";
 import { NumericValue } from "@smithy/core/serde";
-import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
 
 /**
  * @public
@@ -9,28 +7,6 @@ import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-cli
 export interface Alpha {
   id?: string | undefined;
   timestamp?: Date | undefined;
-}
-
-/**
- * @public
- */
-export class CodedThrottlingError extends __BaseException {
-  readonly name: "CodedThrottlingError" = "CodedThrottlingError";
-  readonly $fault: "client" = "client";
-  $retryable = {
-    throttling: true,
-  };
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<CodedThrottlingError, __BaseException>) {
-    super({
-      name: "CodedThrottlingError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, CodedThrottlingError.prototype);
-  }
 }
 
 /**
@@ -62,86 +38,6 @@ export interface GetNumbersRequest {
 export interface GetNumbersResponse {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;
-}
-
-/**
- * @public
- */
-export class HaltError extends __BaseException {
-  readonly name: "HaltError" = "HaltError";
-  readonly $fault: "client" = "client";
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<HaltError, __BaseException>) {
-    super({
-      name: "HaltError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, HaltError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class MysteryThrottlingError extends __BaseException {
-  readonly name: "MysteryThrottlingError" = "MysteryThrottlingError";
-  readonly $fault: "client" = "client";
-  $retryable = {
-    throttling: true,
-  };
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<MysteryThrottlingError, __BaseException>) {
-    super({
-      name: "MysteryThrottlingError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, MysteryThrottlingError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class RetryableError extends __BaseException {
-  readonly name: "RetryableError" = "RetryableError";
-  readonly $fault: "client" = "client";
-  $retryable = {};
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<RetryableError, __BaseException>) {
-    super({
-      name: "RetryableError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, RetryableError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class XYZServiceServiceException extends __BaseException {
-  readonly name: "XYZServiceServiceException" = "XYZServiceServiceException";
-  readonly $fault: "client" = "client";
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<XYZServiceServiceException, __BaseException>) {
-    super({
-      name: "XYZServiceServiceException",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
-  }
 }
 
 /**

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -36,7 +36,7 @@ import {
   MysteryThrottlingError as __MysteryThrottlingError,
   RetryableError as __RetryableError,
   XYZServiceServiceException as __XYZServiceServiceException,
-} from "../models/index";
+} from "../models/errors";
 import { TypeRegistry } from "@smithy/core/schema";
 import { StaticErrorSchema, StaticOperationSchema, StaticStructureSchema } from "@smithy/types";
 

--- a/private/my-local-model/src/index.ts
+++ b/private/my-local-model/src/index.ts
@@ -11,6 +11,8 @@ export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
-export * from "./models";
+
+export * from "./models/errors";
+export type * from "./models/models_0";
 
 export { XYZServiceSyntheticServiceException } from "./models/XYZServiceSyntheticServiceException";

--- a/private/my-local-model/src/models/errors.ts
+++ b/private/my-local-model/src/models/errors.ts
@@ -1,0 +1,105 @@
+// smithy-typescript generated code
+import { XYZServiceSyntheticServiceException as __BaseException } from "./XYZServiceSyntheticServiceException";
+import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
+
+/**
+ * @public
+ */
+export class CodedThrottlingError extends __BaseException {
+  readonly name = "CodedThrottlingError" as const;
+  readonly $fault = "client" as const;
+  $retryable = {
+    throttling: true,
+  };
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<CodedThrottlingError, __BaseException>) {
+    super({
+      name: "CodedThrottlingError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, CodedThrottlingError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class HaltError extends __BaseException {
+  readonly name = "HaltError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<HaltError, __BaseException>) {
+    super({
+      name: "HaltError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, HaltError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class MysteryThrottlingError extends __BaseException {
+  readonly name = "MysteryThrottlingError" as const;
+  readonly $fault = "client" as const;
+  $retryable = {
+    throttling: true,
+  };
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<MysteryThrottlingError, __BaseException>) {
+    super({
+      name: "MysteryThrottlingError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, MysteryThrottlingError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class RetryableError extends __BaseException {
+  readonly name = "RetryableError" as const;
+  readonly $fault = "client" as const;
+  $retryable = {};
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<RetryableError, __BaseException>) {
+    super({
+      name: "RetryableError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, RetryableError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
+export class XYZServiceServiceException extends __BaseException {
+  readonly name = "XYZServiceServiceException" as const;
+  readonly $fault = "client" as const;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<XYZServiceServiceException, __BaseException>) {
+    super({
+      name: "XYZServiceServiceException",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
+  }
+}

--- a/private/my-local-model/src/models/index.ts
+++ b/private/my-local-model/src/models/index.ts
@@ -1,2 +1,0 @@
-// smithy-typescript generated code
-export * from "./models_0";

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -1,7 +1,5 @@
 // smithy-typescript generated code
-import { XYZServiceSyntheticServiceException as __BaseException } from "./XYZServiceSyntheticServiceException";
 import { NumericValue } from "@smithy/core/serde";
-import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
 
 /**
  * @public
@@ -9,28 +7,6 @@ import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-cli
 export interface Alpha {
   id?: string | undefined;
   timestamp?: Date | undefined;
-}
-
-/**
- * @public
- */
-export class CodedThrottlingError extends __BaseException {
-  readonly name: "CodedThrottlingError" = "CodedThrottlingError";
-  readonly $fault: "client" = "client";
-  $retryable = {
-    throttling: true,
-  };
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<CodedThrottlingError, __BaseException>) {
-    super({
-      name: "CodedThrottlingError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, CodedThrottlingError.prototype);
-  }
 }
 
 /**
@@ -62,86 +38,6 @@ export interface GetNumbersRequest {
 export interface GetNumbersResponse {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;
-}
-
-/**
- * @public
- */
-export class HaltError extends __BaseException {
-  readonly name: "HaltError" = "HaltError";
-  readonly $fault: "client" = "client";
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<HaltError, __BaseException>) {
-    super({
-      name: "HaltError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, HaltError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class MysteryThrottlingError extends __BaseException {
-  readonly name: "MysteryThrottlingError" = "MysteryThrottlingError";
-  readonly $fault: "client" = "client";
-  $retryable = {
-    throttling: true,
-  };
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<MysteryThrottlingError, __BaseException>) {
-    super({
-      name: "MysteryThrottlingError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, MysteryThrottlingError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class RetryableError extends __BaseException {
-  readonly name: "RetryableError" = "RetryableError";
-  readonly $fault: "client" = "client";
-  $retryable = {};
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<RetryableError, __BaseException>) {
-    super({
-      name: "RetryableError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, RetryableError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class XYZServiceServiceException extends __BaseException {
-  readonly name: "XYZServiceServiceException" = "XYZServiceServiceException";
-  readonly $fault: "client" = "client";
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<XYZServiceServiceException, __BaseException>) {
-    super({
-      name: "XYZServiceServiceException",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
-  }
 }
 
 /**

--- a/private/my-local-model/src/protocols/Rpcv2cbor.ts
+++ b/private/my-local-model/src/protocols/Rpcv2cbor.ts
@@ -3,17 +3,13 @@ import { GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/Get
 import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "../commands/TradeEventStreamCommand";
 import { XYZServiceSyntheticServiceException as __BaseException } from "../models/XYZServiceSyntheticServiceException";
 import {
-  Alpha,
   CodedThrottlingError,
-  GetNumbersRequest,
-  GetNumbersResponse,
   HaltError,
   MysteryThrottlingError,
   RetryableError,
-  TradeEvents,
-  Unit,
   XYZServiceServiceException,
-} from "../models/models_0";
+} from "../models/errors";
+import { Alpha, GetNumbersRequest, GetNumbersResponse, TradeEvents, Unit } from "../models/models_0";
 import {
   dateToTag as __dateToTag,
   buildHttpRpcRequest,

--- a/private/smithy-rpcv2-cbor-schema/src/index.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/index.ts
@@ -6,6 +6,9 @@ export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RpcV2ProtocolExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
-export * from "./models";
+
+export * from "./models/enums";
+export * from "./models/errors";
+export type * from "./models/models_0";
 
 export { RpcV2ProtocolServiceException } from "./models/RpcV2ProtocolServiceException";

--- a/private/smithy-rpcv2-cbor-schema/src/models/enums.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/enums.ts
@@ -1,0 +1,41 @@
+// smithy-typescript generated code
+/**
+ * @public
+ * @enum
+ */
+export const TestEnum = {
+  BAR: "BAR",
+  BAZ: "BAZ",
+  FOO: "FOO",
+} as const;
+/**
+ * @public
+ */
+export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
+
+export enum TestIntEnum {
+  ONE = 1,
+  TWO = 2,
+}
+
+/**
+ * @public
+ * @enum
+ */
+export const FooEnum = {
+  BAR: "Bar",
+  BAZ: "Baz",
+  FOO: "Foo",
+  ONE: "1",
+  ZERO: "0",
+} as const;
+/**
+ * @public
+ */
+export type FooEnum = (typeof FooEnum)[keyof typeof FooEnum];
+
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}

--- a/private/smithy-rpcv2-cbor-schema/src/models/errors.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/errors.ts
@@ -1,0 +1,80 @@
+// smithy-typescript generated code
+import { RpcV2ProtocolServiceException as __BaseException } from "./RpcV2ProtocolServiceException";
+import { ComplexNestedErrorData, ValidationExceptionField } from "./models_0";
+import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
+
+/**
+ * A standard error for input validation failures.
+ * This should be thrown by services when a member of the input structure
+ * falls outside of the modeled or documented constraints.
+ * @public
+ */
+export class ValidationException extends __BaseException {
+  readonly name = "ValidationException" as const;
+  readonly $fault = "client" as const;
+  /**
+   * A list of specific failures encountered while validating the input.
+   * A member can appear in this list more than once if it failed to satisfy multiple constraints.
+   * @public
+   */
+  fieldList?: ValidationExceptionField[] | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<ValidationException, __BaseException>) {
+    super({
+      name: "ValidationException",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, ValidationException.prototype);
+    this.fieldList = opts.fieldList;
+  }
+}
+
+/**
+ * This error is thrown when a request is invalid.
+ * @public
+ */
+export class ComplexError extends __BaseException {
+  readonly name = "ComplexError" as const;
+  readonly $fault = "client" as const;
+  TopLevel?: string | undefined;
+  Nested?: ComplexNestedErrorData | undefined;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<ComplexError, __BaseException>) {
+    super({
+      name: "ComplexError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, ComplexError.prototype);
+    this.TopLevel = opts.TopLevel;
+    this.Nested = opts.Nested;
+  }
+}
+
+/**
+ * This error is thrown when an invalid greeting value is provided.
+ * @public
+ */
+export class InvalidGreeting extends __BaseException {
+  readonly name = "InvalidGreeting" as const;
+  readonly $fault = "client" as const;
+  Message?: string | undefined;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<InvalidGreeting, __BaseException>) {
+    super({
+      name: "InvalidGreeting",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, InvalidGreeting.prototype);
+    this.Message = opts.Message;
+  }
+}

--- a/private/smithy-rpcv2-cbor-schema/src/models/index.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/index.ts
@@ -1,2 +1,0 @@
-// smithy-typescript generated code
-export * from "./models_0";

--- a/private/smithy-rpcv2-cbor-schema/src/models/models_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolServiceException as __BaseException } from "./RpcV2ProtocolServiceException";
-import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
+import { FooEnum, IntegerEnum, TestEnum, TestIntEnum } from "./enums";
 
 /**
  * Describes one specific validation failure for an input member.
@@ -21,36 +20,6 @@ export interface ValidationExceptionField {
 }
 
 /**
- * A standard error for input validation failures.
- * This should be thrown by services when a member of the input structure
- * falls outside of the modeled or documented constraints.
- * @public
- */
-export class ValidationException extends __BaseException {
-  readonly name: "ValidationException" = "ValidationException";
-  readonly $fault: "client" = "client";
-  /**
-   * A list of specific failures encountered while validating the input.
-   * A member can appear in this list more than once if it failed to satisfy multiple constraints.
-   * @public
-   */
-  fieldList?: ValidationExceptionField[] | undefined;
-
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<ValidationException, __BaseException>) {
-    super({
-      name: "ValidationException",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, ValidationException.prototype);
-    this.fieldList = opts.fieldList;
-  }
-}
-
-/**
  * @public
  */
 export interface ClientOptionalDefaults {
@@ -62,49 +31,6 @@ export interface ClientOptionalDefaults {
  */
 export interface ComplexNestedErrorData {
   Foo?: string | undefined;
-}
-
-/**
- * This error is thrown when a request is invalid.
- * @public
- */
-export class ComplexError extends __BaseException {
-  readonly name: "ComplexError" = "ComplexError";
-  readonly $fault: "client" = "client";
-  TopLevel?: string | undefined;
-  Nested?: ComplexNestedErrorData | undefined;
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<ComplexError, __BaseException>) {
-    super({
-      name: "ComplexError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, ComplexError.prototype);
-    this.TopLevel = opts.TopLevel;
-    this.Nested = opts.Nested;
-  }
-}
-
-/**
- * @public
- * @enum
- */
-export const TestEnum = {
-  BAR: "BAR",
-  BAZ: "BAZ",
-  FOO: "FOO",
-} as const;
-/**
- * @public
- */
-export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
-
-export enum TestIntEnum {
-  ONE = 1,
-  TWO = 2,
 }
 
 /**
@@ -170,28 +96,6 @@ export interface GreetingWithErrorsOutput {
 }
 
 /**
- * This error is thrown when an invalid greeting value is provided.
- * @public
- */
-export class InvalidGreeting extends __BaseException {
-  readonly name: "InvalidGreeting" = "InvalidGreeting";
-  readonly $fault: "client" = "client";
-  Message?: string | undefined;
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<InvalidGreeting, __BaseException>) {
-    super({
-      name: "InvalidGreeting",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, InvalidGreeting.prototype);
-    this.Message = opts.Message;
-  }
-}
-
-/**
  * @public
  */
 export interface OperationWithDefaultsInput {
@@ -246,28 +150,6 @@ export interface RpcV2CborDenseMapsInputOutput {
   denseBooleanMap?: Record<string, boolean> | undefined;
   denseStringMap?: Record<string, string> | undefined;
   denseSetMap?: Record<string, string[]> | undefined;
-}
-
-/**
- * @public
- * @enum
- */
-export const FooEnum = {
-  BAR: "Bar",
-  BAZ: "Baz",
-  FOO: "Foo",
-  ONE: "1",
-  ZERO: "0",
-} as const;
-/**
- * @public
- */
-export type FooEnum = (typeof FooEnum)[keyof typeof FooEnum];
-
-export enum IntegerEnum {
-  A = 1,
-  B = 2,
-  C = 3,
 }
 
 /**

--- a/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
@@ -136,7 +136,7 @@ import {
   ComplexError as __ComplexError,
   InvalidGreeting as __InvalidGreeting,
   ValidationException as __ValidationException,
-} from "../models/index";
+} from "../models/errors";
 import { TypeRegistry } from "@smithy/core/schema";
 import {
   StaticErrorSchema,

--- a/private/smithy-rpcv2-cbor/src/index.ts
+++ b/private/smithy-rpcv2-cbor/src/index.ts
@@ -6,6 +6,9 @@ export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RpcV2ProtocolExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
-export * from "./models";
+
+export * from "./models/enums";
+export * from "./models/errors";
+export type * from "./models/models_0";
 
 export { RpcV2ProtocolServiceException } from "./models/RpcV2ProtocolServiceException";

--- a/private/smithy-rpcv2-cbor/src/models/enums.ts
+++ b/private/smithy-rpcv2-cbor/src/models/enums.ts
@@ -1,0 +1,41 @@
+// smithy-typescript generated code
+/**
+ * @public
+ * @enum
+ */
+export const TestEnum = {
+  BAR: "BAR",
+  BAZ: "BAZ",
+  FOO: "FOO",
+} as const;
+/**
+ * @public
+ */
+export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
+
+export enum TestIntEnum {
+  ONE = 1,
+  TWO = 2,
+}
+
+/**
+ * @public
+ * @enum
+ */
+export const FooEnum = {
+  BAR: "Bar",
+  BAZ: "Baz",
+  FOO: "Foo",
+  ONE: "1",
+  ZERO: "0",
+} as const;
+/**
+ * @public
+ */
+export type FooEnum = (typeof FooEnum)[keyof typeof FooEnum];
+
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}

--- a/private/smithy-rpcv2-cbor/src/models/errors.ts
+++ b/private/smithy-rpcv2-cbor/src/models/errors.ts
@@ -1,0 +1,80 @@
+// smithy-typescript generated code
+import { RpcV2ProtocolServiceException as __BaseException } from "./RpcV2ProtocolServiceException";
+import { ComplexNestedErrorData, ValidationExceptionField } from "./models_0";
+import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
+
+/**
+ * A standard error for input validation failures.
+ * This should be thrown by services when a member of the input structure
+ * falls outside of the modeled or documented constraints.
+ * @public
+ */
+export class ValidationException extends __BaseException {
+  readonly name = "ValidationException" as const;
+  readonly $fault = "client" as const;
+  /**
+   * A list of specific failures encountered while validating the input.
+   * A member can appear in this list more than once if it failed to satisfy multiple constraints.
+   * @public
+   */
+  fieldList?: ValidationExceptionField[] | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<ValidationException, __BaseException>) {
+    super({
+      name: "ValidationException",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, ValidationException.prototype);
+    this.fieldList = opts.fieldList;
+  }
+}
+
+/**
+ * This error is thrown when a request is invalid.
+ * @public
+ */
+export class ComplexError extends __BaseException {
+  readonly name = "ComplexError" as const;
+  readonly $fault = "client" as const;
+  TopLevel?: string | undefined;
+  Nested?: ComplexNestedErrorData | undefined;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<ComplexError, __BaseException>) {
+    super({
+      name: "ComplexError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, ComplexError.prototype);
+    this.TopLevel = opts.TopLevel;
+    this.Nested = opts.Nested;
+  }
+}
+
+/**
+ * This error is thrown when an invalid greeting value is provided.
+ * @public
+ */
+export class InvalidGreeting extends __BaseException {
+  readonly name = "InvalidGreeting" as const;
+  readonly $fault = "client" as const;
+  Message?: string | undefined;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<InvalidGreeting, __BaseException>) {
+    super({
+      name: "InvalidGreeting",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, InvalidGreeting.prototype);
+    this.Message = opts.Message;
+  }
+}

--- a/private/smithy-rpcv2-cbor/src/models/index.ts
+++ b/private/smithy-rpcv2-cbor/src/models/index.ts
@@ -1,2 +1,0 @@
-// smithy-typescript generated code
-export * from "./models_0";

--- a/private/smithy-rpcv2-cbor/src/models/models_0.ts
+++ b/private/smithy-rpcv2-cbor/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolServiceException as __BaseException } from "./RpcV2ProtocolServiceException";
-import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
+import { FooEnum, IntegerEnum, TestEnum, TestIntEnum } from "./enums";
 
 /**
  * Describes one specific validation failure for an input member.
@@ -21,36 +20,6 @@ export interface ValidationExceptionField {
 }
 
 /**
- * A standard error for input validation failures.
- * This should be thrown by services when a member of the input structure
- * falls outside of the modeled or documented constraints.
- * @public
- */
-export class ValidationException extends __BaseException {
-  readonly name: "ValidationException" = "ValidationException";
-  readonly $fault: "client" = "client";
-  /**
-   * A list of specific failures encountered while validating the input.
-   * A member can appear in this list more than once if it failed to satisfy multiple constraints.
-   * @public
-   */
-  fieldList?: ValidationExceptionField[] | undefined;
-
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<ValidationException, __BaseException>) {
-    super({
-      name: "ValidationException",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, ValidationException.prototype);
-    this.fieldList = opts.fieldList;
-  }
-}
-
-/**
  * @public
  */
 export interface ClientOptionalDefaults {
@@ -62,49 +31,6 @@ export interface ClientOptionalDefaults {
  */
 export interface ComplexNestedErrorData {
   Foo?: string | undefined;
-}
-
-/**
- * This error is thrown when a request is invalid.
- * @public
- */
-export class ComplexError extends __BaseException {
-  readonly name: "ComplexError" = "ComplexError";
-  readonly $fault: "client" = "client";
-  TopLevel?: string | undefined;
-  Nested?: ComplexNestedErrorData | undefined;
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<ComplexError, __BaseException>) {
-    super({
-      name: "ComplexError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, ComplexError.prototype);
-    this.TopLevel = opts.TopLevel;
-    this.Nested = opts.Nested;
-  }
-}
-
-/**
- * @public
- * @enum
- */
-export const TestEnum = {
-  BAR: "BAR",
-  BAZ: "BAZ",
-  FOO: "FOO",
-} as const;
-/**
- * @public
- */
-export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
-
-export enum TestIntEnum {
-  ONE = 1,
-  TWO = 2,
 }
 
 /**
@@ -170,28 +96,6 @@ export interface GreetingWithErrorsOutput {
 }
 
 /**
- * This error is thrown when an invalid greeting value is provided.
- * @public
- */
-export class InvalidGreeting extends __BaseException {
-  readonly name: "InvalidGreeting" = "InvalidGreeting";
-  readonly $fault: "client" = "client";
-  Message?: string | undefined;
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<InvalidGreeting, __BaseException>) {
-    super({
-      name: "InvalidGreeting",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, InvalidGreeting.prototype);
-    this.Message = opts.Message;
-  }
-}
-
-/**
  * @public
  */
 export interface OperationWithDefaultsInput {
@@ -246,28 +150,6 @@ export interface RpcV2CborDenseMapsInputOutput {
   denseBooleanMap?: Record<string, boolean> | undefined;
   denseStringMap?: Record<string, string> | undefined;
   denseSetMap?: Record<string, string[]> | undefined;
-}
-
-/**
- * @public
- * @enum
- */
-export const FooEnum = {
-  BAR: "Bar",
-  BAZ: "Baz",
-  FOO: "Foo",
-  ONE: "1",
-  ZERO: "0",
-} as const;
-/**
- * @public
- */
-export type FooEnum = (typeof FooEnum)[keyof typeof FooEnum];
-
-export enum IntegerEnum {
-  A = 1,
-  B = 2,
-  C = 3,
 }
 
 /**

--- a/private/smithy-rpcv2-cbor/src/protocols/Rpcv2cbor.ts
+++ b/private/smithy-rpcv2-cbor/src/protocols/Rpcv2cbor.ts
@@ -28,17 +28,15 @@ import {
   SparseNullsOperationCommandOutput,
 } from "../commands/SparseNullsOperationCommand";
 import { RpcV2ProtocolServiceException as __BaseException } from "../models/RpcV2ProtocolServiceException";
+import { FooEnum, IntegerEnum } from "../models/enums";
+import { ComplexError, InvalidGreeting, ValidationException } from "../models/errors";
 import {
   ClientOptionalDefaults,
-  ComplexError,
   Defaults,
   EmptyStructure,
   Float16Output,
-  FooEnum,
   FractionalSecondsOutput,
   GreetingStruct,
-  IntegerEnum,
-  InvalidGreeting,
   OperationWithDefaultsInput,
   OperationWithDefaultsOutput,
   RecursiveShapesInputOutput,
@@ -51,7 +49,6 @@ import {
   SimpleStructure,
   SparseNullsOperationInputOutput,
   StructureListMember,
-  ValidationException,
 } from "../models/models_0";
 import {
   dateToTag as __dateToTag,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -449,8 +449,10 @@ final class DirectedTypeScriptCodegen
             directive.fileManifest().writeFile(from, getClass(), to);
         });
 
-        SymbolVisitor.writeModelIndex(directive.connectedShapes().values(), directive.symbolProvider(),
-                directive.fileManifest());
+        TypeScriptWriter modelIndexer = SymbolVisitor.modelIndexer(
+            directive.connectedShapes().values(),
+            directive.symbolProvider()
+        );
 
         // Generate the client Node and Browser configuration files. These
         // files are switched between in package.json based on the targeted
@@ -497,17 +499,19 @@ final class DirectedTypeScriptCodegen
                 directive.model(),
                 directive.symbolProvider(),
                 directive.context().protocolGenerator(),
-                writer
+                writer,
+                modelIndexer
             );
         });
 
         if (directive.settings().generateServerSdk()) {
             // Generate index for server
             IndexGenerator.writeServerIndex(
-                    directive.settings(),
-                    directive.model(),
-                    directive.symbolProvider(),
-                    directive.fileManifest());
+                directive.settings(),
+                directive.model(),
+                directive.symbolProvider(),
+                directive.fileManifest()
+            );
         }
 
         // Generate protocol tests IFF found in the model.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -45,7 +45,8 @@ final class IndexGenerator {
         Model model,
         SymbolProvider symbolProvider,
         ProtocolGenerator protocolGenerator,
-        TypeScriptWriter writer
+        TypeScriptWriter writer,
+        TypeScriptWriter modelIndexer
     ) {
 
         writer.write("/* eslint-disable */");
@@ -63,7 +64,10 @@ final class IndexGenerator {
         }
 
         // write export statement for models
-        writer.write("export * from \"./models\";");
+        writer.write(
+            // the header comment is already present in the upper writer.
+            modelIndexer.toString().replace("// smithy-typescript generated code", "")
+        );
     }
 
     private static void writeProtocolExports(ProtocolGenerator protocolGenerator, TypeScriptWriter writer) {
@@ -72,10 +76,10 @@ final class IndexGenerator {
     }
 
     static void writeServerIndex(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            FileManifest fileManifest
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        FileManifest fileManifest
     ) {
         TypeScriptWriter writer = new TypeScriptWriter("");
         ServiceShape service = settings.getService(model);
@@ -91,10 +95,10 @@ final class IndexGenerator {
     }
 
     private static void writeClientExports(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         ServiceShape service = settings.getService(model);
         Symbol symbol = symbolProvider.toSymbol(service);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -279,8 +279,8 @@ final class StructureGenerator implements Runnable {
         writer.writeShapeDocs(shape);
         boolean isServerSdk = this.includeValidation;
         writer.openBlock("export class $T extends $L {", symbol, "__BaseException");
-        writer.write("readonly name: $1S = $1S;", shape.getId().getName());
-        writer.write("readonly $$fault: $1S = $1S;", errorTrait.getValue());
+        writer.write("readonly name = $1S as const;", shape.getId().getName());
+        writer.write("readonly $$fault = $1S as const;", errorTrait.getValue());
         if (!isServerSdk) {
             HttpProtocolGeneratorUtils.writeRetryableTrait(writer, shape, ";");
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaGenerator.java
@@ -299,7 +299,7 @@ public class SchemaGenerator implements Runnable {
                 writer.addRelativeImport(
                     symbolName,
                     exceptionCtorSymbolName,
-                    Paths.get("..", "models", "index")
+                    Paths.get("..", "models", "errors")
                 );
                 writer.openBlock("""
                 export var $L: StaticErrorSchema = [-3, $L, $L,""",

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
@@ -21,12 +21,11 @@ public class IndexGeneratorTest {
         SymbolProvider symbolProvider = new SymbolVisitor(model, settings);
         TypeScriptWriter writer = new TypeScriptWriter("");
 
-        IndexGenerator.writeIndex(settings, model, symbolProvider, null, writer);
+        IndexGenerator.writeIndex(settings, model, symbolProvider, null, writer, writer);
 
         String contents = writer.toString();
         assertThat(contents, containsString("export * from \"./Example\";"));
         assertThat(contents, containsString("export * from \"./ExampleClient\";"));
         assertThat(contents, containsString("export * from \"./commands\";"));
-        assertThat(contents, containsString("export * from \"./models\";"));
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -19,8 +19,8 @@ public class StructureGeneratorTest {
     public void properlyGeneratesEmptyMessageMemberOfException() {
         testErrorStructureCodegen("error-test-empty.smithy",
                 "export class Err extends __BaseException {\n"
-                        + "  readonly name: \"Err\" = \"Err\";\n"
-                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  readonly name = \"Err\" as const;\n"
+                        + "  readonly $fault = \"client\" as const;\n"
                         + "  /**\n"
                         + "   * @internal\n"
                         + "   */\n"
@@ -39,8 +39,8 @@ public class StructureGeneratorTest {
     public void properlyGeneratesOptionalMessageMemberOfException() {
         testErrorStructureCodegen("error-test-optional-message.smithy",
                 "export class Err extends __BaseException {\n"
-                        + "  readonly name: \"Err\" = \"Err\";\n"
-                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  readonly name = \"Err\" as const;\n"
+                        + "  readonly $fault = \"client\" as const;\n"
                         + "  /**\n"
                         + "   * @internal\n"
                         + "   */\n"
@@ -59,8 +59,8 @@ public class StructureGeneratorTest {
     public void properlyGeneratesRequiredMessageMemberOfException() {
         testErrorStructureCodegen("error-test-required-message.smithy",
                 "export class Err extends __BaseException {\n"
-                        + "  readonly name: \"Err\" = \"Err\";\n"
-                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  readonly name = \"Err\" as const;\n"
+                        + "  readonly $fault = \"client\" as const;\n"
                         + "  /**\n"
                         + "   * @internal\n"
                         + "   */\n"
@@ -79,8 +79,8 @@ public class StructureGeneratorTest {
     public void properlyGeneratesOptionalNonMessageMemberOfException() {
         testErrorStructureCodegen("error-test-optional-member-no-message.smithy",
                 "export class Err extends __BaseException {\n"
-                        + "  readonly name: \"Err\" = \"Err\";\n"
-                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  readonly name = \"Err\" as const;\n"
+                        + "  readonly $fault = \"client\" as const;\n"
                         + "  foo?: string | undefined;\n"
                         + "  /**\n"
                         + "   * @internal\n"
@@ -101,8 +101,8 @@ public class StructureGeneratorTest {
     public void properlyGeneratesRequiredNonMessageMemberOfException() {
         testErrorStructureCodegen("error-test-required-member-no-message.smithy",
                 "export class Err extends __BaseException {\n"
-                        + "  readonly name: \"Err\" = \"Err\";\n"
-                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  readonly name = \"Err\" as const;\n"
+                        + "  readonly $fault = \"client\" as const;\n"
                         + "  foo: string | undefined;\n"
                         + "  /**\n"
                         + "   * @internal\n"
@@ -123,8 +123,8 @@ public class StructureGeneratorTest {
     public void generatesEmptyRetryableTrait() {
         testErrorStructureCodegen("error-test-retryable.smithy",
                 "export class Err extends __BaseException {\n"
-                        + "  readonly name: \"Err\" = \"Err\";\n"
-                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  readonly name = \"Err\" as const;\n"
+                        + "  readonly $fault = \"client\" as const;\n"
                         + "  $retryable = {\n"
                         + "  };\n"
                         + "  /**\n"
@@ -145,8 +145,8 @@ public class StructureGeneratorTest {
     public void generatesRetryableTraitWithThrottling() {
         testErrorStructureCodegen("error-test-retryable-throttling.smithy",
                 "export class Err extends __BaseException {\n"
-                        + "  readonly name: \"Err\" = \"Err\";\n"
-                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  readonly name = \"Err\" as const;\n"
+                        + "  readonly $fault = \"client\" as const;\n"
                         + "  $retryable = {\n"
                         + "    throttling: true,\n"
                         + "  };\n"
@@ -203,7 +203,10 @@ public class StructureGeneratorTest {
                 .build();
 
         new TypeScriptCodegenPlugin().execute(context);
-        String contents = manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "//models/models_0.ts").get();
+        String contents = "";
+        contents += manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "//models/models_0.ts").orElse("");
+        contents += manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "//models/enums.ts").orElse("");
+        contents += manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "//models/errors.ts").orElse("");
 
         if (assertContains) {
             assertThat(contents, containsString(testString));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -1,12 +1,10 @@
 package software.amazon.smithy.typescript.codegen;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -61,8 +59,7 @@ public class SymbolProviderTest {
         SymbolProvider provider = new SymbolVisitor(model, settings);
         Symbol symbol1 = provider.toSymbol(shape1);
         Symbol symbol2 = provider.toSymbol(shape2);
-        MockManifest manifest = new MockManifest();
-        SymbolVisitor.writeModelIndex(Arrays.asList(shape1, shape2), provider, manifest);
+        SymbolVisitor.modelIndexer(Arrays.asList(shape1, shape2), provider);
 
         assertThat(symbol1.getName(), equalTo("Hello"));
         assertThat(symbol1.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0"));
@@ -73,8 +70,6 @@ public class SymbolProviderTest {
         assertThat(symbol2.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0"));
         assertThat(symbol2.getNamespaceDelimiter(), equalTo("/"));
         assertThat(symbol2.getDefinitionFile(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0.ts"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/models/index.ts").get(),
-                containsString("export * from \"./models_0\";"));
     }
 
     @Test
@@ -266,14 +261,11 @@ public class SymbolProviderTest {
         SymbolProvider provider = new SymbolVisitor(model, settings, 1);
         Symbol symbol1 = provider.toSymbol(shape1);
         Symbol symbol2 = provider.toSymbol(shape2);
-        MockManifest manifest = new MockManifest();
-        SymbolVisitor.writeModelIndex(Arrays.asList(shape1, shape2), provider, manifest);
+        SymbolVisitor.modelIndexer(Arrays.asList(shape1, shape2), provider);
 
         assertThat(symbol1.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0"));
         assertThat(symbol1.getDefinitionFile(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0.ts"));
         assertThat(symbol2.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0"));
         assertThat(symbol2.getDefinitionFile(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0.ts"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/models/index.ts").get(),
-                containsString("export * from \"./models_0\";"));
     }
 }


### PR DESCRIPTION
This PR splits the contents of the generated client models directory.

Formerly/currently, the models directory has:
- an index, re-exporting everything
- models_0 to models_N files containing a mix of enums, interfaces, error classes, and sensitive log filters (removed since schema-serde)
- a base exception (synthetic)

The PR changes this to:
- no more index, instead the symbols are exported by the package index directly
- models_N now only contain types (interfaces)
- enums and errors have been moved to separate files

