### PR TITLE
fix(core/protocols): allow HttpBindingProtocol to generate idempotency tokens

### DIFF
--- a/.changeset/tender-ducks-act.md
+++ b/.changeset/tender-ducks-act.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+idempotency token generation for HttpBindingProtocol

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
@@ -78,7 +78,7 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
       const memberTraits = memberNs.getMergedTraits() ?? {};
       const inputMemberValue = input[memberName];
 
-      if (inputMemberValue == null) {
+      if (inputMemberValue == null && !memberNs.isIdempotencyToken()) {
         continue;
       }
 


### PR DESCRIPTION
pairs with https://github.com/smithy-lang/smithy-typescript/pull/1773

additional fix for https://github.com/aws/aws-sdk-js-v3/issues/7493