### PR TITLE
fix(core/protocols): generate missing idempotency token in query parameters

### DIFF
--- a/.changeset/fair-taxis-hug.md
+++ b/.changeset/fair-taxis-hug.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+generate idempotency token in ToStringShapeSerializer

--- a/packages/core/src/submodules/protocols/serde/ToStringShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/serde/ToStringShapeSerializer.spec.ts
@@ -1,0 +1,43 @@
+import { NormalizedSchema } from "@smithy/core/schema";
+import type { StaticStructureSchema, TimestampEpochSecondsSchema } from "@smithy/types";
+import { describe, expect, it } from "vitest";
+
+import { ToStringShapeSerializer } from "./ToStringShapeSerializer";
+
+describe(ToStringShapeSerializer.name, () => {
+  it("should serialize idempotency tokens automatically", () => {
+    const structureWithIdempotencyToken = [
+      3,
+      "ns",
+      "Struct",
+      0,
+      ["name", "token"],
+      [
+        0,
+        [
+          0,
+          {
+            idempotencyToken: 1,
+            httpQuery: "token",
+          },
+        ],
+      ],
+    ] satisfies StaticStructureSchema;
+
+    const serializer = new ToStringShapeSerializer({
+      httpBindings: true,
+      timestampFormat: {
+        default: 7 satisfies TimestampEpochSecondsSchema,
+        useTrait: true,
+      },
+    });
+
+    const ns = NormalizedSchema.of(structureWithIdempotencyToken);
+
+    serializer.write(ns.getMemberSchema("token"), undefined);
+    {
+      const serialization = serializer.flush();
+      expect(serialization).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    }
+  });
+});

--- a/packages/core/src/submodules/protocols/serde/ToStringShapeSerializer.ts
+++ b/packages/core/src/submodules/protocols/serde/ToStringShapeSerializer.ts
@@ -1,5 +1,5 @@
 import { NormalizedSchema } from "@smithy/core/schema";
-import { dateToUtcString, LazyJsonString, quoteHeader } from "@smithy/core/serde";
+import { dateToUtcString, generateIdempotencyToken, LazyJsonString, quoteHeader } from "@smithy/core/serde";
 import type {
   CodecSettings,
   Schema,
@@ -94,7 +94,11 @@ export class ToStringShapeSerializer extends SerdeContext implements ShapeSerial
         this.stringBuffer = value;
         break;
       default:
-        this.stringBuffer = String(value);
+        if (ns.isIdempotencyToken()) {
+          this.stringBuffer = generateIdempotencyToken();
+        } else {
+          this.stringBuffer = String(value);
+        }
     }
   }
 


### PR DESCRIPTION
fix for https://github.com/aws/aws-sdk-js-v3/issues/7493 missing idempotency token