### PR TITLE
fix(core/schema): set explicit enumerability on error.$response

### DIFF
--- a/.changeset/fifty-oranges-kneel.md
+++ b/.changeset/fifty-oranges-kneel.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+set explicit enumerability on error.$response

--- a/.changeset/fuzzy-goats-hope.md
+++ b/.changeset/fuzzy-goats-hope.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-serde": patch
+---
+
+explicit non-enumerability for error.$response

--- a/packages/core/src/submodules/cbor/SmithyRpcV2CborProtocol.ts
+++ b/packages/core/src/submodules/cbor/SmithyRpcV2CborProtocol.ts
@@ -99,7 +99,6 @@ export class SmithyRpcV2CborProtocol extends RpcProtocol {
 
     const errorMetadata = {
       $metadata: metadata,
-      $response: response,
       $fault: response.statusCode <= 500 ? ("client" as const) : ("server" as const),
     };
 

--- a/packages/core/src/submodules/schema/middleware/schemaDeserializationMiddleware.ts
+++ b/packages/core/src/submodules/schema/middleware/schemaDeserializationMiddleware.ts
@@ -41,6 +41,11 @@ export const schemaDeserializationMiddleware =
       // For security reasons, the error response is not completely visible by default.
       Object.defineProperty(error, "$response", {
         value: response,
+        // we need to define these properties explicitly because
+        // the service exception class may have set the value to undefined, but populated the key.
+        enumerable: false,
+        writable: false,
+        configurable: false,
       });
 
       if (!("$metadata" in error)) {

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -40,6 +40,11 @@ export const deserializerMiddleware =
       // For security reasons, the error response is not completely visible by default.
       Object.defineProperty(error, "$response", {
         value: response,
+        // we need to define these properties explicitly because
+        // the service exception class may have set the value to undefined, but populated the key.
+        enumerable: false,
+        writable: false,
+        configurable: false,
       });
 
       if (!("$metadata" in error)) {


### PR DESCRIPTION
I noticed that if you define a property as undefined and then call Object.defineProperty on it with only a value, it no longer default to non-enumerable.

The ServiceException (base class) from `@smithy/client` has:

```ts
export class ServiceException extends Error implements SmithyException, MetadataBearer {
  readonly $fault: "client" | "server";
  $response?: HttpResponse;
```

which creates a class instance level key that is undefined.