### PR TITLE
chore: remove formatting on local codegen sample outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ generate-protocol-tests:
 	cp -r ./smithy-typescript-protocol-test-codegen/build/smithyprojections/smithy-typescript-protocol-test-codegen/my-local-model/typescript-client-codegen/ ./private/my-local-model
 	cp -r ./smithy-typescript-protocol-test-codegen/build/smithyprojections/smithy-typescript-protocol-test-codegen/my-local-model-schema/typescript-client-codegen/ ./private/my-local-model-schema
 	node ./scripts/post-protocol-test-codegen
-	npx prettier --write ./private/smithy-rpcv2-cbor
-	npx prettier --write ./private/smithy-rpcv2-cbor-schema
-	npx prettier --write ./private/my-local-model
-	npx prettier --write ./private/my-local-model-schema
+	#	npx prettier --write ./private/smithy-rpcv2-cbor
+	#	npx prettier --write ./private/smithy-rpcv2-cbor-schema
+	#	npx prettier --write ./private/my-local-model
+	#	npx prettier --write ./private/my-local-model-schema
 	yarn
 	yarn turbo run build -F="./private/*" --only
 

--- a/private/my-local-model-schema/src/XYZService.ts
+++ b/private/my-local-model-schema/src/XYZService.ts
@@ -1,6 +1,13 @@
 // smithy-typescript generated code
-import { XYZServiceClient, XYZServiceClientConfig } from "./XYZServiceClient";
-import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
+import {
+  XYZServiceClient,
+  XYZServiceClientConfig,
+} from "./XYZServiceClient";
+import {
+  GetNumbersCommand,
+  GetNumbersCommandInput,
+  GetNumbersCommandOutput,
+} from "./commands/GetNumbersCommand";
 import {
   TradeEventStreamCommand,
   TradeEventStreamCommandInput,
@@ -12,15 +19,21 @@ import { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
 const commands = {
   GetNumbersCommand,
   TradeEventStreamCommand,
-};
+}
 
 export interface XYZService {
   /**
    * @see {@link GetNumbersCommand}
    */
   getNumbers(): Promise<GetNumbersCommandOutput>;
-  getNumbers(args: GetNumbersCommandInput, options?: __HttpHandlerOptions): Promise<GetNumbersCommandOutput>;
-  getNumbers(args: GetNumbersCommandInput, cb: (err: any, data?: GetNumbersCommandOutput) => void): void;
+  getNumbers(
+    args: GetNumbersCommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<GetNumbersCommandOutput>;
+  getNumbers(
+    args: GetNumbersCommandInput,
+    cb: (err: any, data?: GetNumbersCommandOutput) => void
+  ): void;
   getNumbers(
     args: GetNumbersCommandInput,
     options: __HttpHandlerOptions,
@@ -33,7 +46,7 @@ export interface XYZService {
   tradeEventStream(): Promise<TradeEventStreamCommandOutput>;
   tradeEventStream(
     args: TradeEventStreamCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<TradeEventStreamCommandOutput>;
   tradeEventStream(
     args: TradeEventStreamCommandInput,
@@ -44,6 +57,7 @@ export interface XYZService {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: TradeEventStreamCommandOutput) => void
   ): void;
+
 }
 
 /**

--- a/private/my-local-model-schema/src/XYZServiceClient.ts
+++ b/private/my-local-model-schema/src/XYZServiceClient.ts
@@ -5,8 +5,14 @@ import {
   defaultXYZServiceHttpAuthSchemeParametersProvider,
   resolveHttpAuthSchemeConfig,
 } from "./auth/httpAuthSchemeProvider";
-import { GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
-import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "./commands/TradeEventStreamCommand";
+import {
+  GetNumbersCommandInput,
+  GetNumbersCommandOutput,
+} from "./commands/GetNumbersCommand";
+import {
+  TradeEventStreamCommandInput,
+  TradeEventStreamCommandOutput,
+} from "./commands/TradeEventStreamCommand";
 import {
   ClientInputEndpointParameters,
   ClientResolvedEndpointParameters,
@@ -14,7 +20,11 @@ import {
   resolveClientEndpointParameters,
 } from "./endpoint/EndpointParameters";
 import { getRuntimeConfig as __getRuntimeConfig } from "./runtimeConfig";
-import { RuntimeExtension, RuntimeExtensionsConfig, resolveRuntimeExtensions } from "./runtimeExtensions";
+import {
+  RuntimeExtension,
+  RuntimeExtensionsConfig,
+  resolveRuntimeExtensions,
+} from "./runtimeExtensions";
 import {
   DefaultIdentityProviderConfig,
   getHttpAuthSchemeEndpointRuleSetPlugin,
@@ -35,7 +45,12 @@ import {
   resolveEndpointConfig,
   resolveEndpointRequiredConfig,
 } from "@smithy/middleware-endpoint";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@smithy/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@smithy/middleware-retry";
 import { HttpHandlerUserInput as __HttpHandlerUserInput } from "@smithy/protocol-http";
 import {
   Client as __Client,
@@ -61,22 +76,27 @@ import {
   UrlParser as __UrlParser,
 } from "@smithy/types";
 
-export { __Client };
+export { __Client }
 
 /**
  * @public
  */
-export type ServiceInputTypes = GetNumbersCommandInput | TradeEventStreamCommandInput;
+export type ServiceInputTypes =
+  | GetNumbersCommandInput
+  | TradeEventStreamCommandInput;
 
 /**
  * @public
  */
-export type ServiceOutputTypes = GetNumbersCommandOutput | TradeEventStreamCommandOutput;
+export type ServiceOutputTypes =
+  | GetNumbersCommandOutput
+  | TradeEventStreamCommandOutput;
 
 /**
  * @public
  */
-export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
+export interface ClientDefaults
+  extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
   /**
    * The HTTP handler to use or its constructor options. Fetch in browser and Https in Nodejs.
    */
@@ -184,19 +204,20 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * The {@link @smithy/smithy-client#DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;
+
 }
 
 /**
  * @public
  */
-export type XYZServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
-  ClientDefaults &
-  RetryInputConfig &
-  EndpointInputConfig<EndpointParameters> &
-  EndpointRequiredInputConfig &
-  EventStreamSerdeInputConfig &
-  HttpAuthSchemeInputConfig &
-  ClientInputEndpointParameters;
+export type XYZServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>>
+  & ClientDefaults
+  & RetryInputConfig
+  & EndpointInputConfig<EndpointParameters>
+  & EndpointRequiredInputConfig
+  & EventStreamSerdeInputConfig
+  & HttpAuthSchemeInputConfig
+  & ClientInputEndpointParameters
 /**
  * @public
  *
@@ -207,15 +228,15 @@ export interface XYZServiceClientConfig extends XYZServiceClientConfigType {}
 /**
  * @public
  */
-export type XYZServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
-  Required<ClientDefaults> &
-  RuntimeExtensionsConfig &
-  RetryResolvedConfig &
-  EndpointResolvedConfig<EndpointParameters> &
-  EndpointRequiredResolvedConfig &
-  EventStreamSerdeResolvedConfig &
-  HttpAuthSchemeResolvedConfig &
-  ClientResolvedEndpointParameters;
+export type XYZServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions>
+  & Required<ClientDefaults>
+  & RuntimeExtensionsConfig
+  & RetryResolvedConfig
+  & EndpointResolvedConfig<EndpointParameters>
+  & EndpointRequiredResolvedConfig
+  & EventStreamSerdeResolvedConfig
+  & HttpAuthSchemeResolvedConfig
+  & ClientResolvedEndpointParameters
 /**
  * @public
  *
@@ -251,16 +272,17 @@ export class XYZServiceClient extends __Client<
     let _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     this.config = _config_7;
     this.middlewareStack.use(getSchemaSerdePlugin(this.config));
-    this.middlewareStack.use(getRetryPlugin(this.config));
-    this.middlewareStack.use(getContentLengthPlugin(this.config));
-    this.middlewareStack.use(
-      getHttpAuthSchemeEndpointRuleSetPlugin(this.config, {
-        httpAuthSchemeParametersProvider: defaultXYZServiceHttpAuthSchemeParametersProvider,
-        identityProviderConfigProvider: async (config: XYZServiceClientResolvedConfig) =>
-          new DefaultIdentityProviderConfig({}),
-      })
-    );
-    this.middlewareStack.use(getHttpSigningPlugin(this.config));
+    this.middlewareStack.use(getRetryPlugin(this.config
+    ));
+    this.middlewareStack.use(getContentLengthPlugin(this.config
+    ));
+    this.middlewareStack.use(getHttpAuthSchemeEndpointRuleSetPlugin(this.config
+      , {
+        httpAuthSchemeParametersProvider: defaultXYZServiceHttpAuthSchemeParametersProvider,identityProviderConfigProvider: async (config: XYZServiceClientResolvedConfig) => new DefaultIdentityProviderConfig({
+        }), }
+    ));
+    this.middlewareStack.use(getHttpSigningPlugin(this.config
+    ));
   }
 
   /**

--- a/private/my-local-model-schema/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/my-local-model-schema/src/auth/httpAuthExtensionConfiguration.ts
@@ -23,14 +23,12 @@ export type HttpAuthRuntimeConfig = Partial<{
 /**
  * @internal
  */
-export const getHttpAuthExtensionConfiguration = (
-  runtimeConfig: HttpAuthRuntimeConfig
-): HttpAuthExtensionConfiguration => {
+export const getHttpAuthExtensionConfiguration = (runtimeConfig: HttpAuthRuntimeConfig): HttpAuthExtensionConfiguration => {
   let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
-      const index = _httpAuthSchemes.findIndex((scheme) => scheme.schemeId === httpAuthScheme.schemeId);
+      const index = _httpAuthSchemes.findIndex(scheme => scheme.schemeId === httpAuthScheme.schemeId);
       if (index === -1) {
         _httpAuthSchemes.push(httpAuthScheme);
       } else {
@@ -46,7 +44,7 @@ export const getHttpAuthExtensionConfiguration = (
     httpAuthSchemeProvider(): XYZServiceHttpAuthSchemeProvider {
       return _httpAuthSchemeProvider;
     },
-  };
+  }
 };
 
 /**

--- a/private/my-local-model-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/my-local-model-schema/src/auth/httpAuthSchemeProvider.ts
@@ -9,32 +9,26 @@ import {
   HttpAuthSchemeProvider,
   Provider,
 } from "@smithy/types";
-import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
+import {
+  getSmithyContext,
+  normalizeProvider,
+} from "@smithy/util-middleware";
 
 /**
  * @internal
  */
-export interface XYZServiceHttpAuthSchemeParameters extends HttpAuthSchemeParameters {}
+export interface XYZServiceHttpAuthSchemeParameters extends HttpAuthSchemeParameters {
+}
 
 /**
  * @internal
  */
-export interface XYZServiceHttpAuthSchemeParametersProvider
-  extends HttpAuthSchemeParametersProvider<
-    XYZServiceClientResolvedConfig,
-    HandlerExecutionContext,
-    XYZServiceHttpAuthSchemeParameters,
-    object
-  > {}
+export interface XYZServiceHttpAuthSchemeParametersProvider extends HttpAuthSchemeParametersProvider<XYZServiceClientResolvedConfig, HandlerExecutionContext, XYZServiceHttpAuthSchemeParameters, object> {}
 
 /**
  * @internal
  */
-export const defaultXYZServiceHttpAuthSchemeParametersProvider = async (
-  config: XYZServiceClientResolvedConfig,
-  context: HandlerExecutionContext,
-  input: object
-): Promise<XYZServiceHttpAuthSchemeParameters> => {
+export const defaultXYZServiceHttpAuthSchemeParametersProvider = async (config: XYZServiceClientResolvedConfig, context: HandlerExecutionContext, input: object): Promise<XYZServiceHttpAuthSchemeParameters> => {
   return {
     operation: getSmithyContext(context).operation as string,
   };
@@ -44,7 +38,7 @@ function createSmithyApiNoAuthHttpAuthOption(authParameters: XYZServiceHttpAuthS
   return {
     schemeId: "smithy.api#noAuth",
   };
-}
+};
 
 /**
  * @internal
@@ -59,8 +53,8 @@ export const defaultXYZServiceHttpAuthSchemeProvider: XYZServiceHttpAuthSchemePr
   switch (authParameters.operation) {
     default: {
       options.push(createSmithyApiNoAuthHttpAuthOption(authParameters));
-    }
-  }
+    };
+  };
   return options;
 };
 
@@ -87,6 +81,7 @@ export interface HttpAuthSchemeInputConfig {
    * @internal
    */
   httpAuthSchemeProvider?: XYZServiceHttpAuthSchemeProvider;
+
 }
 
 /**
@@ -112,15 +107,15 @@ export interface HttpAuthSchemeResolvedConfig {
    * @internal
    */
   readonly httpAuthSchemeProvider: XYZServiceHttpAuthSchemeProvider;
+
 }
 
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
-): T & HttpAuthSchemeResolvedConfig => {
-  return Object.assign(config, {
+export const resolveHttpAuthSchemeConfig = <T>(config: T & HttpAuthSchemeInputConfig): T & HttpAuthSchemeResolvedConfig => {
+  return Object.assign(
+    config, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/private/my-local-model-schema/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model-schema/src/commands/GetNumbersCommand.ts
@@ -1,7 +1,14 @@
 // smithy-typescript generated code
-import { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+import {
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  XYZServiceClientResolvedConfig,
+} from "../XYZServiceClient";
 import { commonParams } from "../endpoint/EndpointParameters";
-import { GetNumbersRequest, GetNumbersResponse } from "../models/models_0";
+import {
+  GetNumbersRequest,
+  GetNumbersResponse,
+} from "../models/models_0";
 import { GetNumbers } from "../schemas/schemas_0";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -72,31 +79,29 @@ export interface GetNumbersCommandOutput extends GetNumbersResponse, __MetadataB
  *
  *
  */
-export class GetNumbersCommand extends $Command
-  .classBuilder<
-    GetNumbersCommandInput,
-    GetNumbersCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class GetNumbersCommand extends $Command.classBuilder<GetNumbersCommandInput, GetNumbersCommandOutput, XYZServiceClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("XYZService", "GetNumbers", {})
+  .s("XYZService", "GetNumbers", {
+
+  })
   .n("XYZServiceClient", "GetNumbersCommand")
   .sc(GetNumbers)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: GetNumbersRequest;
       output: GetNumbersResponse;
-    };
-    sdk: {
+  };
+  sdk: {
       input: GetNumbersCommandInput;
       output: GetNumbersCommandOutput;
-    };
   };
+};
 }

--- a/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
@@ -1,7 +1,14 @@
 // smithy-typescript generated code
-import { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+import {
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  XYZServiceClientResolvedConfig,
+} from "../XYZServiceClient";
 import { commonParams } from "../endpoint/EndpointParameters";
-import { TradeEventStreamRequest, TradeEventStreamResponse } from "../models/models_0";
+import {
+  TradeEventStreamRequest,
+  TradeEventStreamResponse,
+} from "../models/models_0";
 import { TradeEventStream } from "../schemas/schemas_0";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -72,19 +79,16 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  *
  *
  */
-export class TradeEventStreamCommand extends $Command
-  .classBuilder<
-    TradeEventStreamCommandInput,
-    TradeEventStreamCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class TradeEventStreamCommand extends $Command.classBuilder<TradeEventStreamCommandInput, TradeEventStreamCommandOutput, XYZServiceClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
   .s("XYZService", "TradeEventStream", {
+
     /**
      * @internal
      */
@@ -95,16 +99,16 @@ export class TradeEventStreamCommand extends $Command
   })
   .n("XYZServiceClient", "TradeEventStreamCommand")
   .sc(TradeEventStream)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: TradeEventStreamRequest;
       output: TradeEventStreamResponse;
-    };
-    sdk: {
+  };
+  sdk: {
       input: TradeEventStreamCommandInput;
       output: TradeEventStreamCommandOutput;
-    };
   };
+};
 }

--- a/private/my-local-model-schema/src/endpoint/EndpointParameters.ts
+++ b/private/my-local-model-schema/src/endpoint/EndpointParameters.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { Endpoint, EndpointV2, Provider, EndpointParameters as __EndpointParameters } from "@smithy/types";
+import {
+  Endpoint,
+  EndpointV2,
+  Provider,
+  EndpointParameters as __EndpointParameters,
+} from "@smithy/types";
 
 /**
  * @public
@@ -9,20 +14,19 @@ export interface ClientInputEndpointParameters {
 }
 
 export type ClientResolvedEndpointParameters = Omit<ClientInputEndpointParameters, "endpoint"> & {
+
   defaultSigningName: string;
 };
 
-export const resolveClientEndpointParameters = <T>(
-  options: T & ClientInputEndpointParameters
-): T & ClientResolvedEndpointParameters => {
+export const resolveClientEndpointParameters = <T>(options: T & ClientInputEndpointParameters): T & ClientResolvedEndpointParameters => {
   return Object.assign(options, {
     defaultSigningName: "",
   });
-};
+}
 
 export const commonParams = {
   endpoint: { type: "builtInParams", name: "endpoint" },
-} as const;
+} as const
 
 export interface EndpointParameters extends __EndpointParameters {
   endpoint?: string | undefined;

--- a/private/my-local-model-schema/src/endpoint/endpointResolver.ts
+++ b/private/my-local-model-schema/src/endpoint/endpointResolver.ts
@@ -1,22 +1,27 @@
 // smithy-typescript generated code
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
-import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointCache, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import {
+  EndpointV2,
+  Logger,
+} from "@smithy/types";
+import {
+  EndpointCache,
+  EndpointParams,
+  resolveEndpoint,
+} from "@smithy/util-endpoints";
 
 const cache = new EndpointCache({
-  size: 50,
-  params: ["endpoint"],
+    size: 50,
+    params: ["endpoint"]
 });
 
 export const defaultEndpointResolver = (
-  endpointParams: EndpointParameters,
-  context: { logger?: Logger } = {}
+    endpointParams: EndpointParameters,
+    context: { logger?: Logger } = {}
 ): EndpointV2 => {
-  return cache.get(endpointParams as EndpointParams, () =>
-    resolveEndpoint(ruleSet, {
-      endpointParams: endpointParams as EndpointParams,
-      logger: context.logger,
-    })
-  );
+    return cache.get(endpointParams as EndpointParams, () => resolveEndpoint(ruleSet, {
+        endpointParams: endpointParams as EndpointParams,
+        logger: context.logger,
+    }));
 };

--- a/private/my-local-model-schema/src/endpoint/ruleset.ts
+++ b/private/my-local-model-schema/src/endpoint/ruleset.ts
@@ -1,38 +1,41 @@
 // smithy-typescript generated code
 import { RuleSetObject } from "@smithy/types";
 
-export const ruleSet: RuleSetObject = {
-  version: "1.0",
-  parameters: {
-    endpoint: {
-      type: "string",
-      builtIn: "SDK::Endpoint",
-      documentation: "Endpoint used for making requests. Should be formatted as a URI.",
-    },
-  },
-  rules: [
-    {
-      conditions: [
-        {
-          fn: "isSet",
-          argv: [
-            {
-              ref: "endpoint",
-            },
-          ],
-        },
-      ],
-      endpoint: {
-        url: {
-          ref: "endpoint",
-        },
+export const ruleSet: RuleSetObject =
+  {
+    "version": "1.0",
+    "parameters": {
+      "endpoint": {
+        "type": "string",
+        "builtIn": "SDK::Endpoint",
+        "documentation": "Endpoint used for making requests. Should be formatted as a URI.",
       },
-      type: "endpoint",
     },
-    {
-      conditions: [],
-      error: "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
-      type: "error",
-    },
-  ],
-};
+    "rules": [
+      {
+        "conditions": [
+          {
+            "fn": "isSet",
+            "argv": [
+              {
+                "ref": "endpoint",
+              },
+            ],
+          },
+        ],
+        "endpoint": {
+          "url": {
+            "ref": "endpoint",
+          },
+        },
+        "type": "endpoint",
+      },
+      {
+        "conditions": [
+        ],
+        "error": "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
+        "type": "error",
+      },
+    ],
+  }
+;

--- a/private/my-local-model-schema/src/extensionConfiguration.ts
+++ b/private/my-local-model-schema/src/extensionConfiguration.ts
@@ -6,7 +6,4 @@ import { DefaultExtensionConfiguration } from "@smithy/types";
 /**
  * @internal
  */
-export interface XYZServiceExtensionConfiguration
-  extends HttpHandlerExtensionConfiguration,
-    DefaultExtensionConfiguration,
-    HttpAuthExtensionConfiguration {}
+export interface XYZServiceExtensionConfiguration extends HttpHandlerExtensionConfiguration, DefaultExtensionConfiguration, HttpAuthExtensionConfiguration {}

--- a/private/my-local-model-schema/src/models/XYZServiceSyntheticServiceException.ts
+++ b/private/my-local-model-schema/src/models/XYZServiceSyntheticServiceException.ts
@@ -4,9 +4,9 @@ import {
   ServiceExceptionOptions as __ServiceExceptionOptions,
 } from "@smithy/smithy-client";
 
-export type { __ServiceExceptionOptions };
+export type { __ServiceExceptionOptions }
 
-export { __ServiceException };
+export { __ServiceException }
 
 /**
  * @public

--- a/private/my-local-model-schema/src/models/errors.ts
+++ b/private/my-local-model-schema/src/models/errors.ts
@@ -18,7 +18,7 @@ export class CodedThrottlingError extends __BaseException {
     super({
       name: "CodedThrottlingError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, CodedThrottlingError.prototype);
   }
@@ -37,7 +37,7 @@ export class HaltError extends __BaseException {
     super({
       name: "HaltError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, HaltError.prototype);
   }
@@ -59,7 +59,7 @@ export class MysteryThrottlingError extends __BaseException {
     super({
       name: "MysteryThrottlingError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, MysteryThrottlingError.prototype);
   }
@@ -71,7 +71,8 @@ export class MysteryThrottlingError extends __BaseException {
 export class RetryableError extends __BaseException {
   readonly name = "RetryableError" as const;
   readonly $fault = "client" as const;
-  $retryable = {};
+  $retryable = {
+  };
   /**
    * @internal
    */
@@ -79,7 +80,7 @@ export class RetryableError extends __BaseException {
     super({
       name: "RetryableError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, RetryableError.prototype);
   }
@@ -98,7 +99,7 @@ export class XYZServiceServiceException extends __BaseException {
     super({
       name: "XYZServiceServiceException",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
   }

--- a/private/my-local-model-schema/src/models/models_0.ts
+++ b/private/my-local-model-schema/src/models/models_0.ts
@@ -43,7 +43,8 @@ export interface GetNumbersResponse {
 /**
  * @public
  */
-export interface Unit {}
+export interface Unit {
+}
 
 /**
  * @public
@@ -52,12 +53,13 @@ export type TradeEvents =
   | TradeEvents.AlphaMember
   | TradeEvents.BetaMember
   | TradeEvents.GammaMember
-  | TradeEvents.$UnknownMember;
+  | TradeEvents.$UnknownMember
 
 /**
  * @public
  */
 export namespace TradeEvents {
+
   export interface AlphaMember {
     alpha: Alpha;
     beta?: never;
@@ -99,6 +101,7 @@ export namespace TradeEvents {
     gamma: (value: Unit) => T;
     _: (name: string, value: any) => T;
   }
+
 }
 
 /**

--- a/private/my-local-model-schema/src/runtimeConfig.browser.ts
+++ b/private/my-local-model-schema/src/runtimeConfig.browser.ts
@@ -1,9 +1,15 @@
 // smithy-typescript generated code
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@smithy/eventstream-serde-browser";
-import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  FetchHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/fetch-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_MODE,
+} from "@smithy/util-retry";
 import { XYZServiceClientConfig } from "./XYZServiceClient";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 import { loadConfigsForDefaultMode } from "@smithy/smithy-client";

--- a/private/my-local-model-schema/src/runtimeConfig.shared.ts
+++ b/private/my-local-model-schema/src/runtimeConfig.shared.ts
@@ -6,8 +6,14 @@ import { SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
 import { NoOpLogger } from "@smithy/smithy-client";
 import { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
-import { fromBase64, toBase64 } from "@smithy/util-base64";
-import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
+import {
+  fromBase64,
+  toBase64,
+} from "@smithy/util-base64";
+import {
+  fromUtf8,
+  toUtf8,
+} from "@smithy/util-utf8";
 import { XYZServiceClientConfig } from "./XYZServiceClient";
 
 /**
@@ -16,24 +22,22 @@ import { XYZServiceClientConfig } from "./XYZServiceClient";
 export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
   return {
     apiVersion: "1.0",
-    base64Decoder: config?.base64Decoder ?? fromBase64,
-    base64Encoder: config?.base64Encoder ?? toBase64,
-    disableHostPrefix: config?.disableHostPrefix ?? false,
-    endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-    extensions: config?.extensions ?? [],
-    httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultXYZServiceHttpAuthSchemeProvider,
-    httpAuthSchemes: config?.httpAuthSchemes ?? [
-      {
+      base64Decoder: config?.base64Decoder ?? fromBase64,
+  base64Encoder: config?.base64Encoder ?? toBase64,
+  disableHostPrefix: config?.disableHostPrefix ?? false,
+  endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
+  extensions: config?.extensions ?? [],
+  httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultXYZServiceHttpAuthSchemeProvider,
+  httpAuthSchemes: config?.httpAuthSchemes ?? [{
         schemeId: "smithy.api#noAuth",
         identityProvider: (ipc: IdentityProviderConfig) =>
           ipc.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
         signer: new NoAuthSigner(),
-      },
-    ],
-    logger: config?.logger ?? new NoOpLogger(),
-    protocol: config?.protocol ?? new SmithyRpcV2CborProtocol({ defaultNamespace: "org.xyz.v1" }),
-    urlParser: config?.urlParser ?? parseUrl,
-    utf8Decoder: config?.utf8Decoder ?? fromUtf8,
-    utf8Encoder: config?.utf8Encoder ?? toUtf8,
-  };
+      }],
+  logger: config?.logger ?? new NoOpLogger(),
+  protocol: config?.protocol ?? new SmithyRpcV2CborProtocol({ defaultNamespace: "org.xyz.v1" }),
+  urlParser: config?.urlParser ?? parseUrl,
+  utf8Decoder: config?.utf8Decoder ?? fromUtf8,
+  utf8Encoder: config?.utf8Encoder ?? toUtf8,
+  }
 };

--- a/private/my-local-model-schema/src/runtimeConfig.ts
+++ b/private/my-local-model-schema/src/runtimeConfig.ts
@@ -1,9 +1,15 @@
 // smithy-typescript generated code
 import { eventStreamSerdeProvider } from "@smithy/eventstream-serde-node";
 import { Hash } from "@smithy/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
+import {
+  NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
+  NODE_RETRY_MODE_CONFIG_OPTIONS,
+} from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
-import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
+import {
+  NodeHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/node-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-node";
 import { DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { XYZServiceClientConfig } from "./XYZServiceClient";
@@ -29,15 +35,7 @@ export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
-    retryMode:
-      config?.retryMode ??
-      loadNodeConfig(
-        {
-          ...NODE_RETRY_MODE_CONFIG_OPTIONS,
-          default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
-        },
-        config
-      ),
+    retryMode: config?.retryMode ?? loadNodeConfig({...NODE_RETRY_MODE_CONFIG_OPTIONS,default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,}, config),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };

--- a/private/my-local-model-schema/src/runtimeExtensions.ts
+++ b/private/my-local-model-schema/src/runtimeExtensions.ts
@@ -1,39 +1,50 @@
 // smithy-typescript generated code
-import { getHttpAuthExtensionConfiguration, resolveHttpAuthRuntimeConfig } from "./auth/httpAuthExtensionConfiguration";
-import { getHttpHandlerExtensionConfiguration, resolveHttpHandlerRuntimeConfig } from "@smithy/protocol-http";
-import { getDefaultExtensionConfiguration, resolveDefaultRuntimeConfig } from "@smithy/smithy-client";
+import {
+  getHttpAuthExtensionConfiguration,
+  resolveHttpAuthRuntimeConfig,
+} from "./auth/httpAuthExtensionConfiguration";
+import {
+  getHttpHandlerExtensionConfiguration,
+  resolveHttpHandlerRuntimeConfig,
+} from "@smithy/protocol-http";
+import {
+  getDefaultExtensionConfiguration,
+  resolveDefaultRuntimeConfig,
+} from "@smithy/smithy-client";
 import { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 
 /**
  * @public
  */
 export interface RuntimeExtension {
-  configure(extensionConfiguration: XYZServiceExtensionConfiguration): void;
+    configure(extensionConfiguration: XYZServiceExtensionConfiguration): void;
 }
 
 /**
  * @public
  */
 export interface RuntimeExtensionsConfig {
-  extensions: RuntimeExtension[];
+    extensions: RuntimeExtension[]
 }
 
 /**
  * @internal
  */
-export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: RuntimeExtension[]) => {
+export const resolveRuntimeExtensions = (
+    runtimeConfig: any,
+    extensions: RuntimeExtension[]
+) => {
   const extensionConfiguration: XYZServiceExtensionConfiguration = Object.assign(
     getDefaultExtensionConfiguration(runtimeConfig),
     getHttpHandlerExtensionConfiguration(runtimeConfig),
-    getHttpAuthExtensionConfiguration(runtimeConfig)
+    getHttpAuthExtensionConfiguration(runtimeConfig),
   );
 
-  extensions.forEach((extension) => extension.configure(extensionConfiguration));
+  extensions.forEach(extension => extension.configure(extensionConfiguration));
 
-  return Object.assign(
-    runtimeConfig,
+  return Object.assign(runtimeConfig,
     resolveDefaultRuntimeConfig(extensionConfiguration),
     resolveHttpHandlerRuntimeConfig(extensionConfiguration),
-    resolveHttpAuthRuntimeConfig(extensionConfiguration)
+    resolveHttpAuthRuntimeConfig(extensionConfiguration),
   );
-};
+}

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -38,104 +38,136 @@ import {
   XYZServiceServiceException as __XYZServiceServiceException,
 } from "../models/errors";
 import { TypeRegistry } from "@smithy/core/schema";
-import { StaticErrorSchema, StaticOperationSchema, StaticStructureSchema } from "@smithy/types";
+import {
+  StaticErrorSchema,
+  StaticOperationSchema,
+  StaticStructureSchema,
+} from "@smithy/types";
 
-/* eslint no-var: 0 */
+    /* eslint no-var: 0 */
 
-export var Alpha: StaticStructureSchema = [3, n0, _A, 0, [_i, _t], [0, 4]];
-export var CodedThrottlingError: StaticErrorSchema = [
-  -3,
-  n0,
-  _CTE,
+export var Alpha: StaticStructureSchema = [3, n0, _A,
+  0
+  , [
+  _i,
+  _t,
+   ], [
+  0,
+  4,
+  ]
+];
+export var CodedThrottlingError: StaticErrorSchema = [-3, n0, _CTE,
   {
-    [_e]: _c,
-    [_hE]: 429,
-  },
-  [],
-  [],
+  [_e]: _c,[_hE]: 429,}
+  , [
+   ], [
+  ]
 ];
 TypeRegistry.for(n0).registerError(CodedThrottlingError, __CodedThrottlingError);
 
-export var GetNumbersRequest: StaticStructureSchema = [3, n0, _GNR, 0, [_bD, _bI, _fWM, _fWMi], [17, 19, 0, 0]];
-export var GetNumbersResponse: StaticStructureSchema = [3, n0, _GNRe, 0, [_bD, _bI], [17, 19]];
-export var HaltError: StaticErrorSchema = [
-  -3,
-  n0,
-  _HE,
+export var GetNumbersRequest: StaticStructureSchema = [3, n0, _GNR,
+  0
+  , [
+  _bD,
+  _bI,
+  _fWM,
+  _fWMi,
+   ], [
+  17,
+  19,
+  0,
+  0,
+  ]
+];
+export var GetNumbersResponse: StaticStructureSchema = [3, n0, _GNRe,
+  0
+  , [
+  _bD,
+  _bI,
+   ], [
+  17,
+  19,
+  ]
+];
+export var HaltError: StaticErrorSchema = [-3, n0, _HE,
   {
-    [_e]: _c,
-  },
-  [],
-  [],
+  [_e]: _c,}
+  , [
+   ], [
+  ]
 ];
 TypeRegistry.for(n0).registerError(HaltError, __HaltError);
 
-export var MysteryThrottlingError: StaticErrorSchema = [
-  -3,
-  n0,
-  _MTE,
+export var MysteryThrottlingError: StaticErrorSchema = [-3, n0, _MTE,
   {
-    [_e]: _c,
-  },
-  [],
-  [],
+  [_e]: _c,}
+  , [
+   ], [
+  ]
 ];
 TypeRegistry.for(n0).registerError(MysteryThrottlingError, __MysteryThrottlingError);
 
-export var RetryableError: StaticErrorSchema = [
-  -3,
-  n0,
-  _RE,
+export var RetryableError: StaticErrorSchema = [-3, n0, _RE,
   {
-    [_e]: _c,
-  },
-  [],
-  [],
+  [_e]: _c,}
+  , [
+   ], [
+  ]
 ];
 TypeRegistry.for(n0).registerError(RetryableError, __RetryableError);
 
-export var TradeEventStreamRequest: StaticStructureSchema = [3, n0, _TESR, 0, [_eS], [[() => TradeEvents, 0]]];
-export var TradeEventStreamResponse: StaticStructureSchema = [3, n0, _TESRr, 0, [_eS], [[() => TradeEvents, 0]]];
-export var XYZServiceServiceException: StaticErrorSchema = [
-  -3,
-  n0,
-  _XYZSSE,
+export var TradeEventStreamRequest: StaticStructureSchema = [3, n0, _TESR,
+  0
+  , [
+  _eS,
+   ], [
+  [() => TradeEvents,
+    0
+  ],
+  ]
+];
+export var TradeEventStreamResponse: StaticStructureSchema = [3, n0, _TESRr,
+  0
+  , [
+  _eS,
+   ], [
+  [() => TradeEvents,
+    0
+  ],
+  ]
+];
+export var XYZServiceServiceException: StaticErrorSchema = [-3, n0, _XYZSSE,
   {
-    [_e]: _c,
-  },
-  [],
-  [],
+  [_e]: _c,}
+  , [
+   ], [
+  ]
 ];
 TypeRegistry.for(n0).registerError(XYZServiceServiceException, __XYZServiceServiceException);
 
 export var __Unit = "unit" as const;
 
-export var XYZServiceSyntheticServiceException: StaticErrorSchema = [
-  -3,
-  _s,
-  "XYZServiceSyntheticServiceException",
-  0,
-  [],
-  [],
-];
+export var XYZServiceSyntheticServiceException: StaticErrorSchema = [-3, _s, "XYZServiceSyntheticServiceException", 0, [], []];
 TypeRegistry.for(_s).registerError(XYZServiceSyntheticServiceException, __XYZServiceSyntheticServiceException);
 
-export var TradeEvents: StaticStructureSchema = [
-  3,
-  n0,
-  _TE,
+export var TradeEvents: StaticStructureSchema = [3, n0, _TE,
   {
-    [_st]: 1,
-  },
-  [_a, _b, _g],
-  [() => Alpha, () => __Unit, () => __Unit],
+  [_st]: 1,}
+  , [
+  _a,
+  _b,
+  _g,
+   ], [
+  () => Alpha,
+  () => __Unit,
+  () => __Unit,
+  ]
 ];
-export var GetNumbers: StaticOperationSchema = [9, n0, _GN, 0, () => GetNumbersRequest, () => GetNumbersResponse];
-export var TradeEventStream: StaticOperationSchema = [
-  9,
-  n0,
-  _TES,
-  0,
-  () => TradeEventStreamRequest,
-  () => TradeEventStreamResponse,
+export var GetNumbers: StaticOperationSchema = [9, n0, _GN,
+  0
+  , () => GetNumbersRequest, () => GetNumbersResponse
+];
+export var TradeEventStream: StaticOperationSchema = [9, n0, _TES,
+  0
+  , () => TradeEventStreamRequest, () => TradeEventStreamResponse
 ];

--- a/private/my-local-model/src/XYZService.ts
+++ b/private/my-local-model/src/XYZService.ts
@@ -1,6 +1,13 @@
 // smithy-typescript generated code
-import { XYZServiceClient, XYZServiceClientConfig } from "./XYZServiceClient";
-import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
+import {
+  XYZServiceClient,
+  XYZServiceClientConfig,
+} from "./XYZServiceClient";
+import {
+  GetNumbersCommand,
+  GetNumbersCommandInput,
+  GetNumbersCommandOutput,
+} from "./commands/GetNumbersCommand";
 import {
   TradeEventStreamCommand,
   TradeEventStreamCommandInput,
@@ -12,15 +19,21 @@ import { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
 const commands = {
   GetNumbersCommand,
   TradeEventStreamCommand,
-};
+}
 
 export interface XYZService {
   /**
    * @see {@link GetNumbersCommand}
    */
   getNumbers(): Promise<GetNumbersCommandOutput>;
-  getNumbers(args: GetNumbersCommandInput, options?: __HttpHandlerOptions): Promise<GetNumbersCommandOutput>;
-  getNumbers(args: GetNumbersCommandInput, cb: (err: any, data?: GetNumbersCommandOutput) => void): void;
+  getNumbers(
+    args: GetNumbersCommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<GetNumbersCommandOutput>;
+  getNumbers(
+    args: GetNumbersCommandInput,
+    cb: (err: any, data?: GetNumbersCommandOutput) => void
+  ): void;
   getNumbers(
     args: GetNumbersCommandInput,
     options: __HttpHandlerOptions,
@@ -33,7 +46,7 @@ export interface XYZService {
   tradeEventStream(): Promise<TradeEventStreamCommandOutput>;
   tradeEventStream(
     args: TradeEventStreamCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<TradeEventStreamCommandOutput>;
   tradeEventStream(
     args: TradeEventStreamCommandInput,
@@ -44,6 +57,7 @@ export interface XYZService {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: TradeEventStreamCommandOutput) => void
   ): void;
+
 }
 
 /**

--- a/private/my-local-model/src/XYZServiceClient.ts
+++ b/private/my-local-model/src/XYZServiceClient.ts
@@ -5,8 +5,14 @@ import {
   defaultXYZServiceHttpAuthSchemeParametersProvider,
   resolveHttpAuthSchemeConfig,
 } from "./auth/httpAuthSchemeProvider";
-import { GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
-import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "./commands/TradeEventStreamCommand";
+import {
+  GetNumbersCommandInput,
+  GetNumbersCommandOutput,
+} from "./commands/GetNumbersCommand";
+import {
+  TradeEventStreamCommandInput,
+  TradeEventStreamCommandOutput,
+} from "./commands/TradeEventStreamCommand";
 import {
   ClientInputEndpointParameters,
   ClientResolvedEndpointParameters,
@@ -14,7 +20,11 @@ import {
   resolveClientEndpointParameters,
 } from "./endpoint/EndpointParameters";
 import { getRuntimeConfig as __getRuntimeConfig } from "./runtimeConfig";
-import { RuntimeExtension, RuntimeExtensionsConfig, resolveRuntimeExtensions } from "./runtimeExtensions";
+import {
+  RuntimeExtension,
+  RuntimeExtensionsConfig,
+  resolveRuntimeExtensions,
+} from "./runtimeExtensions";
 import {
   DefaultIdentityProviderConfig,
   getHttpAuthSchemeEndpointRuleSetPlugin,
@@ -34,7 +44,12 @@ import {
   resolveEndpointConfig,
   resolveEndpointRequiredConfig,
 } from "@smithy/middleware-endpoint";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@smithy/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@smithy/middleware-retry";
 import { HttpHandlerUserInput as __HttpHandlerUserInput } from "@smithy/protocol-http";
 import {
   Client as __Client,
@@ -57,22 +72,27 @@ import {
   UrlParser as __UrlParser,
 } from "@smithy/types";
 
-export { __Client };
+export { __Client }
 
 /**
  * @public
  */
-export type ServiceInputTypes = GetNumbersCommandInput | TradeEventStreamCommandInput;
+export type ServiceInputTypes =
+  | GetNumbersCommandInput
+  | TradeEventStreamCommandInput;
 
 /**
  * @public
  */
-export type ServiceOutputTypes = GetNumbersCommandOutput | TradeEventStreamCommandOutput;
+export type ServiceOutputTypes =
+  | GetNumbersCommandOutput
+  | TradeEventStreamCommandOutput;
 
 /**
  * @public
  */
-export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
+export interface ClientDefaults
+  extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
   /**
    * The HTTP handler to use or its constructor options. Fetch in browser and Https in Nodejs.
    */
@@ -170,19 +190,20 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * The {@link @smithy/smithy-client#DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;
+
 }
 
 /**
  * @public
  */
-export type XYZServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
-  ClientDefaults &
-  RetryInputConfig &
-  EndpointInputConfig<EndpointParameters> &
-  EndpointRequiredInputConfig &
-  EventStreamSerdeInputConfig &
-  HttpAuthSchemeInputConfig &
-  ClientInputEndpointParameters;
+export type XYZServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>>
+  & ClientDefaults
+  & RetryInputConfig
+  & EndpointInputConfig<EndpointParameters>
+  & EndpointRequiredInputConfig
+  & EventStreamSerdeInputConfig
+  & HttpAuthSchemeInputConfig
+  & ClientInputEndpointParameters
 /**
  * @public
  *
@@ -193,15 +214,15 @@ export interface XYZServiceClientConfig extends XYZServiceClientConfigType {}
 /**
  * @public
  */
-export type XYZServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
-  Required<ClientDefaults> &
-  RuntimeExtensionsConfig &
-  RetryResolvedConfig &
-  EndpointResolvedConfig<EndpointParameters> &
-  EndpointRequiredResolvedConfig &
-  EventStreamSerdeResolvedConfig &
-  HttpAuthSchemeResolvedConfig &
-  ClientResolvedEndpointParameters;
+export type XYZServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions>
+  & Required<ClientDefaults>
+  & RuntimeExtensionsConfig
+  & RetryResolvedConfig
+  & EndpointResolvedConfig<EndpointParameters>
+  & EndpointRequiredResolvedConfig
+  & EventStreamSerdeResolvedConfig
+  & HttpAuthSchemeResolvedConfig
+  & ClientResolvedEndpointParameters
 /**
  * @public
  *
@@ -236,16 +257,17 @@ export class XYZServiceClient extends __Client<
     let _config_6 = resolveHttpAuthSchemeConfig(_config_5);
     let _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     this.config = _config_7;
-    this.middlewareStack.use(getRetryPlugin(this.config));
-    this.middlewareStack.use(getContentLengthPlugin(this.config));
-    this.middlewareStack.use(
-      getHttpAuthSchemeEndpointRuleSetPlugin(this.config, {
-        httpAuthSchemeParametersProvider: defaultXYZServiceHttpAuthSchemeParametersProvider,
-        identityProviderConfigProvider: async (config: XYZServiceClientResolvedConfig) =>
-          new DefaultIdentityProviderConfig({}),
-      })
-    );
-    this.middlewareStack.use(getHttpSigningPlugin(this.config));
+    this.middlewareStack.use(getRetryPlugin(this.config
+    ));
+    this.middlewareStack.use(getContentLengthPlugin(this.config
+    ));
+    this.middlewareStack.use(getHttpAuthSchemeEndpointRuleSetPlugin(this.config
+      , {
+        httpAuthSchemeParametersProvider: defaultXYZServiceHttpAuthSchemeParametersProvider,identityProviderConfigProvider: async (config: XYZServiceClientResolvedConfig) => new DefaultIdentityProviderConfig({
+        }), }
+    ));
+    this.middlewareStack.use(getHttpSigningPlugin(this.config
+    ));
   }
 
   /**

--- a/private/my-local-model/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/my-local-model/src/auth/httpAuthExtensionConfiguration.ts
@@ -23,14 +23,12 @@ export type HttpAuthRuntimeConfig = Partial<{
 /**
  * @internal
  */
-export const getHttpAuthExtensionConfiguration = (
-  runtimeConfig: HttpAuthRuntimeConfig
-): HttpAuthExtensionConfiguration => {
+export const getHttpAuthExtensionConfiguration = (runtimeConfig: HttpAuthRuntimeConfig): HttpAuthExtensionConfiguration => {
   let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
-      const index = _httpAuthSchemes.findIndex((scheme) => scheme.schemeId === httpAuthScheme.schemeId);
+      const index = _httpAuthSchemes.findIndex(scheme => scheme.schemeId === httpAuthScheme.schemeId);
       if (index === -1) {
         _httpAuthSchemes.push(httpAuthScheme);
       } else {
@@ -46,7 +44,7 @@ export const getHttpAuthExtensionConfiguration = (
     httpAuthSchemeProvider(): XYZServiceHttpAuthSchemeProvider {
       return _httpAuthSchemeProvider;
     },
-  };
+  }
 };
 
 /**

--- a/private/my-local-model/src/auth/httpAuthSchemeProvider.ts
+++ b/private/my-local-model/src/auth/httpAuthSchemeProvider.ts
@@ -9,32 +9,26 @@ import {
   HttpAuthSchemeProvider,
   Provider,
 } from "@smithy/types";
-import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
+import {
+  getSmithyContext,
+  normalizeProvider,
+} from "@smithy/util-middleware";
 
 /**
  * @internal
  */
-export interface XYZServiceHttpAuthSchemeParameters extends HttpAuthSchemeParameters {}
+export interface XYZServiceHttpAuthSchemeParameters extends HttpAuthSchemeParameters {
+}
 
 /**
  * @internal
  */
-export interface XYZServiceHttpAuthSchemeParametersProvider
-  extends HttpAuthSchemeParametersProvider<
-    XYZServiceClientResolvedConfig,
-    HandlerExecutionContext,
-    XYZServiceHttpAuthSchemeParameters,
-    object
-  > {}
+export interface XYZServiceHttpAuthSchemeParametersProvider extends HttpAuthSchemeParametersProvider<XYZServiceClientResolvedConfig, HandlerExecutionContext, XYZServiceHttpAuthSchemeParameters, object> {}
 
 /**
  * @internal
  */
-export const defaultXYZServiceHttpAuthSchemeParametersProvider = async (
-  config: XYZServiceClientResolvedConfig,
-  context: HandlerExecutionContext,
-  input: object
-): Promise<XYZServiceHttpAuthSchemeParameters> => {
+export const defaultXYZServiceHttpAuthSchemeParametersProvider = async (config: XYZServiceClientResolvedConfig, context: HandlerExecutionContext, input: object): Promise<XYZServiceHttpAuthSchemeParameters> => {
   return {
     operation: getSmithyContext(context).operation as string,
   };
@@ -44,7 +38,7 @@ function createSmithyApiNoAuthHttpAuthOption(authParameters: XYZServiceHttpAuthS
   return {
     schemeId: "smithy.api#noAuth",
   };
-}
+};
 
 /**
  * @internal
@@ -59,8 +53,8 @@ export const defaultXYZServiceHttpAuthSchemeProvider: XYZServiceHttpAuthSchemePr
   switch (authParameters.operation) {
     default: {
       options.push(createSmithyApiNoAuthHttpAuthOption(authParameters));
-    }
-  }
+    };
+  };
   return options;
 };
 
@@ -87,6 +81,7 @@ export interface HttpAuthSchemeInputConfig {
    * @internal
    */
   httpAuthSchemeProvider?: XYZServiceHttpAuthSchemeProvider;
+
 }
 
 /**
@@ -112,15 +107,15 @@ export interface HttpAuthSchemeResolvedConfig {
    * @internal
    */
   readonly httpAuthSchemeProvider: XYZServiceHttpAuthSchemeProvider;
+
 }
 
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
-): T & HttpAuthSchemeResolvedConfig => {
-  return Object.assign(config, {
+export const resolveHttpAuthSchemeConfig = <T>(config: T & HttpAuthSchemeInputConfig): T & HttpAuthSchemeResolvedConfig => {
+  return Object.assign(
+    config, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/private/my-local-model/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model/src/commands/GetNumbersCommand.ts
@@ -1,8 +1,18 @@
 // smithy-typescript generated code
-import { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+import {
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  XYZServiceClientResolvedConfig,
+} from "../XYZServiceClient";
 import { commonParams } from "../endpoint/EndpointParameters";
-import { GetNumbersRequest, GetNumbersResponse } from "../models/models_0";
-import { de_GetNumbersCommand, se_GetNumbersCommand } from "../protocols/Rpcv2cbor";
+import {
+  GetNumbersRequest,
+  GetNumbersResponse,
+} from "../models/models_0";
+import {
+  de_GetNumbersCommand,
+  se_GetNumbersCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -73,36 +83,31 @@ export interface GetNumbersCommandOutput extends GetNumbersResponse, __MetadataB
  *
  *
  */
-export class GetNumbersCommand extends $Command
-  .classBuilder<
-    GetNumbersCommandInput,
-    GetNumbersCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class GetNumbersCommand extends $Command.classBuilder<GetNumbersCommandInput, GetNumbersCommandOutput, XYZServiceClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("XYZService", "GetNumbers", {})
-  .n("XYZServiceClient", "GetNumbersCommand")
-  .f(void 0, void 0)
+  .s("XYZService", "GetNumbers", {
+
+  })
+  .n("XYZServiceClient", "GetNumbersCommand").f(void 0, void 0)
   .ser(se_GetNumbersCommand)
   .de(de_GetNumbersCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: GetNumbersRequest;
       output: GetNumbersResponse;
-    };
-    sdk: {
+  };
+  sdk: {
       input: GetNumbersCommandInput;
       output: GetNumbersCommandOutput;
-    };
   };
+};
 }

--- a/private/my-local-model/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model/src/commands/TradeEventStreamCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+import {
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  XYZServiceClientResolvedConfig,
+} from "../XYZServiceClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import {
   TradeEventStreamRequest,
@@ -7,7 +11,10 @@ import {
   TradeEventStreamResponse,
   TradeEventStreamResponseFilterSensitiveLog,
 } from "../models/models_0";
-import { de_TradeEventStreamCommand, se_TradeEventStreamCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_TradeEventStreamCommand,
+  se_TradeEventStreamCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -78,22 +85,17 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  *
  *
  */
-export class TradeEventStreamCommand extends $Command
-  .classBuilder<
-    TradeEventStreamCommandInput,
-    TradeEventStreamCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class TradeEventStreamCommand extends $Command.classBuilder<TradeEventStreamCommandInput, TradeEventStreamCommandOutput, XYZServiceClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
   .s("XYZService", "TradeEventStream", {
+
     /**
      * @internal
      */
@@ -102,20 +104,19 @@ export class TradeEventStreamCommand extends $Command
       output: true,
     },
   })
-  .n("XYZServiceClient", "TradeEventStreamCommand")
-  .f(TradeEventStreamRequestFilterSensitiveLog, TradeEventStreamResponseFilterSensitiveLog)
+  .n("XYZServiceClient", "TradeEventStreamCommand").f(TradeEventStreamRequestFilterSensitiveLog, TradeEventStreamResponseFilterSensitiveLog)
   .ser(se_TradeEventStreamCommand)
   .de(de_TradeEventStreamCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: TradeEventStreamRequest;
       output: TradeEventStreamResponse;
-    };
-    sdk: {
+  };
+  sdk: {
       input: TradeEventStreamCommandInput;
       output: TradeEventStreamCommandOutput;
-    };
   };
+};
 }

--- a/private/my-local-model/src/endpoint/EndpointParameters.ts
+++ b/private/my-local-model/src/endpoint/EndpointParameters.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { Endpoint, EndpointV2, Provider, EndpointParameters as __EndpointParameters } from "@smithy/types";
+import {
+  Endpoint,
+  EndpointV2,
+  Provider,
+  EndpointParameters as __EndpointParameters,
+} from "@smithy/types";
 
 /**
  * @public
@@ -9,20 +14,19 @@ export interface ClientInputEndpointParameters {
 }
 
 export type ClientResolvedEndpointParameters = Omit<ClientInputEndpointParameters, "endpoint"> & {
+
   defaultSigningName: string;
 };
 
-export const resolveClientEndpointParameters = <T>(
-  options: T & ClientInputEndpointParameters
-): T & ClientResolvedEndpointParameters => {
+export const resolveClientEndpointParameters = <T>(options: T & ClientInputEndpointParameters): T & ClientResolvedEndpointParameters => {
   return Object.assign(options, {
     defaultSigningName: "",
   });
-};
+}
 
 export const commonParams = {
   endpoint: { type: "builtInParams", name: "endpoint" },
-} as const;
+} as const
 
 export interface EndpointParameters extends __EndpointParameters {
   endpoint?: string | undefined;

--- a/private/my-local-model/src/endpoint/endpointResolver.ts
+++ b/private/my-local-model/src/endpoint/endpointResolver.ts
@@ -1,22 +1,27 @@
 // smithy-typescript generated code
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
-import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointCache, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import {
+  EndpointV2,
+  Logger,
+} from "@smithy/types";
+import {
+  EndpointCache,
+  EndpointParams,
+  resolveEndpoint,
+} from "@smithy/util-endpoints";
 
 const cache = new EndpointCache({
-  size: 50,
-  params: ["endpoint"],
+    size: 50,
+    params: ["endpoint"]
 });
 
 export const defaultEndpointResolver = (
-  endpointParams: EndpointParameters,
-  context: { logger?: Logger } = {}
+    endpointParams: EndpointParameters,
+    context: { logger?: Logger } = {}
 ): EndpointV2 => {
-  return cache.get(endpointParams as EndpointParams, () =>
-    resolveEndpoint(ruleSet, {
-      endpointParams: endpointParams as EndpointParams,
-      logger: context.logger,
-    })
-  );
+    return cache.get(endpointParams as EndpointParams, () => resolveEndpoint(ruleSet, {
+        endpointParams: endpointParams as EndpointParams,
+        logger: context.logger,
+    }));
 };

--- a/private/my-local-model/src/endpoint/ruleset.ts
+++ b/private/my-local-model/src/endpoint/ruleset.ts
@@ -1,38 +1,41 @@
 // smithy-typescript generated code
 import { RuleSetObject } from "@smithy/types";
 
-export const ruleSet: RuleSetObject = {
-  version: "1.0",
-  parameters: {
-    endpoint: {
-      type: "string",
-      builtIn: "SDK::Endpoint",
-      documentation: "Endpoint used for making requests. Should be formatted as a URI.",
-    },
-  },
-  rules: [
-    {
-      conditions: [
-        {
-          fn: "isSet",
-          argv: [
-            {
-              ref: "endpoint",
-            },
-          ],
-        },
-      ],
-      endpoint: {
-        url: {
-          ref: "endpoint",
-        },
+export const ruleSet: RuleSetObject =
+  {
+    "version": "1.0",
+    "parameters": {
+      "endpoint": {
+        "type": "string",
+        "builtIn": "SDK::Endpoint",
+        "documentation": "Endpoint used for making requests. Should be formatted as a URI.",
       },
-      type: "endpoint",
     },
-    {
-      conditions: [],
-      error: "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
-      type: "error",
-    },
-  ],
-};
+    "rules": [
+      {
+        "conditions": [
+          {
+            "fn": "isSet",
+            "argv": [
+              {
+                "ref": "endpoint",
+              },
+            ],
+          },
+        ],
+        "endpoint": {
+          "url": {
+            "ref": "endpoint",
+          },
+        },
+        "type": "endpoint",
+      },
+      {
+        "conditions": [
+        ],
+        "error": "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
+        "type": "error",
+      },
+    ],
+  }
+;

--- a/private/my-local-model/src/extensionConfiguration.ts
+++ b/private/my-local-model/src/extensionConfiguration.ts
@@ -6,7 +6,4 @@ import { DefaultExtensionConfiguration } from "@smithy/types";
 /**
  * @internal
  */
-export interface XYZServiceExtensionConfiguration
-  extends HttpHandlerExtensionConfiguration,
-    DefaultExtensionConfiguration,
-    HttpAuthExtensionConfiguration {}
+export interface XYZServiceExtensionConfiguration extends HttpHandlerExtensionConfiguration, DefaultExtensionConfiguration, HttpAuthExtensionConfiguration {}

--- a/private/my-local-model/src/models/XYZServiceSyntheticServiceException.ts
+++ b/private/my-local-model/src/models/XYZServiceSyntheticServiceException.ts
@@ -4,9 +4,9 @@ import {
   ServiceExceptionOptions as __ServiceExceptionOptions,
 } from "@smithy/smithy-client";
 
-export type { __ServiceExceptionOptions };
+export type { __ServiceExceptionOptions }
 
-export { __ServiceException };
+export { __ServiceException }
 
 /**
  * @public

--- a/private/my-local-model/src/models/errors.ts
+++ b/private/my-local-model/src/models/errors.ts
@@ -18,7 +18,7 @@ export class CodedThrottlingError extends __BaseException {
     super({
       name: "CodedThrottlingError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, CodedThrottlingError.prototype);
   }
@@ -37,7 +37,7 @@ export class HaltError extends __BaseException {
     super({
       name: "HaltError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, HaltError.prototype);
   }
@@ -59,7 +59,7 @@ export class MysteryThrottlingError extends __BaseException {
     super({
       name: "MysteryThrottlingError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, MysteryThrottlingError.prototype);
   }
@@ -71,7 +71,8 @@ export class MysteryThrottlingError extends __BaseException {
 export class RetryableError extends __BaseException {
   readonly name = "RetryableError" as const;
   readonly $fault = "client" as const;
-  $retryable = {};
+  $retryable = {
+  };
   /**
    * @internal
    */
@@ -79,7 +80,7 @@ export class RetryableError extends __BaseException {
     super({
       name: "RetryableError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, RetryableError.prototype);
   }
@@ -98,7 +99,7 @@ export class XYZServiceServiceException extends __BaseException {
     super({
       name: "XYZServiceServiceException",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, XYZServiceServiceException.prototype);
   }

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -43,7 +43,8 @@ export interface GetNumbersResponse {
 /**
  * @public
  */
-export interface Unit {}
+export interface Unit {
+}
 
 /**
  * @public
@@ -52,12 +53,13 @@ export type TradeEvents =
   | TradeEvents.AlphaMember
   | TradeEvents.BetaMember
   | TradeEvents.GammaMember
-  | TradeEvents.$UnknownMember;
+  | TradeEvents.$UnknownMember
 
 /**
  * @public
  */
 export namespace TradeEvents {
+
   export interface AlphaMember {
     alpha: Alpha;
     beta?: never;
@@ -96,22 +98,32 @@ export namespace TradeEvents {
     _: (name: string, value: any) => T;
   }
 
-  export const visit = <T>(value: TradeEvents, visitor: Visitor<T>): T => {
+  export const visit = <T>(
+    value: TradeEvents,
+    visitor: Visitor<T>
+  ): T => {
     if (value.alpha !== undefined) return visitor.alpha(value.alpha);
     if (value.beta !== undefined) return visitor.beta(value.beta);
     if (value.gamma !== undefined) return visitor.gamma(value.gamma);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
+  }
+
 }
 /**
  * @internal
  */
 export const TradeEventsFilterSensitiveLog = (obj: TradeEvents): any => {
-  if (obj.alpha !== undefined) return { alpha: obj.alpha };
-  if (obj.beta !== undefined) return { beta: obj.beta };
-  if (obj.gamma !== undefined) return { gamma: obj.gamma };
-  if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
-};
+  if (obj.alpha !== undefined) return {alpha:
+    obj.alpha
+  };
+  if (obj.beta !== undefined) return {beta:
+    obj.beta
+  };
+  if (obj.gamma !== undefined) return {gamma:
+    obj.gamma
+  };
+  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};
+}
 
 /**
  * @public
@@ -125,8 +137,10 @@ export interface TradeEventStreamRequest {
  */
 export const TradeEventStreamRequestFilterSensitiveLog = (obj: TradeEventStreamRequest): any => ({
   ...obj,
-  ...(obj.eventStream && { eventStream: "STREAMING_CONTENT" }),
-});
+  ...(obj.eventStream && { eventStream:
+    'STREAMING_CONTENT'
+  }),
+})
 
 /**
  * @public
@@ -140,5 +154,7 @@ export interface TradeEventStreamResponse {
  */
 export const TradeEventStreamResponseFilterSensitiveLog = (obj: TradeEventStreamResponse): any => ({
   ...obj,
-  ...(obj.eventStream && { eventStream: "STREAMING_CONTENT" }),
-});
+  ...(obj.eventStream && { eventStream:
+    'STREAMING_CONTENT'
+  }),
+})

--- a/private/my-local-model/src/protocols/Rpcv2cbor.ts
+++ b/private/my-local-model/src/protocols/Rpcv2cbor.ts
@@ -1,6 +1,12 @@
 // smithy-typescript generated code
-import { GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
-import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "../commands/TradeEventStreamCommand";
+import {
+  GetNumbersCommandInput,
+  GetNumbersCommandOutput,
+} from "../commands/GetNumbersCommand";
+import {
+  TradeEventStreamCommandInput,
+  TradeEventStreamCommandOutput,
+} from "../commands/TradeEventStreamCommand";
 import { XYZServiceSyntheticServiceException as __BaseException } from "../models/XYZServiceSyntheticServiceException";
 import {
   CodedThrottlingError,
@@ -9,7 +15,13 @@ import {
   RetryableError,
   XYZServiceServiceException,
 } from "../models/errors";
-import { Alpha, GetNumbersRequest, GetNumbersResponse, TradeEvents, Unit } from "../models/models_0";
+import {
+  Alpha,
+  GetNumbersRequest,
+  GetNumbersResponse,
+  TradeEvents,
+  Unit,
+} from "../models/models_0";
 import {
   dateToTag as __dateToTag,
   buildHttpRpcRequest,
@@ -20,7 +32,10 @@ import {
   parseCborErrorBody as parseErrorBody,
 } from "@smithy/core/cbor";
 import { nv as __nv } from "@smithy/core/serde";
-import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
+import {
+  HttpRequest as __HttpRequest,
+  HttpResponse as __HttpResponse,
+} from "@smithy/protocol-http";
 import {
   decorateServiceException as __decorateServiceException,
   expectNonNull as __expectNonNull,
@@ -44,7 +59,7 @@ import {
 /**
  * serializeRpcv2cborGetNumbersCommand
  */
-export const se_GetNumbersCommand = async (
+export const se_GetNumbersCommand = async(
   input: GetNumbersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -52,12 +67,12 @@ export const se_GetNumbersCommand = async (
   let body: any;
   body = cbor.serialize(se_GetNumbersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/service/XYZService/operation/GetNumbers", undefined, body);
-};
+}
 
 /**
  * serializeRpcv2cborTradeEventStreamCommand
  */
-export const se_TradeEventStreamCommand = async (
+export const se_TradeEventStreamCommand = async(
   input: TradeEventStreamCommandInput,
   context: __SerdeContext & __EventStreamSerdeContext
 ): Promise<__HttpRequest> => {
@@ -69,12 +84,12 @@ export const se_TradeEventStreamCommand = async (
   let body: any;
   body = se_TradeEvents(input.eventStream, context);
   return buildHttpRpcRequest(context, headers, "/service/XYZService/operation/TradeEventStream", undefined, body);
-};
+}
 
 /**
  * deserializeRpcv2cborGetNumbersCommand
  */
-export const de_GetNumbersCommand = async (
+export const de_GetNumbersCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNumbersCommandOutput> => {
@@ -83,20 +98,20 @@ export const de_GetNumbersCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_GetNumbersResponse(data, context);
   const response: GetNumbersCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborTradeEventStreamCommand
  */
-export const de_TradeEventStreamCommand = async (
+export const de_TradeEventStreamCommand = async(
   output: __HttpResponse,
   context: __SerdeContext & __EventStreamSerdeContext
 ): Promise<TradeEventStreamCommandOutput> => {
@@ -107,19 +122,22 @@ export const de_TradeEventStreamCommand = async (
 
   const contents = { eventStream: de_TradeEvents(output.body, context) };
   const response: TradeEventStreamCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserialize_Rpcv2cborCommandError
  */
-const de_CommandError = async (output: __HttpResponse, context: __SerdeContext): Promise<never> => {
+const de_CommandError = async(
+  output: __HttpResponse,
+  context: __SerdeContext,
+): Promise<never> => {
   const parsedOutput: any = {
     ...output,
-    body: await parseErrorBody(output.body, context),
+    body: await parseErrorBody(output.body, context)
   };
   const errorCode = loadSmithyRpcV2CborErrorCode(output, parsedOutput.body);
   switch (errorCode) {
@@ -143,225 +161,260 @@ const de_CommandError = async (output: __HttpResponse, context: __SerdeContext):
       return throwDefaultError({
         output,
         parsedBody,
-        errorCode,
-      }) as never;
+        errorCode
+      }) as never
+    }
   }
-};
 
-/**
- * deserializeRpcv2cborCodedThrottlingErrorRes
- */
-const de_CodedThrottlingErrorRes = async (
-  parsedOutput: any,
-  context: __SerdeContext
-): Promise<CodedThrottlingError> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new CodedThrottlingError({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
-
-/**
- * deserializeRpcv2cborHaltErrorRes
- */
-const de_HaltErrorRes = async (parsedOutput: any, context: __SerdeContext): Promise<HaltError> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new HaltError({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
-
-/**
- * deserializeRpcv2cborMysteryThrottlingErrorRes
- */
-const de_MysteryThrottlingErrorRes = async (
-  parsedOutput: any,
-  context: __SerdeContext
-): Promise<MysteryThrottlingError> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new MysteryThrottlingError({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
-
-/**
- * deserializeRpcv2cborRetryableErrorRes
- */
-const de_RetryableErrorRes = async (parsedOutput: any, context: __SerdeContext): Promise<RetryableError> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new RetryableError({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
-
-/**
- * deserializeRpcv2cborXYZServiceServiceExceptionRes
- */
-const de_XYZServiceServiceExceptionRes = async (
-  parsedOutput: any,
-  context: __SerdeContext
-): Promise<XYZServiceServiceException> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new XYZServiceServiceException({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
-
-/**
- * serializeRpcv2cborTradeEvents
- */
-const se_TradeEvents = (input: any, context: __SerdeContext & __EventStreamSerdeContext): any => {
-  const eventMarshallingVisitor = (event: any): __Message =>
-    TradeEvents.visit(event, {
-      alpha: (value) => se_Alpha_event(value, context),
-      beta: (value) => se_Unit_event(value, context),
-      gamma: (value) => se_Unit_event(value, context),
-      _: (value) => value as any,
+  /**
+   * deserializeRpcv2cborCodedThrottlingErrorRes
+   */
+  const de_CodedThrottlingErrorRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<CodedThrottlingError> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new CodedThrottlingError({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
     });
-  return context.eventStreamMarshaller.serialize(input, eventMarshallingVisitor);
-};
-const se_Alpha_event = (input: Alpha, context: __SerdeContext): __Message => {
-  const headers: __MessageHeaders = {
-    ":event-type": { type: "string", value: "alpha" },
-    ":message-type": { type: "string", value: "event" },
-    ":content-type": { type: "string", value: "application/cbor" },
+    return __decorateServiceException(exception, body);
   };
-  let body = new Uint8Array();
-  body = se_Alpha(input, context);
-  body = cbor.serialize(body);
-  return { headers, body };
-};
-const se_Unit_event = (input: Unit, context: __SerdeContext): __Message => {
-  const headers: __MessageHeaders = {
-    ":event-type": { type: "string", value: "beta" },
-    ":message-type": { type: "string", value: "event" },
-    ":content-type": { type: "string", value: "application/cbor" },
+
+  /**
+   * deserializeRpcv2cborHaltErrorRes
+   */
+  const de_HaltErrorRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<HaltError> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new HaltError({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
+    });
+    return __decorateServiceException(exception, body);
   };
-  let body = new Uint8Array();
-  body = _json(input);
-  body = cbor.serialize(body);
-  return { headers, body };
-};
-/**
- * deserializeRpcv2cborTradeEvents
- */
-const de_TradeEvents = (
-  output: any,
-  context: __SerdeContext & __EventStreamSerdeContext
-): AsyncIterable<TradeEvents> => {
-  return context.eventStreamMarshaller.deserialize(output, async (event) => {
-    if (event["alpha"] != null) {
-      return {
-        alpha: await de_Alpha_event(event["alpha"], context),
-      };
+
+  /**
+   * deserializeRpcv2cborMysteryThrottlingErrorRes
+   */
+  const de_MysteryThrottlingErrorRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<MysteryThrottlingError> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new MysteryThrottlingError({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
+    });
+    return __decorateServiceException(exception, body);
+  };
+
+  /**
+   * deserializeRpcv2cborRetryableErrorRes
+   */
+  const de_RetryableErrorRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<RetryableError> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new RetryableError({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
+    });
+    return __decorateServiceException(exception, body);
+  };
+
+  /**
+   * deserializeRpcv2cborXYZServiceServiceExceptionRes
+   */
+  const de_XYZServiceServiceExceptionRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<XYZServiceServiceException> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new XYZServiceServiceException({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
+    });
+    return __decorateServiceException(exception, body);
+  };
+
+  /**
+   * serializeRpcv2cborTradeEvents
+   */
+  const se_TradeEvents = (
+    input: any,
+    context: __SerdeContext & __EventStreamSerdeContext
+  ): any => {
+    const eventMarshallingVisitor = (event: any): __Message => TradeEvents.visit(event, {
+      alpha: value => se_Alpha_event(value, context),
+      beta: value => se_Unit_event(value, context),
+      gamma: value => se_Unit_event(value, context),
+      _: value => value as any
+    });
+    return context.eventStreamMarshaller.serialize(input, eventMarshallingVisitor);
+  }
+  const se_Alpha_event = (
+    input: Alpha,
+    context: __SerdeContext
+  ): __Message => {
+    const headers: __MessageHeaders = {
+      ":event-type": { type: "string", value: "alpha" },
+      ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/cbor" },
     }
-    if (event["beta"] != null) {
-      return {
-        beta: await de_Unit_event(event["beta"], context),
-      };
+    let body = new Uint8Array();
+    body = se_Alpha(input, context);
+    body = cbor.serialize(body);
+    return { headers, body };
     }
-    if (event["gamma"] != null) {
-      return {
-        gamma: await de_Unit_event(event["gamma"], context),
+    const se_Unit_event = (
+      input: Unit,
+      context: __SerdeContext
+    ): __Message => {
+      const headers: __MessageHeaders = {
+        ":event-type": { type: "string", value: "beta" },
+        ":message-type": { type: "string", value: "event" },
+        ":content-type": { type: "string", value: "application/cbor" },
+      }
+      let body = new Uint8Array();
+      body = _json(input);
+      body = cbor.serialize(body);
+      return { headers, body };
+      }
+      /**
+       * deserializeRpcv2cborTradeEvents
+       */
+      const de_TradeEvents = (
+        output: any,
+        context: __SerdeContext & __EventStreamSerdeContext
+      ): AsyncIterable<TradeEvents> => {
+        return context.eventStreamMarshaller.deserialize(
+          output,
+          async event => {
+            if (event["alpha"] != null) {
+              return {
+                alpha: await de_Alpha_event(event["alpha"], context),
+              };
+            }
+            if (event["beta"] != null) {
+              return {
+                beta: await de_Unit_event(event["beta"], context),
+              };
+            }
+            if (event["gamma"] != null) {
+              return {
+                gamma: await de_Unit_event(event["gamma"], context),
+              };
+            }
+            return {$unknown: event as any};
+          }
+        );
+      }
+      const de_Alpha_event = async (
+        output: any,
+        context: __SerdeContext
+      ): Promise<Alpha> => {
+        const contents: Alpha = {} as any;
+        const data: any = await parseBody(output.body, context);
+        Object.assign(contents, de_Alpha(data, context));
+        return contents;
+      }
+      const de_Unit_event = async (
+        output: any,
+        context: __SerdeContext
+      ): Promise<Unit> => {
+        const contents: Unit = {} as any;
+        const data: any = await parseBody(output.body, context);
+        Object.assign(contents, _json(data));
+        return contents;
+      }
+      /**
+       * serializeRpcv2cborAlpha
+       */
+      const se_Alpha = (
+        input: Alpha,
+        context: __SerdeContext
+      ): any => {
+        return take(input, {
+          'id': [],
+          'timestamp': __dateToTag,
+        });
+      }
+
+      /**
+       * serializeRpcv2cborGetNumbersRequest
+       */
+      const se_GetNumbersRequest = (
+        input: GetNumbersRequest,
+        context: __SerdeContext
+      ): any => {
+        return take(input, {
+          'bigDecimal': __nv,
+          'bigInteger': [],
+          'fieldWithMessage': [],
+          'fieldWithoutMessage': [],
+        });
+      }
+
+      // se_Unit omitted.
+
+      /**
+       * deserializeRpcv2cborAlpha
+       */
+      const de_Alpha = (
+        output: any,
+        context: __SerdeContext
+      ): Alpha => {
+        return take(output, {
+          'id': __expectString,
+          'timestamp': (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
+        }) as any;
+      }
+
+      // de_CodedThrottlingError omitted.
+
+      /**
+       * deserializeRpcv2cborGetNumbersResponse
+       */
+      const de_GetNumbersResponse = (
+        output: any,
+        context: __SerdeContext
+      ): GetNumbersResponse => {
+        return take(output, {
+          'bigDecimal': [],
+          'bigInteger': [],
+        }) as any;
+      }
+
+      // de_HaltError omitted.
+
+      // de_MysteryThrottlingError omitted.
+
+      // de_RetryableError omitted.
+
+      // de_XYZServiceServiceException omitted.
+
+      // de_Unit omitted.
+
+      const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
+        httpStatusCode: output.statusCode,
+        requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
+        extendedRequestId: output.headers["x-amz-id-2"],
+        cfId: output.headers["x-amz-cf-id"],
+      });
+
+      const throwDefaultError = withBaseException(__BaseException);
+      const SHARED_HEADERS: __HeaderBag = {
+        'content-type': "application/cbor",
+        "smithy-protocol": "rpc-v2-cbor",
+        "accept": "application/cbor",
+
       };
-    }
-    return { $unknown: event as any };
-  });
-};
-const de_Alpha_event = async (output: any, context: __SerdeContext): Promise<Alpha> => {
-  const contents: Alpha = {} as any;
-  const data: any = await parseBody(output.body, context);
-  Object.assign(contents, de_Alpha(data, context));
-  return contents;
-};
-const de_Unit_event = async (output: any, context: __SerdeContext): Promise<Unit> => {
-  const contents: Unit = {} as any;
-  const data: any = await parseBody(output.body, context);
-  Object.assign(contents, _json(data));
-  return contents;
-};
-/**
- * serializeRpcv2cborAlpha
- */
-const se_Alpha = (input: Alpha, context: __SerdeContext): any => {
-  return take(input, {
-    id: [],
-    timestamp: __dateToTag,
-  });
-};
-
-/**
- * serializeRpcv2cborGetNumbersRequest
- */
-const se_GetNumbersRequest = (input: GetNumbersRequest, context: __SerdeContext): any => {
-  return take(input, {
-    bigDecimal: __nv,
-    bigInteger: [],
-    fieldWithMessage: [],
-    fieldWithoutMessage: [],
-  });
-};
-
-// se_Unit omitted.
-
-/**
- * deserializeRpcv2cborAlpha
- */
-const de_Alpha = (output: any, context: __SerdeContext): Alpha => {
-  return take(output, {
-    id: __expectString,
-    timestamp: (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
-  }) as any;
-};
-
-// de_CodedThrottlingError omitted.
-
-/**
- * deserializeRpcv2cborGetNumbersResponse
- */
-const de_GetNumbersResponse = (output: any, context: __SerdeContext): GetNumbersResponse => {
-  return take(output, {
-    bigDecimal: [],
-    bigInteger: [],
-  }) as any;
-};
-
-// de_HaltError omitted.
-
-// de_MysteryThrottlingError omitted.
-
-// de_RetryableError omitted.
-
-// de_XYZServiceServiceException omitted.
-
-// de_Unit omitted.
-
-const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
-  httpStatusCode: output.statusCode,
-  requestId:
-    output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
-  extendedRequestId: output.headers["x-amz-id-2"],
-  cfId: output.headers["x-amz-cf-id"],
-});
-
-const throwDefaultError = withBaseException(__BaseException);
-const SHARED_HEADERS: __HeaderBag = {
-  "content-type": "application/cbor",
-  "smithy-protocol": "rpc-v2-cbor",
-  accept: "application/cbor",
-};

--- a/private/my-local-model/src/runtimeConfig.browser.ts
+++ b/private/my-local-model/src/runtimeConfig.browser.ts
@@ -1,9 +1,15 @@
 // smithy-typescript generated code
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@smithy/eventstream-serde-browser";
-import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  FetchHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/fetch-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_MODE,
+} from "@smithy/util-retry";
 import { XYZServiceClientConfig } from "./XYZServiceClient";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 import { loadConfigsForDefaultMode } from "@smithy/smithy-client";

--- a/private/my-local-model/src/runtimeConfig.shared.ts
+++ b/private/my-local-model/src/runtimeConfig.shared.ts
@@ -5,8 +5,14 @@ import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";
 import { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
-import { fromBase64, toBase64 } from "@smithy/util-base64";
-import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
+import {
+  fromBase64,
+  toBase64,
+} from "@smithy/util-base64";
+import {
+  fromUtf8,
+  toUtf8,
+} from "@smithy/util-utf8";
 import { XYZServiceClientConfig } from "./XYZServiceClient";
 
 /**
@@ -15,23 +21,21 @@ import { XYZServiceClientConfig } from "./XYZServiceClient";
 export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
   return {
     apiVersion: "1.0",
-    base64Decoder: config?.base64Decoder ?? fromBase64,
-    base64Encoder: config?.base64Encoder ?? toBase64,
-    disableHostPrefix: config?.disableHostPrefix ?? false,
-    endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-    extensions: config?.extensions ?? [],
-    httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultXYZServiceHttpAuthSchemeProvider,
-    httpAuthSchemes: config?.httpAuthSchemes ?? [
-      {
+      base64Decoder: config?.base64Decoder ?? fromBase64,
+  base64Encoder: config?.base64Encoder ?? toBase64,
+  disableHostPrefix: config?.disableHostPrefix ?? false,
+  endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
+  extensions: config?.extensions ?? [],
+  httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultXYZServiceHttpAuthSchemeProvider,
+  httpAuthSchemes: config?.httpAuthSchemes ?? [{
         schemeId: "smithy.api#noAuth",
         identityProvider: (ipc: IdentityProviderConfig) =>
           ipc.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
         signer: new NoAuthSigner(),
-      },
-    ],
-    logger: config?.logger ?? new NoOpLogger(),
-    urlParser: config?.urlParser ?? parseUrl,
-    utf8Decoder: config?.utf8Decoder ?? fromUtf8,
-    utf8Encoder: config?.utf8Encoder ?? toUtf8,
-  };
+      }],
+  logger: config?.logger ?? new NoOpLogger(),
+  urlParser: config?.urlParser ?? parseUrl,
+  utf8Decoder: config?.utf8Decoder ?? fromUtf8,
+  utf8Encoder: config?.utf8Encoder ?? toUtf8,
+  }
 };

--- a/private/my-local-model/src/runtimeConfig.ts
+++ b/private/my-local-model/src/runtimeConfig.ts
@@ -1,9 +1,15 @@
 // smithy-typescript generated code
 import { eventStreamSerdeProvider } from "@smithy/eventstream-serde-node";
 import { Hash } from "@smithy/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
+import {
+  NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
+  NODE_RETRY_MODE_CONFIG_OPTIONS,
+} from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
-import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
+import {
+  NodeHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/node-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-node";
 import { DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { XYZServiceClientConfig } from "./XYZServiceClient";
@@ -29,15 +35,7 @@ export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
-    retryMode:
-      config?.retryMode ??
-      loadNodeConfig(
-        {
-          ...NODE_RETRY_MODE_CONFIG_OPTIONS,
-          default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
-        },
-        config
-      ),
+    retryMode: config?.retryMode ?? loadNodeConfig({...NODE_RETRY_MODE_CONFIG_OPTIONS,default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,}, config),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };

--- a/private/my-local-model/src/runtimeExtensions.ts
+++ b/private/my-local-model/src/runtimeExtensions.ts
@@ -1,39 +1,50 @@
 // smithy-typescript generated code
-import { getHttpAuthExtensionConfiguration, resolveHttpAuthRuntimeConfig } from "./auth/httpAuthExtensionConfiguration";
-import { getHttpHandlerExtensionConfiguration, resolveHttpHandlerRuntimeConfig } from "@smithy/protocol-http";
-import { getDefaultExtensionConfiguration, resolveDefaultRuntimeConfig } from "@smithy/smithy-client";
+import {
+  getHttpAuthExtensionConfiguration,
+  resolveHttpAuthRuntimeConfig,
+} from "./auth/httpAuthExtensionConfiguration";
+import {
+  getHttpHandlerExtensionConfiguration,
+  resolveHttpHandlerRuntimeConfig,
+} from "@smithy/protocol-http";
+import {
+  getDefaultExtensionConfiguration,
+  resolveDefaultRuntimeConfig,
+} from "@smithy/smithy-client";
 import { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 
 /**
  * @public
  */
 export interface RuntimeExtension {
-  configure(extensionConfiguration: XYZServiceExtensionConfiguration): void;
+    configure(extensionConfiguration: XYZServiceExtensionConfiguration): void;
 }
 
 /**
  * @public
  */
 export interface RuntimeExtensionsConfig {
-  extensions: RuntimeExtension[];
+    extensions: RuntimeExtension[]
 }
 
 /**
  * @internal
  */
-export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: RuntimeExtension[]) => {
+export const resolveRuntimeExtensions = (
+    runtimeConfig: any,
+    extensions: RuntimeExtension[]
+) => {
   const extensionConfiguration: XYZServiceExtensionConfiguration = Object.assign(
     getDefaultExtensionConfiguration(runtimeConfig),
     getHttpHandlerExtensionConfiguration(runtimeConfig),
-    getHttpAuthExtensionConfiguration(runtimeConfig)
+    getHttpAuthExtensionConfiguration(runtimeConfig),
   );
 
-  extensions.forEach((extension) => extension.configure(extensionConfiguration));
+  extensions.forEach(extension => extension.configure(extensionConfiguration));
 
-  return Object.assign(
-    runtimeConfig,
+  return Object.assign(runtimeConfig,
     resolveDefaultRuntimeConfig(extensionConfiguration),
     resolveHttpHandlerRuntimeConfig(extensionConfiguration),
-    resolveHttpAuthRuntimeConfig(extensionConfiguration)
+    resolveHttpAuthRuntimeConfig(extensionConfiguration),
   );
-};
+}

--- a/private/smithy-rpcv2-cbor-schema/src/RpcV2Protocol.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/RpcV2Protocol.ts
@@ -1,11 +1,18 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClient, RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClient,
+  RpcV2ProtocolClientConfig,
+} from "./RpcV2ProtocolClient";
 import {
   EmptyInputOutputCommand,
   EmptyInputOutputCommandInput,
   EmptyInputOutputCommandOutput,
 } from "./commands/EmptyInputOutputCommand";
-import { Float16Command, Float16CommandInput, Float16CommandOutput } from "./commands/Float16Command";
+import {
+  Float16Command,
+  Float16CommandInput,
+  Float16CommandOutput,
+} from "./commands/Float16Command";
 import {
   FractionalSecondsCommand,
   FractionalSecondsCommandInput,
@@ -78,7 +85,7 @@ const commands = {
   RpcV2CborSparseMapsCommand,
   SimpleScalarPropertiesCommand,
   SparseNullsOperationCommand,
-};
+}
 
 export interface RpcV2Protocol {
   /**
@@ -87,7 +94,7 @@ export interface RpcV2Protocol {
   emptyInputOutput(): Promise<EmptyInputOutputCommandOutput>;
   emptyInputOutput(
     args: EmptyInputOutputCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<EmptyInputOutputCommandOutput>;
   emptyInputOutput(
     args: EmptyInputOutputCommandInput,
@@ -103,8 +110,14 @@ export interface RpcV2Protocol {
    * @see {@link Float16Command}
    */
   float16(): Promise<Float16CommandOutput>;
-  float16(args: Float16CommandInput, options?: __HttpHandlerOptions): Promise<Float16CommandOutput>;
-  float16(args: Float16CommandInput, cb: (err: any, data?: Float16CommandOutput) => void): void;
+  float16(
+    args: Float16CommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<Float16CommandOutput>;
+  float16(
+    args: Float16CommandInput,
+    cb: (err: any, data?: Float16CommandOutput) => void
+  ): void;
   float16(
     args: Float16CommandInput,
     options: __HttpHandlerOptions,
@@ -117,7 +130,7 @@ export interface RpcV2Protocol {
   fractionalSeconds(): Promise<FractionalSecondsCommandOutput>;
   fractionalSeconds(
     args: FractionalSecondsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<FractionalSecondsCommandOutput>;
   fractionalSeconds(
     args: FractionalSecondsCommandInput,
@@ -135,7 +148,7 @@ export interface RpcV2Protocol {
   greetingWithErrors(): Promise<GreetingWithErrorsCommandOutput>;
   greetingWithErrors(
     args: GreetingWithErrorsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<GreetingWithErrorsCommandOutput>;
   greetingWithErrors(
     args: GreetingWithErrorsCommandInput,
@@ -151,8 +164,14 @@ export interface RpcV2Protocol {
    * @see {@link NoInputOutputCommand}
    */
   noInputOutput(): Promise<NoInputOutputCommandOutput>;
-  noInputOutput(args: NoInputOutputCommandInput, options?: __HttpHandlerOptions): Promise<NoInputOutputCommandOutput>;
-  noInputOutput(args: NoInputOutputCommandInput, cb: (err: any, data?: NoInputOutputCommandOutput) => void): void;
+  noInputOutput(
+    args: NoInputOutputCommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<NoInputOutputCommandOutput>;
+  noInputOutput(
+    args: NoInputOutputCommandInput,
+    cb: (err: any, data?: NoInputOutputCommandOutput) => void
+  ): void;
   noInputOutput(
     args: NoInputOutputCommandInput,
     options: __HttpHandlerOptions,
@@ -165,7 +184,7 @@ export interface RpcV2Protocol {
   operationWithDefaults(): Promise<OperationWithDefaultsCommandOutput>;
   operationWithDefaults(
     args: OperationWithDefaultsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<OperationWithDefaultsCommandOutput>;
   operationWithDefaults(
     args: OperationWithDefaultsCommandInput,
@@ -183,7 +202,7 @@ export interface RpcV2Protocol {
   optionalInputOutput(): Promise<OptionalInputOutputCommandOutput>;
   optionalInputOutput(
     args: OptionalInputOutputCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<OptionalInputOutputCommandOutput>;
   optionalInputOutput(
     args: OptionalInputOutputCommandInput,
@@ -201,9 +220,12 @@ export interface RpcV2Protocol {
   recursiveShapes(): Promise<RecursiveShapesCommandOutput>;
   recursiveShapes(
     args: RecursiveShapesCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RecursiveShapesCommandOutput>;
-  recursiveShapes(args: RecursiveShapesCommandInput, cb: (err: any, data?: RecursiveShapesCommandOutput) => void): void;
+  recursiveShapes(
+    args: RecursiveShapesCommandInput,
+    cb: (err: any, data?: RecursiveShapesCommandOutput) => void
+  ): void;
   recursiveShapes(
     args: RecursiveShapesCommandInput,
     options: __HttpHandlerOptions,
@@ -216,7 +238,7 @@ export interface RpcV2Protocol {
   rpcV2CborDenseMaps(): Promise<RpcV2CborDenseMapsCommandOutput>;
   rpcV2CborDenseMaps(
     args: RpcV2CborDenseMapsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RpcV2CborDenseMapsCommandOutput>;
   rpcV2CborDenseMaps(
     args: RpcV2CborDenseMapsCommandInput,
@@ -234,9 +256,12 @@ export interface RpcV2Protocol {
   rpcV2CborLists(): Promise<RpcV2CborListsCommandOutput>;
   rpcV2CborLists(
     args: RpcV2CborListsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RpcV2CborListsCommandOutput>;
-  rpcV2CborLists(args: RpcV2CborListsCommandInput, cb: (err: any, data?: RpcV2CborListsCommandOutput) => void): void;
+  rpcV2CborLists(
+    args: RpcV2CborListsCommandInput,
+    cb: (err: any, data?: RpcV2CborListsCommandOutput) => void
+  ): void;
   rpcV2CborLists(
     args: RpcV2CborListsCommandInput,
     options: __HttpHandlerOptions,
@@ -249,7 +274,7 @@ export interface RpcV2Protocol {
   rpcV2CborSparseMaps(): Promise<RpcV2CborSparseMapsCommandOutput>;
   rpcV2CborSparseMaps(
     args: RpcV2CborSparseMapsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RpcV2CborSparseMapsCommandOutput>;
   rpcV2CborSparseMaps(
     args: RpcV2CborSparseMapsCommandInput,
@@ -267,7 +292,7 @@ export interface RpcV2Protocol {
   simpleScalarProperties(): Promise<SimpleScalarPropertiesCommandOutput>;
   simpleScalarProperties(
     args: SimpleScalarPropertiesCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<SimpleScalarPropertiesCommandOutput>;
   simpleScalarProperties(
     args: SimpleScalarPropertiesCommandInput,
@@ -285,7 +310,7 @@ export interface RpcV2Protocol {
   sparseNullsOperation(): Promise<SparseNullsOperationCommandOutput>;
   sparseNullsOperation(
     args: SparseNullsOperationCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<SparseNullsOperationCommandOutput>;
   sparseNullsOperation(
     args: SparseNullsOperationCommandInput,
@@ -296,6 +321,7 @@ export interface RpcV2Protocol {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: SparseNullsOperationCommandOutput) => void
   ): void;
+
 }
 
 /**

--- a/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
@@ -5,11 +5,26 @@ import {
   defaultRpcV2ProtocolHttpAuthSchemeParametersProvider,
   resolveHttpAuthSchemeConfig,
 } from "./auth/httpAuthSchemeProvider";
-import { EmptyInputOutputCommandInput, EmptyInputOutputCommandOutput } from "./commands/EmptyInputOutputCommand";
-import { Float16CommandInput, Float16CommandOutput } from "./commands/Float16Command";
-import { FractionalSecondsCommandInput, FractionalSecondsCommandOutput } from "./commands/FractionalSecondsCommand";
-import { GreetingWithErrorsCommandInput, GreetingWithErrorsCommandOutput } from "./commands/GreetingWithErrorsCommand";
-import { NoInputOutputCommandInput, NoInputOutputCommandOutput } from "./commands/NoInputOutputCommand";
+import {
+  EmptyInputOutputCommandInput,
+  EmptyInputOutputCommandOutput,
+} from "./commands/EmptyInputOutputCommand";
+import {
+  Float16CommandInput,
+  Float16CommandOutput,
+} from "./commands/Float16Command";
+import {
+  FractionalSecondsCommandInput,
+  FractionalSecondsCommandOutput,
+} from "./commands/FractionalSecondsCommand";
+import {
+  GreetingWithErrorsCommandInput,
+  GreetingWithErrorsCommandOutput,
+} from "./commands/GreetingWithErrorsCommand";
+import {
+  NoInputOutputCommandInput,
+  NoInputOutputCommandOutput,
+} from "./commands/NoInputOutputCommand";
 import {
   OperationWithDefaultsCommandInput,
   OperationWithDefaultsCommandOutput,
@@ -18,9 +33,18 @@ import {
   OptionalInputOutputCommandInput,
   OptionalInputOutputCommandOutput,
 } from "./commands/OptionalInputOutputCommand";
-import { RecursiveShapesCommandInput, RecursiveShapesCommandOutput } from "./commands/RecursiveShapesCommand";
-import { RpcV2CborDenseMapsCommandInput, RpcV2CborDenseMapsCommandOutput } from "./commands/RpcV2CborDenseMapsCommand";
-import { RpcV2CborListsCommandInput, RpcV2CborListsCommandOutput } from "./commands/RpcV2CborListsCommand";
+import {
+  RecursiveShapesCommandInput,
+  RecursiveShapesCommandOutput,
+} from "./commands/RecursiveShapesCommand";
+import {
+  RpcV2CborDenseMapsCommandInput,
+  RpcV2CborDenseMapsCommandOutput,
+} from "./commands/RpcV2CborDenseMapsCommand";
+import {
+  RpcV2CborListsCommandInput,
+  RpcV2CborListsCommandOutput,
+} from "./commands/RpcV2CborListsCommand";
 import {
   RpcV2CborSparseMapsCommandInput,
   RpcV2CborSparseMapsCommandOutput,
@@ -40,7 +64,11 @@ import {
   resolveClientEndpointParameters,
 } from "./endpoint/EndpointParameters";
 import { getRuntimeConfig as __getRuntimeConfig } from "./runtimeConfig";
-import { RuntimeExtension, RuntimeExtensionsConfig, resolveRuntimeExtensions } from "./runtimeExtensions";
+import {
+  RuntimeExtension,
+  RuntimeExtensionsConfig,
+  resolveRuntimeExtensions,
+} from "./runtimeExtensions";
 import {
   DefaultIdentityProviderConfig,
   getHttpAuthSchemeEndpointRuleSetPlugin,
@@ -56,7 +84,12 @@ import {
   resolveEndpointConfig,
   resolveEndpointRequiredConfig,
 } from "@smithy/middleware-endpoint";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@smithy/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@smithy/middleware-retry";
 import { HttpHandlerUserInput as __HttpHandlerUserInput } from "@smithy/protocol-http";
 import {
   Client as __Client,
@@ -81,7 +114,7 @@ import {
   UrlParser as __UrlParser,
 } from "@smithy/types";
 
-export { __Client };
+export { __Client }
 
 /**
  * @public
@@ -122,7 +155,8 @@ export type ServiceOutputTypes =
 /**
  * @public
  */
-export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
+export interface ClientDefaults
+  extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
   /**
    * The HTTP handler to use or its constructor options. Fetch in browser and Https in Nodejs.
    */
@@ -225,18 +259,19 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * The {@link @smithy/smithy-client#DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;
+
 }
 
 /**
  * @public
  */
-export type RpcV2ProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
-  ClientDefaults &
-  RetryInputConfig &
-  EndpointInputConfig<EndpointParameters> &
-  EndpointRequiredInputConfig &
-  HttpAuthSchemeInputConfig &
-  ClientInputEndpointParameters;
+export type RpcV2ProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>>
+  & ClientDefaults
+  & RetryInputConfig
+  & EndpointInputConfig<EndpointParameters>
+  & EndpointRequiredInputConfig
+  & HttpAuthSchemeInputConfig
+  & ClientInputEndpointParameters
 /**
  * @public
  *
@@ -247,14 +282,14 @@ export interface RpcV2ProtocolClientConfig extends RpcV2ProtocolClientConfigType
 /**
  * @public
  */
-export type RpcV2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
-  Required<ClientDefaults> &
-  RuntimeExtensionsConfig &
-  RetryResolvedConfig &
-  EndpointResolvedConfig<EndpointParameters> &
-  EndpointRequiredResolvedConfig &
-  HttpAuthSchemeResolvedConfig &
-  ClientResolvedEndpointParameters;
+export type RpcV2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions>
+  & Required<ClientDefaults>
+  & RuntimeExtensionsConfig
+  & RetryResolvedConfig
+  & EndpointResolvedConfig<EndpointParameters>
+  & EndpointRequiredResolvedConfig
+  & HttpAuthSchemeResolvedConfig
+  & ClientResolvedEndpointParameters
 /**
  * @public
  *
@@ -288,16 +323,17 @@ export class RpcV2ProtocolClient extends __Client<
     let _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
     this.config = _config_6;
     this.middlewareStack.use(getSchemaSerdePlugin(this.config));
-    this.middlewareStack.use(getRetryPlugin(this.config));
-    this.middlewareStack.use(getContentLengthPlugin(this.config));
-    this.middlewareStack.use(
-      getHttpAuthSchemeEndpointRuleSetPlugin(this.config, {
-        httpAuthSchemeParametersProvider: defaultRpcV2ProtocolHttpAuthSchemeParametersProvider,
-        identityProviderConfigProvider: async (config: RpcV2ProtocolClientResolvedConfig) =>
-          new DefaultIdentityProviderConfig({}),
-      })
-    );
-    this.middlewareStack.use(getHttpSigningPlugin(this.config));
+    this.middlewareStack.use(getRetryPlugin(this.config
+    ));
+    this.middlewareStack.use(getContentLengthPlugin(this.config
+    ));
+    this.middlewareStack.use(getHttpAuthSchemeEndpointRuleSetPlugin(this.config
+      , {
+        httpAuthSchemeParametersProvider: defaultRpcV2ProtocolHttpAuthSchemeParametersProvider,identityProviderConfigProvider: async (config: RpcV2ProtocolClientResolvedConfig) => new DefaultIdentityProviderConfig({
+        }), }
+    ));
+    this.middlewareStack.use(getHttpSigningPlugin(this.config
+    ));
   }
 
   /**

--- a/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthExtensionConfiguration.ts
@@ -23,14 +23,12 @@ export type HttpAuthRuntimeConfig = Partial<{
 /**
  * @internal
  */
-export const getHttpAuthExtensionConfiguration = (
-  runtimeConfig: HttpAuthRuntimeConfig
-): HttpAuthExtensionConfiguration => {
+export const getHttpAuthExtensionConfiguration = (runtimeConfig: HttpAuthRuntimeConfig): HttpAuthExtensionConfiguration => {
   let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
-      const index = _httpAuthSchemes.findIndex((scheme) => scheme.schemeId === httpAuthScheme.schemeId);
+      const index = _httpAuthSchemes.findIndex(scheme => scheme.schemeId === httpAuthScheme.schemeId);
       if (index === -1) {
         _httpAuthSchemes.push(httpAuthScheme);
       } else {
@@ -46,7 +44,7 @@ export const getHttpAuthExtensionConfiguration = (
     httpAuthSchemeProvider(): RpcV2ProtocolHttpAuthSchemeProvider {
       return _httpAuthSchemeProvider;
     },
-  };
+  }
 };
 
 /**

--- a/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthSchemeProvider.ts
@@ -9,32 +9,26 @@ import {
   HttpAuthSchemeProvider,
   Provider,
 } from "@smithy/types";
-import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
+import {
+  getSmithyContext,
+  normalizeProvider,
+} from "@smithy/util-middleware";
 
 /**
  * @internal
  */
-export interface RpcV2ProtocolHttpAuthSchemeParameters extends HttpAuthSchemeParameters {}
+export interface RpcV2ProtocolHttpAuthSchemeParameters extends HttpAuthSchemeParameters {
+}
 
 /**
  * @internal
  */
-export interface RpcV2ProtocolHttpAuthSchemeParametersProvider
-  extends HttpAuthSchemeParametersProvider<
-    RpcV2ProtocolClientResolvedConfig,
-    HandlerExecutionContext,
-    RpcV2ProtocolHttpAuthSchemeParameters,
-    object
-  > {}
+export interface RpcV2ProtocolHttpAuthSchemeParametersProvider extends HttpAuthSchemeParametersProvider<RpcV2ProtocolClientResolvedConfig, HandlerExecutionContext, RpcV2ProtocolHttpAuthSchemeParameters, object> {}
 
 /**
  * @internal
  */
-export const defaultRpcV2ProtocolHttpAuthSchemeParametersProvider = async (
-  config: RpcV2ProtocolClientResolvedConfig,
-  context: HandlerExecutionContext,
-  input: object
-): Promise<RpcV2ProtocolHttpAuthSchemeParameters> => {
+export const defaultRpcV2ProtocolHttpAuthSchemeParametersProvider = async (config: RpcV2ProtocolClientResolvedConfig, context: HandlerExecutionContext, input: object): Promise<RpcV2ProtocolHttpAuthSchemeParameters> => {
   return {
     operation: getSmithyContext(context).operation as string,
   };
@@ -44,13 +38,12 @@ function createSmithyApiNoAuthHttpAuthOption(authParameters: RpcV2ProtocolHttpAu
   return {
     schemeId: "smithy.api#noAuth",
   };
-}
+};
 
 /**
  * @internal
  */
-export interface RpcV2ProtocolHttpAuthSchemeProvider
-  extends HttpAuthSchemeProvider<RpcV2ProtocolHttpAuthSchemeParameters> {}
+export interface RpcV2ProtocolHttpAuthSchemeProvider extends HttpAuthSchemeProvider<RpcV2ProtocolHttpAuthSchemeParameters> {}
 
 /**
  * @internal
@@ -60,8 +53,8 @@ export const defaultRpcV2ProtocolHttpAuthSchemeProvider: RpcV2ProtocolHttpAuthSc
   switch (authParameters.operation) {
     default: {
       options.push(createSmithyApiNoAuthHttpAuthOption(authParameters));
-    }
-  }
+    };
+  };
   return options;
 };
 
@@ -88,6 +81,7 @@ export interface HttpAuthSchemeInputConfig {
    * @internal
    */
   httpAuthSchemeProvider?: RpcV2ProtocolHttpAuthSchemeProvider;
+
 }
 
 /**
@@ -113,15 +107,15 @@ export interface HttpAuthSchemeResolvedConfig {
    * @internal
    */
   readonly httpAuthSchemeProvider: RpcV2ProtocolHttpAuthSchemeProvider;
+
 }
 
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
-): T & HttpAuthSchemeResolvedConfig => {
-  return Object.assign(config, {
+export const resolveHttpAuthSchemeConfig = <T>(config: T & HttpAuthSchemeInputConfig): T & HttpAuthSchemeResolvedConfig => {
+  return Object.assign(
+    config, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { EmptyStructure } from "../models/models_0";
 import { EmptyInputOutput } from "../schemas/schemas_0";
@@ -54,31 +58,29 @@ export interface EmptyInputOutputCommandOutput extends EmptyStructure, __Metadat
  *
  *
  */
-export class EmptyInputOutputCommand extends $Command
-  .classBuilder<
-    EmptyInputOutputCommandInput,
-    EmptyInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class EmptyInputOutputCommand extends $Command.classBuilder<EmptyInputOutputCommandInput, EmptyInputOutputCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "EmptyInputOutput", {})
+  .s("RpcV2Protocol", "EmptyInputOutput", {
+
+  })
   .n("RpcV2ProtocolClient", "EmptyInputOutputCommand")
   .sc(EmptyInputOutput)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: {};
-    };
-    sdk: {
+  };
+  sdk: {
       input: EmptyInputOutputCommandInput;
       output: EmptyInputOutputCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { Float16Output } from "../models/models_0";
 import { Float16 } from "../schemas/schemas_0";
@@ -56,31 +60,29 @@ export interface Float16CommandOutput extends Float16Output, __MetadataBearer {}
  *
  *
  */
-export class Float16Command extends $Command
-  .classBuilder<
-    Float16CommandInput,
-    Float16CommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class Float16Command extends $Command.classBuilder<Float16CommandInput, Float16CommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "Float16", {})
+  .s("RpcV2Protocol", "Float16", {
+
+  })
   .n("RpcV2ProtocolClient", "Float16Command")
   .sc(Float16)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: Float16Output;
-    };
-    sdk: {
+  };
+  sdk: {
       input: Float16CommandInput;
       output: Float16CommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { FractionalSecondsOutput } from "../models/models_0";
 import { FractionalSeconds } from "../schemas/schemas_0";
@@ -56,31 +60,29 @@ export interface FractionalSecondsCommandOutput extends FractionalSecondsOutput,
  *
  *
  */
-export class FractionalSecondsCommand extends $Command
-  .classBuilder<
-    FractionalSecondsCommandInput,
-    FractionalSecondsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class FractionalSecondsCommand extends $Command.classBuilder<FractionalSecondsCommandInput, FractionalSecondsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "FractionalSeconds", {})
+  .s("RpcV2Protocol", "FractionalSeconds", {
+
+  })
   .n("RpcV2ProtocolClient", "FractionalSecondsCommand")
   .sc(FractionalSeconds)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: FractionalSecondsOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: FractionalSecondsCommandInput;
       output: FractionalSecondsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { GreetingWithErrorsOutput } from "../models/models_0";
 import { GreetingWithErrors } from "../schemas/schemas_0";
@@ -69,31 +73,29 @@ export interface GreetingWithErrorsCommandOutput extends GreetingWithErrorsOutpu
  *
  * @public
  */
-export class GreetingWithErrorsCommand extends $Command
-  .classBuilder<
-    GreetingWithErrorsCommandInput,
-    GreetingWithErrorsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class GreetingWithErrorsCommand extends $Command.classBuilder<GreetingWithErrorsCommandInput, GreetingWithErrorsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "GreetingWithErrors", {})
+  .s("RpcV2Protocol", "GreetingWithErrors", {
+
+  })
   .n("RpcV2ProtocolClient", "GreetingWithErrorsCommand")
   .sc(GreetingWithErrors)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: GreetingWithErrorsOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: GreetingWithErrorsCommandInput;
       output: GreetingWithErrorsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { NoInputOutput } from "../schemas/schemas_0";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
@@ -53,31 +57,29 @@ export interface NoInputOutputCommandOutput extends __MetadataBearer {}
  *
  *
  */
-export class NoInputOutputCommand extends $Command
-  .classBuilder<
-    NoInputOutputCommandInput,
-    NoInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class NoInputOutputCommand extends $Command.classBuilder<NoInputOutputCommandInput, NoInputOutputCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "NoInputOutput", {})
+  .s("RpcV2Protocol", "NoInputOutput", {
+
+  })
   .n("RpcV2ProtocolClient", "NoInputOutputCommand")
   .sc(NoInputOutput)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: {};
-    };
-    sdk: {
+  };
+  sdk: {
       input: NoInputOutputCommandInput;
       output: NoInputOutputCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
@@ -1,7 +1,14 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
-import { OperationWithDefaultsInput, OperationWithDefaultsOutput } from "../models/models_0";
+import {
+  OperationWithDefaultsInput,
+  OperationWithDefaultsOutput,
+} from "../models/models_0";
 import { OperationWithDefaults } from "../schemas/schemas_0";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -122,31 +129,29 @@ export interface OperationWithDefaultsCommandOutput extends OperationWithDefault
  *
  *
  */
-export class OperationWithDefaultsCommand extends $Command
-  .classBuilder<
-    OperationWithDefaultsCommandInput,
-    OperationWithDefaultsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class OperationWithDefaultsCommand extends $Command.classBuilder<OperationWithDefaultsCommandInput, OperationWithDefaultsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "OperationWithDefaults", {})
+  .s("RpcV2Protocol", "OperationWithDefaults", {
+
+  })
   .n("RpcV2ProtocolClient", "OperationWithDefaultsCommand")
   .sc(OperationWithDefaults)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: OperationWithDefaultsInput;
       output: OperationWithDefaultsOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: OperationWithDefaultsCommandInput;
       output: OperationWithDefaultsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { SimpleStructure } from "../models/models_0";
 import { OptionalInputOutput } from "../schemas/schemas_0";
@@ -58,31 +62,29 @@ export interface OptionalInputOutputCommandOutput extends SimpleStructure, __Met
  *
  *
  */
-export class OptionalInputOutputCommand extends $Command
-  .classBuilder<
-    OptionalInputOutputCommandInput,
-    OptionalInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class OptionalInputOutputCommand extends $Command.classBuilder<OptionalInputOutputCommandInput, OptionalInputOutputCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "OptionalInputOutput", {})
+  .s("RpcV2Protocol", "OptionalInputOutput", {
+
+  })
   .n("RpcV2ProtocolClient", "OptionalInputOutputCommand")
   .sc(OptionalInputOutput)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: SimpleStructure;
       output: SimpleStructure;
-    };
-    sdk: {
+  };
+  sdk: {
       input: OptionalInputOutputCommandInput;
       output: OptionalInputOutputCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RecursiveShapesInputOutput } from "../models/models_0";
 import { RecursiveShapes } from "../schemas/schemas_0";
@@ -82,31 +86,29 @@ export interface RecursiveShapesCommandOutput extends RecursiveShapesInputOutput
  *
  *
  */
-export class RecursiveShapesCommand extends $Command
-  .classBuilder<
-    RecursiveShapesCommandInput,
-    RecursiveShapesCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RecursiveShapesCommand extends $Command.classBuilder<RecursiveShapesCommandInput, RecursiveShapesCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RecursiveShapes", {})
+  .s("RpcV2Protocol", "RecursiveShapes", {
+
+  })
   .n("RpcV2ProtocolClient", "RecursiveShapesCommand")
   .sc(RecursiveShapes)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RecursiveShapesInputOutput;
       output: RecursiveShapesInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RecursiveShapesCommandInput;
       output: RecursiveShapesCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RpcV2CborDenseMapsInputOutput } from "../models/models_0";
 import { RpcV2CborDenseMaps } from "../schemas/schemas_0";
@@ -99,31 +103,29 @@ export interface RpcV2CborDenseMapsCommandOutput extends RpcV2CborDenseMapsInput
  *
  * @public
  */
-export class RpcV2CborDenseMapsCommand extends $Command
-  .classBuilder<
-    RpcV2CborDenseMapsCommandInput,
-    RpcV2CborDenseMapsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RpcV2CborDenseMapsCommand extends $Command.classBuilder<RpcV2CborDenseMapsCommandInput, RpcV2CborDenseMapsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RpcV2CborDenseMaps", {})
+  .s("RpcV2Protocol", "RpcV2CborDenseMaps", {
+
+  })
   .n("RpcV2ProtocolClient", "RpcV2CborDenseMapsCommand")
   .sc(RpcV2CborDenseMaps)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RpcV2CborDenseMapsInputOutput;
       output: RpcV2CborDenseMapsInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RpcV2CborDenseMapsCommandInput;
       output: RpcV2CborDenseMapsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RpcV2CborListInputOutput } from "../models/models_0";
 import { RpcV2CborLists } from "../schemas/schemas_0";
@@ -137,31 +141,29 @@ export interface RpcV2CborListsCommandOutput extends RpcV2CborListInputOutput, _
  *
  * @public
  */
-export class RpcV2CborListsCommand extends $Command
-  .classBuilder<
-    RpcV2CborListsCommandInput,
-    RpcV2CborListsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RpcV2CborListsCommand extends $Command.classBuilder<RpcV2CborListsCommandInput, RpcV2CborListsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RpcV2CborLists", {})
+  .s("RpcV2Protocol", "RpcV2CborLists", {
+
+  })
   .n("RpcV2ProtocolClient", "RpcV2CborListsCommand")
   .sc(RpcV2CborLists)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RpcV2CborListInputOutput;
       output: RpcV2CborListInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RpcV2CborListsCommandInput;
       output: RpcV2CborListsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RpcV2CborSparseMapsInputOutput } from "../models/models_0";
 import { RpcV2CborSparseMaps } from "../schemas/schemas_0";
@@ -99,31 +103,29 @@ export interface RpcV2CborSparseMapsCommandOutput extends RpcV2CborSparseMapsInp
  *
  *
  */
-export class RpcV2CborSparseMapsCommand extends $Command
-  .classBuilder<
-    RpcV2CborSparseMapsCommandInput,
-    RpcV2CborSparseMapsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RpcV2CborSparseMapsCommand extends $Command.classBuilder<RpcV2CborSparseMapsCommandInput, RpcV2CborSparseMapsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RpcV2CborSparseMaps", {})
+  .s("RpcV2Protocol", "RpcV2CborSparseMaps", {
+
+  })
   .n("RpcV2ProtocolClient", "RpcV2CborSparseMapsCommand")
   .sc(RpcV2CborSparseMaps)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RpcV2CborSparseMapsInputOutput;
       output: RpcV2CborSparseMapsInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RpcV2CborSparseMapsCommandInput;
       output: RpcV2CborSparseMapsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { SimpleScalarStructure } from "../models/models_0";
 import { SimpleScalarProperties } from "../schemas/schemas_0";
@@ -76,31 +80,29 @@ export interface SimpleScalarPropertiesCommandOutput extends SimpleScalarStructu
  *
  *
  */
-export class SimpleScalarPropertiesCommand extends $Command
-  .classBuilder<
-    SimpleScalarPropertiesCommandInput,
-    SimpleScalarPropertiesCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class SimpleScalarPropertiesCommand extends $Command.classBuilder<SimpleScalarPropertiesCommandInput, SimpleScalarPropertiesCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "SimpleScalarProperties", {})
+  .s("RpcV2Protocol", "SimpleScalarProperties", {
+
+  })
   .n("RpcV2ProtocolClient", "SimpleScalarPropertiesCommand")
   .sc(SimpleScalarProperties)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: SimpleScalarStructure;
       output: SimpleScalarStructure;
-    };
-    sdk: {
+  };
+  sdk: {
       input: SimpleScalarPropertiesCommandInput;
       output: SimpleScalarPropertiesCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { SparseNullsOperationInputOutput } from "../models/models_0";
 import { SparseNullsOperation } from "../schemas/schemas_0";
@@ -68,31 +72,29 @@ export interface SparseNullsOperationCommandOutput extends SparseNullsOperationI
  *
  *
  */
-export class SparseNullsOperationCommand extends $Command
-  .classBuilder<
-    SparseNullsOperationCommandInput,
-    SparseNullsOperationCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class SparseNullsOperationCommand extends $Command.classBuilder<SparseNullsOperationCommandInput, SparseNullsOperationCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "SparseNullsOperation", {})
+  .s("RpcV2Protocol", "SparseNullsOperation", {
+
+  })
   .n("RpcV2ProtocolClient", "SparseNullsOperationCommand")
   .sc(SparseNullsOperation)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: SparseNullsOperationInputOutput;
       output: SparseNullsOperationInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: SparseNullsOperationCommandInput;
       output: SparseNullsOperationCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor-schema/src/endpoint/EndpointParameters.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/endpoint/EndpointParameters.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { Endpoint, EndpointV2, Provider, EndpointParameters as __EndpointParameters } from "@smithy/types";
+import {
+  Endpoint,
+  EndpointV2,
+  Provider,
+  EndpointParameters as __EndpointParameters,
+} from "@smithy/types";
 
 /**
  * @public
@@ -9,20 +14,19 @@ export interface ClientInputEndpointParameters {
 }
 
 export type ClientResolvedEndpointParameters = Omit<ClientInputEndpointParameters, "endpoint"> & {
+
   defaultSigningName: string;
 };
 
-export const resolveClientEndpointParameters = <T>(
-  options: T & ClientInputEndpointParameters
-): T & ClientResolvedEndpointParameters => {
+export const resolveClientEndpointParameters = <T>(options: T & ClientInputEndpointParameters): T & ClientResolvedEndpointParameters => {
   return Object.assign(options, {
     defaultSigningName: "",
   });
-};
+}
 
 export const commonParams = {
   endpoint: { type: "builtInParams", name: "endpoint" },
-} as const;
+} as const
 
 export interface EndpointParameters extends __EndpointParameters {
   endpoint?: string | undefined;

--- a/private/smithy-rpcv2-cbor-schema/src/endpoint/endpointResolver.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/endpoint/endpointResolver.ts
@@ -1,22 +1,27 @@
 // smithy-typescript generated code
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
-import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointCache, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import {
+  EndpointV2,
+  Logger,
+} from "@smithy/types";
+import {
+  EndpointCache,
+  EndpointParams,
+  resolveEndpoint,
+} from "@smithy/util-endpoints";
 
 const cache = new EndpointCache({
-  size: 50,
-  params: ["endpoint"],
+    size: 50,
+    params: ["endpoint"]
 });
 
 export const defaultEndpointResolver = (
-  endpointParams: EndpointParameters,
-  context: { logger?: Logger } = {}
+    endpointParams: EndpointParameters,
+    context: { logger?: Logger } = {}
 ): EndpointV2 => {
-  return cache.get(endpointParams as EndpointParams, () =>
-    resolveEndpoint(ruleSet, {
-      endpointParams: endpointParams as EndpointParams,
-      logger: context.logger,
-    })
-  );
+    return cache.get(endpointParams as EndpointParams, () => resolveEndpoint(ruleSet, {
+        endpointParams: endpointParams as EndpointParams,
+        logger: context.logger,
+    }));
 };

--- a/private/smithy-rpcv2-cbor-schema/src/endpoint/ruleset.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/endpoint/ruleset.ts
@@ -1,38 +1,41 @@
 // smithy-typescript generated code
 import { RuleSetObject } from "@smithy/types";
 
-export const ruleSet: RuleSetObject = {
-  version: "1.0",
-  parameters: {
-    endpoint: {
-      type: "string",
-      builtIn: "SDK::Endpoint",
-      documentation: "Endpoint used for making requests. Should be formatted as a URI.",
-    },
-  },
-  rules: [
-    {
-      conditions: [
-        {
-          fn: "isSet",
-          argv: [
-            {
-              ref: "endpoint",
-            },
-          ],
-        },
-      ],
-      endpoint: {
-        url: {
-          ref: "endpoint",
-        },
+export const ruleSet: RuleSetObject =
+  {
+    "version": "1.0",
+    "parameters": {
+      "endpoint": {
+        "type": "string",
+        "builtIn": "SDK::Endpoint",
+        "documentation": "Endpoint used for making requests. Should be formatted as a URI.",
       },
-      type: "endpoint",
     },
-    {
-      conditions: [],
-      error: "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
-      type: "error",
-    },
-  ],
-};
+    "rules": [
+      {
+        "conditions": [
+          {
+            "fn": "isSet",
+            "argv": [
+              {
+                "ref": "endpoint",
+              },
+            ],
+          },
+        ],
+        "endpoint": {
+          "url": {
+            "ref": "endpoint",
+          },
+        },
+        "type": "endpoint",
+      },
+      {
+        "conditions": [
+        ],
+        "error": "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
+        "type": "error",
+      },
+    ],
+  }
+;

--- a/private/smithy-rpcv2-cbor-schema/src/extensionConfiguration.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/extensionConfiguration.ts
@@ -6,7 +6,4 @@ import { DefaultExtensionConfiguration } from "@smithy/types";
 /**
  * @internal
  */
-export interface RpcV2ProtocolExtensionConfiguration
-  extends HttpHandlerExtensionConfiguration,
-    DefaultExtensionConfiguration,
-    HttpAuthExtensionConfiguration {}
+export interface RpcV2ProtocolExtensionConfiguration extends HttpHandlerExtensionConfiguration, DefaultExtensionConfiguration, HttpAuthExtensionConfiguration {}

--- a/private/smithy-rpcv2-cbor-schema/src/models/RpcV2ProtocolServiceException.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/RpcV2ProtocolServiceException.ts
@@ -4,9 +4,9 @@ import {
   ServiceExceptionOptions as __ServiceExceptionOptions,
 } from "@smithy/smithy-client";
 
-export type { __ServiceExceptionOptions };
+export type { __ServiceExceptionOptions }
 
-export { __ServiceException };
+export { __ServiceException }
 
 /**
  * @public

--- a/private/smithy-rpcv2-cbor-schema/src/models/enums.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/enums.ts
@@ -7,11 +7,11 @@ export const TestEnum = {
   BAR: "BAR",
   BAZ: "BAZ",
   FOO: "FOO",
-} as const;
+} as const
 /**
  * @public
  */
-export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
+export type TestEnum = typeof TestEnum[keyof typeof TestEnum]
 
 export enum TestIntEnum {
   ONE = 1,
@@ -28,11 +28,11 @@ export const FooEnum = {
   FOO: "Foo",
   ONE: "1",
   ZERO: "0",
-} as const;
+} as const
 /**
  * @public
  */
-export type FooEnum = (typeof FooEnum)[keyof typeof FooEnum];
+export type FooEnum = typeof FooEnum[keyof typeof FooEnum]
 
 export enum IntegerEnum {
   A = 1,

--- a/private/smithy-rpcv2-cbor-schema/src/models/errors.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/errors.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { RpcV2ProtocolServiceException as __BaseException } from "./RpcV2ProtocolServiceException";
-import { ComplexNestedErrorData, ValidationExceptionField } from "./models_0";
+import {
+  ComplexNestedErrorData,
+  ValidationExceptionField,
+} from "./models_0";
 import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
 
 /**
@@ -17,7 +20,7 @@ export class ValidationException extends __BaseException {
    * A member can appear in this list more than once if it failed to satisfy multiple constraints.
    * @public
    */
-  fieldList?: ValidationExceptionField[] | undefined;
+  fieldList?: (ValidationExceptionField)[] | undefined;
 
   /**
    * @internal
@@ -26,7 +29,7 @@ export class ValidationException extends __BaseException {
     super({
       name: "ValidationException",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, ValidationException.prototype);
     this.fieldList = opts.fieldList;
@@ -49,7 +52,7 @@ export class ComplexError extends __BaseException {
     super({
       name: "ComplexError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, ComplexError.prototype);
     this.TopLevel = opts.TopLevel;
@@ -72,7 +75,7 @@ export class InvalidGreeting extends __BaseException {
     super({
       name: "InvalidGreeting",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, InvalidGreeting.prototype);
     this.Message = opts.Message;

--- a/private/smithy-rpcv2-cbor-schema/src/models/models_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/models/models_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { FooEnum, IntegerEnum, TestEnum, TestIntEnum } from "./enums";
+import {
+  FooEnum,
+  IntegerEnum,
+  TestEnum,
+  TestIntEnum,
+} from "./enums";
 
 /**
  * Describes one specific validation failure for an input member.
@@ -39,7 +44,7 @@ export interface ComplexNestedErrorData {
 export interface Defaults {
   defaultString?: string | undefined;
   defaultBoolean?: boolean | undefined;
-  defaultList?: string[] | undefined;
+  defaultList?: (string)[] | undefined;
   defaultTimestamp?: Date | undefined;
   defaultBlob?: Uint8Array | undefined;
   defaultByte?: number | undefined;
@@ -72,7 +77,8 @@ export interface GreetingStruct {
 /**
  * @public
  */
-export interface EmptyStructure {}
+export interface EmptyStructure {
+}
 
 /**
  * @public
@@ -111,7 +117,7 @@ export interface OperationWithDefaultsInput {
 export interface OperationWithDefaultsOutput {
   defaultString?: string | undefined;
   defaultBoolean?: boolean | undefined;
-  defaultList?: string[] | undefined;
+  defaultList?: (string)[] | undefined;
   defaultTimestamp?: Date | undefined;
   defaultBlob?: Uint8Array | undefined;
   defaultByte?: number | undefined;
@@ -149,7 +155,7 @@ export interface RpcV2CborDenseMapsInputOutput {
   denseNumberMap?: Record<string, number> | undefined;
   denseBooleanMap?: Record<string, boolean> | undefined;
   denseStringMap?: Record<string, string> | undefined;
-  denseSetMap?: Record<string, string[]> | undefined;
+  denseSetMap?: Record<string, (string)[]> | undefined;
 }
 
 /**
@@ -164,21 +170,21 @@ export interface StructureListMember {
  * @public
  */
 export interface RpcV2CborListInputOutput {
-  stringList?: string[] | undefined;
-  stringSet?: string[] | undefined;
-  integerList?: number[] | undefined;
-  booleanList?: boolean[] | undefined;
-  timestampList?: Date[] | undefined;
-  enumList?: FooEnum[] | undefined;
-  intEnumList?: IntegerEnum[] | undefined;
+  stringList?: (string)[] | undefined;
+  stringSet?: (string)[] | undefined;
+  integerList?: (number)[] | undefined;
+  booleanList?: (boolean)[] | undefined;
+  timestampList?: (Date)[] | undefined;
+  enumList?: (FooEnum)[] | undefined;
+  intEnumList?: (IntegerEnum)[] | undefined;
   /**
    * A list of lists of strings.
    * @public
    */
-  nestedStringList?: string[][] | undefined;
+  nestedStringList?: ((string)[])[] | undefined;
 
-  structureList?: StructureListMember[] | undefined;
-  blobList?: Uint8Array[] | undefined;
+  structureList?: (StructureListMember)[] | undefined;
+  blobList?: (Uint8Array)[] | undefined;
 }
 
 /**
@@ -189,7 +195,7 @@ export interface RpcV2CborSparseMapsInputOutput {
   sparseNumberMap?: Record<string, number> | undefined;
   sparseBooleanMap?: Record<string, boolean> | undefined;
   sparseStringMap?: Record<string, string> | undefined;
-  sparseSetMap?: Record<string, string[]> | undefined;
+  sparseSetMap?: Record<string, (string)[]> | undefined;
 }
 
 /**
@@ -212,7 +218,7 @@ export interface SimpleScalarStructure {
  * @public
  */
 export interface SparseNullsOperationInputOutput {
-  sparseStringList?: string[] | undefined;
+  sparseStringList?: (string)[] | undefined;
   sparseStringMap?: Record<string, string> | undefined;
 }
 

--- a/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.browser.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.browser.ts
@@ -1,8 +1,14 @@
 // smithy-typescript generated code
 import { Sha256 } from "@aws-crypto/sha256-browser";
-import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  FetchHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/fetch-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_MODE,
+} from "@smithy/util-retry";
 import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 import { loadConfigsForDefaultMode } from "@smithy/smithy-client";

--- a/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.shared.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.shared.ts
@@ -6,8 +6,14 @@ import { SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
 import { NoOpLogger } from "@smithy/smithy-client";
 import { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
-import { fromBase64, toBase64 } from "@smithy/util-base64";
-import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
+import {
+  fromBase64,
+  toBase64,
+} from "@smithy/util-base64";
+import {
+  fromUtf8,
+  toUtf8,
+} from "@smithy/util-utf8";
 import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
 
 /**
@@ -16,24 +22,22 @@ import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
 export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
   return {
     apiVersion: "2020-07-14",
-    base64Decoder: config?.base64Decoder ?? fromBase64,
-    base64Encoder: config?.base64Encoder ?? toBase64,
-    disableHostPrefix: config?.disableHostPrefix ?? false,
-    endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-    extensions: config?.extensions ?? [],
-    httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultRpcV2ProtocolHttpAuthSchemeProvider,
-    httpAuthSchemes: config?.httpAuthSchemes ?? [
-      {
+      base64Decoder: config?.base64Decoder ?? fromBase64,
+  base64Encoder: config?.base64Encoder ?? toBase64,
+  disableHostPrefix: config?.disableHostPrefix ?? false,
+  endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
+  extensions: config?.extensions ?? [],
+  httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultRpcV2ProtocolHttpAuthSchemeProvider,
+  httpAuthSchemes: config?.httpAuthSchemes ?? [{
         schemeId: "smithy.api#noAuth",
         identityProvider: (ipc: IdentityProviderConfig) =>
           ipc.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
         signer: new NoAuthSigner(),
-      },
-    ],
-    logger: config?.logger ?? new NoOpLogger(),
-    protocol: config?.protocol ?? new SmithyRpcV2CborProtocol({ defaultNamespace: "smithy.protocoltests.rpcv2Cbor" }),
-    urlParser: config?.urlParser ?? parseUrl,
-    utf8Decoder: config?.utf8Decoder ?? fromUtf8,
-    utf8Encoder: config?.utf8Encoder ?? toUtf8,
-  };
+      }],
+  logger: config?.logger ?? new NoOpLogger(),
+  protocol: config?.protocol ?? new SmithyRpcV2CborProtocol({ defaultNamespace: "smithy.protocoltests.rpcv2Cbor" }),
+  urlParser: config?.urlParser ?? parseUrl,
+  utf8Decoder: config?.utf8Decoder ?? fromUtf8,
+  utf8Encoder: config?.utf8Encoder ?? toUtf8,
+  }
 };

--- a/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.ts
@@ -1,8 +1,14 @@
 // smithy-typescript generated code
 import { Hash } from "@smithy/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
+import {
+  NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
+  NODE_RETRY_MODE_CONFIG_OPTIONS,
+} from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
-import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
+import {
+  NodeHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/node-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-node";
 import { DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
@@ -27,15 +33,7 @@ export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
-    retryMode:
-      config?.retryMode ??
-      loadNodeConfig(
-        {
-          ...NODE_RETRY_MODE_CONFIG_OPTIONS,
-          default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
-        },
-        config
-      ),
+    retryMode: config?.retryMode ?? loadNodeConfig({...NODE_RETRY_MODE_CONFIG_OPTIONS,default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,}, config),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };

--- a/private/smithy-rpcv2-cbor-schema/src/runtimeExtensions.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/runtimeExtensions.ts
@@ -1,39 +1,50 @@
 // smithy-typescript generated code
-import { getHttpAuthExtensionConfiguration, resolveHttpAuthRuntimeConfig } from "./auth/httpAuthExtensionConfiguration";
-import { getHttpHandlerExtensionConfiguration, resolveHttpHandlerRuntimeConfig } from "@smithy/protocol-http";
-import { getDefaultExtensionConfiguration, resolveDefaultRuntimeConfig } from "@smithy/smithy-client";
+import {
+  getHttpAuthExtensionConfiguration,
+  resolveHttpAuthRuntimeConfig,
+} from "./auth/httpAuthExtensionConfiguration";
+import {
+  getHttpHandlerExtensionConfiguration,
+  resolveHttpHandlerRuntimeConfig,
+} from "@smithy/protocol-http";
+import {
+  getDefaultExtensionConfiguration,
+  resolveDefaultRuntimeConfig,
+} from "@smithy/smithy-client";
 import { RpcV2ProtocolExtensionConfiguration } from "./extensionConfiguration";
 
 /**
  * @public
  */
 export interface RuntimeExtension {
-  configure(extensionConfiguration: RpcV2ProtocolExtensionConfiguration): void;
+    configure(extensionConfiguration: RpcV2ProtocolExtensionConfiguration): void;
 }
 
 /**
  * @public
  */
 export interface RuntimeExtensionsConfig {
-  extensions: RuntimeExtension[];
+    extensions: RuntimeExtension[]
 }
 
 /**
  * @internal
  */
-export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: RuntimeExtension[]) => {
+export const resolveRuntimeExtensions = (
+    runtimeConfig: any,
+    extensions: RuntimeExtension[]
+) => {
   const extensionConfiguration: RpcV2ProtocolExtensionConfiguration = Object.assign(
     getDefaultExtensionConfiguration(runtimeConfig),
     getHttpHandlerExtensionConfiguration(runtimeConfig),
-    getHttpAuthExtensionConfiguration(runtimeConfig)
+    getHttpAuthExtensionConfiguration(runtimeConfig),
   );
 
-  extensions.forEach((extension) => extension.configure(extensionConfiguration));
+  extensions.forEach(extension => extension.configure(extensionConfiguration));
 
-  return Object.assign(
-    runtimeConfig,
+  return Object.assign(runtimeConfig,
     resolveDefaultRuntimeConfig(extensionConfiguration),
     resolveHttpHandlerRuntimeConfig(extensionConfiguration),
-    resolveHttpAuthRuntimeConfig(extensionConfiguration)
+    resolveHttpAuthRuntimeConfig(extensionConfiguration),
   );
-};
+}

--- a/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
@@ -146,353 +146,511 @@ import {
   StaticStructureSchema,
 } from "@smithy/types";
 
-/* eslint no-var: 0 */
+    /* eslint no-var: 0 */
 
 export var __Unit = "unit" as const;
 
-export var ValidationException: StaticErrorSchema = [
-  -3,
-  n0,
-  _VE,
+export var ValidationException: StaticErrorSchema = [-3, n0, _VE,
   {
-    [_e]: _c,
-  },
-  [_m, _fL],
-  [0, () => ValidationExceptionFieldList],
+  [_e]: _c,}
+  , [
+  _m,
+  _fL,
+   ], [
+  0,
+  () => ValidationExceptionFieldList,
+  ]
 ];
 TypeRegistry.for(n0).registerError(ValidationException, __ValidationException);
 
-export var ValidationExceptionField: StaticStructureSchema = [3, n0, _VEF, 0, [_p, _m], [0, 0]];
-export var ClientOptionalDefaults: StaticStructureSchema = [3, n1, _COD, 0, [_me], [1]];
-export var ComplexError: StaticErrorSchema = [
-  -3,
-  n1,
-  _CE,
+export var ValidationExceptionField: StaticStructureSchema = [3, n0, _VEF,
+  0
+  , [
+  _p,
+  _m,
+   ], [
+  0,
+  0,
+  ]
+];
+export var ClientOptionalDefaults: StaticStructureSchema = [3, n1, _COD,
+  0
+  , [
+  _me,
+   ], [
+  1,
+  ]
+];
+export var ComplexError: StaticErrorSchema = [-3, n1, _CE,
   {
-    [_e]: _c,
-  },
-  [_TL, _N],
-  [0, () => ComplexNestedErrorData],
+  [_e]: _c,}
+  , [
+  _TL,
+  _N,
+   ], [
+  0,
+  () => ComplexNestedErrorData,
+  ]
 ];
 TypeRegistry.for(n1).registerError(ComplexError, __ComplexError);
 
-export var ComplexNestedErrorData: StaticStructureSchema = [3, n1, _CNED, 0, [_F], [0]];
-export var Defaults: StaticStructureSchema = [
-  3,
-  n1,
-  _D,
+export var ComplexNestedErrorData: StaticStructureSchema = [3, n1, _CNED,
+  0
+  , [
+  _F,
+   ], [
   0,
-  [
-    _dS,
-    _dB,
-    _dL,
-    _dT,
-    _dBe,
-    _dBef,
-    _dSe,
-    _dI,
-    _dLe,
-    _dF,
-    _dD,
-    _dM,
-    _dE,
-    _dIE,
-    _eS,
-    _fB,
-    _eB,
-    _zB,
-    _zS,
-    _zI,
-    _zL,
-    _zF,
-    _zD,
-  ],
-  [0, 2, 64 | 0, 4, 21, 1, 1, 1, 1, 1, 1, 128 | 0, 0, 1, 0, 2, 21, 1, 1, 1, 1, 1, 1],
+  ]
 ];
-export var EmptyStructure: StaticStructureSchema = [3, n1, _ES, 0, [], []];
-export var Float16Output: StaticStructureSchema = [3, n1, _FO, 0, [_v], [1]];
-export var FractionalSecondsOutput: StaticStructureSchema = [3, n1, _FSO, 0, [_d], [5]];
-export var GreetingWithErrorsOutput: StaticStructureSchema = [3, n1, _GWEO, 0, [_g], [0]];
-export var InvalidGreeting: StaticErrorSchema = [
-  -3,
-  n1,
-  _IG,
+export var Defaults: StaticStructureSchema = [3, n1, _D,
+  0
+  , [
+  _dS,
+  _dB,
+  _dL,
+  _dT,
+  _dBe,
+  _dBef,
+  _dSe,
+  _dI,
+  _dLe,
+  _dF,
+  _dD,
+  _dM,
+  _dE,
+  _dIE,
+  _eS,
+  _fB,
+  _eB,
+  _zB,
+  _zS,
+  _zI,
+  _zL,
+  _zF,
+  _zD,
+   ], [
+  0,
+  2,
+  64|0,
+  4,
+  21,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  128|0,
+  0,
+  1,
+  0,
+  2,
+  21,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  ]
+];
+export var EmptyStructure: StaticStructureSchema = [3, n1, _ES,
+  0
+  , [
+   ], [
+  ]
+];
+export var Float16Output: StaticStructureSchema = [3, n1, _FO,
+  0
+  , [
+  _v,
+   ], [
+  1,
+  ]
+];
+export var FractionalSecondsOutput: StaticStructureSchema = [3, n1, _FSO,
+  0
+  , [
+  _d,
+   ], [
+  5,
+  ]
+];
+export var GreetingWithErrorsOutput: StaticStructureSchema = [3, n1, _GWEO,
+  0
+  , [
+  _g,
+   ], [
+  0,
+  ]
+];
+export var InvalidGreeting: StaticErrorSchema = [-3, n1, _IG,
   {
-    [_e]: _c,
-  },
-  [_M],
-  [0],
+  [_e]: _c,}
+  , [
+  _M,
+   ], [
+  0,
+  ]
 ];
 TypeRegistry.for(n1).registerError(InvalidGreeting, __InvalidGreeting);
 
-export var OperationWithDefaultsInput: StaticStructureSchema = [
-  3,
-  n1,
-  _OWDI,
+export var OperationWithDefaultsInput: StaticStructureSchema = [3, n1, _OWDI,
+  0
+  , [
+  _de,
+  _cOD,
+  _tLD,
+  _oTLD,
+   ], [
+  () => Defaults,
+  () => ClientOptionalDefaults,
   0,
-  [_de, _cOD, _tLD, _oTLD],
-  [() => Defaults, () => ClientOptionalDefaults, 0, 1],
+  1,
+  ]
 ];
-export var OperationWithDefaultsOutput: StaticStructureSchema = [
-  3,
-  n1,
-  _OWDO,
+export var OperationWithDefaultsOutput: StaticStructureSchema = [3, n1, _OWDO,
+  0
+  , [
+  _dS,
+  _dB,
+  _dL,
+  _dT,
+  _dBe,
+  _dBef,
+  _dSe,
+  _dI,
+  _dLe,
+  _dF,
+  _dD,
+  _dM,
+  _dE,
+  _dIE,
+  _eS,
+  _fB,
+  _eB,
+  _zB,
+  _zS,
+  _zI,
+  _zL,
+  _zF,
+  _zD,
+   ], [
   0,
-  [
-    _dS,
-    _dB,
-    _dL,
-    _dT,
-    _dBe,
-    _dBef,
-    _dSe,
-    _dI,
-    _dLe,
-    _dF,
-    _dD,
-    _dM,
-    _dE,
-    _dIE,
-    _eS,
-    _fB,
-    _eB,
-    _zB,
-    _zS,
-    _zI,
-    _zL,
-    _zF,
-    _zD,
+  2,
+  64|0,
+  4,
+  21,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  128|0,
+  0,
+  1,
+  0,
+  2,
+  21,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  ]
+];
+export var RecursiveShapesInputOutput: StaticStructureSchema = [3, n1, _RSIO,
+  0
+  , [
+  _n,
+   ], [
+  () => RecursiveShapesInputOutputNested1,
+  ]
+];
+export var RecursiveShapesInputOutputNested1: StaticStructureSchema = [3, n1, _RSION,
+  0
+  , [
+  _f,
+  _n,
+   ], [
+  0,
+  () => RecursiveShapesInputOutputNested2,
+  ]
+];
+export var RecursiveShapesInputOutputNested2: StaticStructureSchema = [3, n1, _RSIONe,
+  0
+  , [
+  _b,
+  _rM,
+   ], [
+  0,
+  () => RecursiveShapesInputOutputNested1,
+  ]
+];
+export var RpcV2CborDenseMapsInputOutput: StaticStructureSchema = [3, n1, _RVCDMIO,
+  0
+  , [
+  _dSM,
+  _dNM,
+  _dBM,
+  _dSMe,
+  _dSMen,
+   ], [
+  () => DenseStructMap,
+  128|1,
+  128|2,
+  128|0,
+  [2, n1, _DSM, 0, 0, 64|0],
+  ]
+];
+export var RpcV2CborListInputOutput: StaticStructureSchema = [3, n1, _RVCLIO,
+  0
+  , [
+  _sL,
+  _sS,
+  _iL,
+  _bL,
+  _tL,
+  _eL,
+  _iEL,
+  _nSL,
+  _sLt,
+  _bLl,
+   ], [
+  64|0,
+  64|0,
+  64|1,
+  64|2,
+  64|4,
+  64|0,
+  64|1,
+  [1, n2, _NSL, 0, 64|0],
+  () => StructureList,
+  64|21,
+  ]
+];
+export var RpcV2CborSparseMapsInputOutput: StaticStructureSchema = [3, n1, _RVCSMIO,
+  0
+  , [
+  _sSM,
+  _sNM,
+  _sBM,
+  _sSMp,
+  _sSMpa,
+   ], [
+  [() => SparseStructMap,
+    0
   ],
-  [0, 2, 64 | 0, 4, 21, 1, 1, 1, 1, 1, 1, 128 | 0, 0, 1, 0, 2, 21, 1, 1, 1, 1, 1, 1],
-];
-export var RecursiveShapesInputOutput: StaticStructureSchema = [
-  3,
-  n1,
-  _RSIO,
-  0,
-  [_n],
-  [() => RecursiveShapesInputOutputNested1],
-];
-export var RecursiveShapesInputOutputNested1: StaticStructureSchema = [
-  3,
-  n1,
-  _RSION,
-  0,
-  [_f, _n],
-  [0, () => RecursiveShapesInputOutputNested2],
-];
-export var RecursiveShapesInputOutputNested2: StaticStructureSchema = [
-  3,
-  n1,
-  _RSIONe,
-  0,
-  [_b, _rM],
-  [0, () => RecursiveShapesInputOutputNested1],
-];
-export var RpcV2CborDenseMapsInputOutput: StaticStructureSchema = [
-  3,
-  n1,
-  _RVCDMIO,
-  0,
-  [_dSM, _dNM, _dBM, _dSMe, _dSMen],
-  [() => DenseStructMap, 128 | 1, 128 | 2, 128 | 0, [2, n1, _DSM, 0, 0, 64 | 0]],
-];
-export var RpcV2CborListInputOutput: StaticStructureSchema = [
-  3,
-  n1,
-  _RVCLIO,
-  0,
-  [_sL, _sS, _iL, _bL, _tL, _eL, _iEL, _nSL, _sLt, _bLl],
-  [64 | 0, 64 | 0, 64 | 1, 64 | 2, 64 | 4, 64 | 0, 64 | 1, [1, n2, _NSL, 0, 64 | 0], () => StructureList, 64 | 21],
-];
-export var RpcV2CborSparseMapsInputOutput: StaticStructureSchema = [
-  3,
-  n1,
-  _RVCSMIO,
-  0,
-  [_sSM, _sNM, _sBM, _sSMp, _sSMpa],
-  [
-    [() => SparseStructMap, 0],
-    [() => SparseNumberMap, 0],
-    [() => SparseBooleanMap, 0],
-    [() => SparseStringMap, 0],
-    [() => SparseSetMap, 0],
+  [() => SparseNumberMap,
+    0
   ],
-];
-export var SimpleScalarStructure: StaticStructureSchema = [
-  3,
-  n1,
-  _SSS,
-  0,
-  [_tBV, _fBV, _bV, _dV, _fV, _iV, _lV, _sV, _sVt, _bVl],
-  [2, 2, 1, 1, 1, 1, 1, 1, 0, 21],
-];
-export var SimpleStructure: StaticStructureSchema = [3, n1, _SS, 0, [_v], [0]];
-export var SparseNullsOperationInputOutput: StaticStructureSchema = [
-  3,
-  n1,
-  _SNOIO,
-  0,
-  [_sSL, _sSMp],
-  [
-    [() => SparseStringList, 0],
-    [() => SparseStringMap, 0],
+  [() => SparseBooleanMap,
+    0
   ],
+  [() => SparseStringMap,
+    0
+  ],
+  [() => SparseSetMap,
+    0
+  ],
+  ]
 ];
-export var StructureListMember: StaticStructureSchema = [3, n1, _SLM, 0, [_a, _b_], [0, 0]];
-export var GreetingStruct: StaticStructureSchema = [3, n2, _GS, 0, [_h], [0]];
+export var SimpleScalarStructure: StaticStructureSchema = [3, n1, _SSS,
+  0
+  , [
+  _tBV,
+  _fBV,
+  _bV,
+  _dV,
+  _fV,
+  _iV,
+  _lV,
+  _sV,
+  _sVt,
+  _bVl,
+   ], [
+  2,
+  2,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  0,
+  21,
+  ]
+];
+export var SimpleStructure: StaticStructureSchema = [3, n1, _SS,
+  0
+  , [
+  _v,
+   ], [
+  0,
+  ]
+];
+export var SparseNullsOperationInputOutput: StaticStructureSchema = [3, n1, _SNOIO,
+  0
+  , [
+  _sSL,
+  _sSMp,
+   ], [
+  [() => SparseStringList,
+    0
+  ],
+  [() => SparseStringMap,
+    0
+  ],
+  ]
+];
+export var StructureListMember: StaticStructureSchema = [3, n1, _SLM,
+  0
+  , [
+  _a,
+  _b_,
+   ], [
+  0,
+  0,
+  ]
+];
+export var GreetingStruct: StaticStructureSchema = [3, n2, _GS,
+  0
+  , [
+  _h,
+   ], [
+  0,
+  ]
+];
 export var RpcV2ProtocolServiceException: StaticErrorSchema = [-3, _sC, "RpcV2ProtocolServiceException", 0, [], []];
 TypeRegistry.for(_sC).registerError(RpcV2ProtocolServiceException, __RpcV2ProtocolServiceException);
 
-export var ValidationExceptionFieldList: StaticListSchema = [1, n0, _VEFL, 0, () => ValidationExceptionField];
-export var StructureList: StaticListSchema = [1, n1, _SL, 0, () => StructureListMember];
-export var TestStringList = 64 | 0;
+export var ValidationExceptionFieldList: StaticListSchema = [1, n0, _VEFL,
+  0
+  , () => ValidationExceptionField
+];
+export var StructureList: StaticListSchema = [1, n1, _SL,
+  0
+  , () => StructureListMember
+];
+export var TestStringList = 64|0;
 
-export var BlobList = 64 | 21;
+export var BlobList = 64|21;
 
-export var BooleanList = 64 | 2;
+export var BooleanList = 64|2;
 
-export var FooEnumList = 64 | 0;
+export var FooEnumList = 64|0;
 
-export var IntegerEnumList = 64 | 1;
+export var IntegerEnumList = 64|1;
 
-export var IntegerList = 64 | 1;
+export var IntegerList = 64|1;
 
-export var NestedStringList: StaticListSchema = [1, n2, _NSL, 0, 64 | 0];
-export var SparseStringList: StaticListSchema = [
-  1,
-  n2,
-  _SSL,
+export var NestedStringList: StaticListSchema = [1, n2, _NSL,
+  0
+  , 64|0
+];
+export var SparseStringList: StaticListSchema = [1, n2, _SSL,
   {
-    [_s]: 1,
-  },
-  0,
+  [_s]: 1,}
+  , 0
 ];
-export var StringList = 64 | 0;
+export var StringList = 64|0;
 
-export var StringSet = 64 | 0;
+export var StringSet = 64|0;
 
-export var TimestampList = 64 | 4;
+export var TimestampList = 64|4;
 
-export var DenseBooleanMap = 128 | 2;
+export var DenseBooleanMap = 128|2;
 
-export var DenseNumberMap = 128 | 1;
+export var DenseNumberMap = 128|1;
 
-export var DenseSetMap: StaticMapSchema = [2, n1, _DSM, 0, 0, 64 | 0];
-export var DenseStringMap = 128 | 0;
+export var DenseSetMap: StaticMapSchema = [2, n1, _DSM,
+  0
+  , 0, 64|0
+];
+export var DenseStringMap = 128|0;
 
-export var DenseStructMap: StaticMapSchema = [2, n1, _DSMe, 0, 0, () => GreetingStruct];
-export var SparseBooleanMap: StaticMapSchema = [
-  2,
-  n1,
-  _SBM,
+export var DenseStructMap: StaticMapSchema = [2, n1, _DSMe,
+  0
+  , 0, () => GreetingStruct
+];
+export var SparseBooleanMap: StaticMapSchema = [2, n1, _SBM,
   {
-    [_s]: 1,
-  },
-  0,
-  2,
+  [_s]: 1,}
+  , 0, 2
 ];
-export var SparseNumberMap: StaticMapSchema = [
-  2,
-  n1,
-  _SNM,
+export var SparseNumberMap: StaticMapSchema = [2, n1, _SNM,
   {
-    [_s]: 1,
-  },
-  0,
-  1,
+  [_s]: 1,}
+  , 0, 1
 ];
-export var SparseSetMap: StaticMapSchema = [
-  2,
-  n1,
-  _SSM,
+export var SparseSetMap: StaticMapSchema = [2, n1, _SSM,
   {
-    [_s]: 1,
-  },
-  0,
-  64 | 0,
+  [_s]: 1,}
+  , 0, 64|0
 ];
-export var SparseStructMap: StaticMapSchema = [
-  2,
-  n1,
-  _SSMp,
+export var SparseStructMap: StaticMapSchema = [2, n1, _SSMp,
   {
-    [_s]: 1,
-  },
-  0,
-  () => GreetingStruct,
+  [_s]: 1,}
+  , 0, () => GreetingStruct
 ];
-export var TestStringMap = 128 | 0;
+export var TestStringMap = 128|0;
 
-export var SparseStringMap: StaticMapSchema = [
-  2,
-  n2,
-  _SSMpa,
+export var SparseStringMap: StaticMapSchema = [2, n2, _SSMpa,
   {
-    [_s]: 1,
-  },
-  0,
-  0,
+  [_s]: 1,}
+  , 0, 0
 ];
-export var EmptyInputOutput: StaticOperationSchema = [9, n1, _EIO, 0, () => EmptyStructure, () => EmptyStructure];
-export var Float16: StaticOperationSchema = [9, n1, _Fl, 0, () => __Unit, () => Float16Output];
-export var FractionalSeconds: StaticOperationSchema = [9, n1, _FS, 0, () => __Unit, () => FractionalSecondsOutput];
-export var GreetingWithErrors: StaticOperationSchema = [9, n1, _GWE, 2, () => __Unit, () => GreetingWithErrorsOutput];
-export var NoInputOutput: StaticOperationSchema = [9, n1, _NIO, 0, () => __Unit, () => __Unit];
-export var OperationWithDefaults: StaticOperationSchema = [
-  9,
-  n1,
-  _OWD,
-  0,
-  () => OperationWithDefaultsInput,
-  () => OperationWithDefaultsOutput,
+export var EmptyInputOutput: StaticOperationSchema = [9, n1, _EIO,
+  0
+  , () => EmptyStructure, () => EmptyStructure
 ];
-export var OptionalInputOutput: StaticOperationSchema = [9, n1, _OIO, 0, () => SimpleStructure, () => SimpleStructure];
-export var RecursiveShapes: StaticOperationSchema = [
-  9,
-  n1,
-  _RS,
-  0,
-  () => RecursiveShapesInputOutput,
-  () => RecursiveShapesInputOutput,
+export var Float16: StaticOperationSchema = [9, n1, _Fl,
+  0
+  , () => __Unit, () => Float16Output
 ];
-export var RpcV2CborDenseMaps: StaticOperationSchema = [
-  9,
-  n1,
-  _RVCDM,
-  0,
-  () => RpcV2CborDenseMapsInputOutput,
-  () => RpcV2CborDenseMapsInputOutput,
+export var FractionalSeconds: StaticOperationSchema = [9, n1, _FS,
+  0
+  , () => __Unit, () => FractionalSecondsOutput
 ];
-export var RpcV2CborLists: StaticOperationSchema = [
-  9,
-  n1,
-  _RVCL,
-  2,
-  () => RpcV2CborListInputOutput,
-  () => RpcV2CborListInputOutput,
+export var GreetingWithErrors: StaticOperationSchema = [9, n1, _GWE,
+  2
+  , () => __Unit, () => GreetingWithErrorsOutput
 ];
-export var RpcV2CborSparseMaps: StaticOperationSchema = [
-  9,
-  n1,
-  _RVCSM,
-  0,
-  () => RpcV2CborSparseMapsInputOutput,
-  () => RpcV2CborSparseMapsInputOutput,
+export var NoInputOutput: StaticOperationSchema = [9, n1, _NIO,
+  0
+  , () => __Unit, () => __Unit
 ];
-export var SimpleScalarProperties: StaticOperationSchema = [
-  9,
-  n1,
-  _SSP,
-  0,
-  () => SimpleScalarStructure,
-  () => SimpleScalarStructure,
+export var OperationWithDefaults: StaticOperationSchema = [9, n1, _OWD,
+  0
+  , () => OperationWithDefaultsInput, () => OperationWithDefaultsOutput
 ];
-export var SparseNullsOperation: StaticOperationSchema = [
-  9,
-  n1,
-  _SNO,
-  0,
-  () => SparseNullsOperationInputOutput,
-  () => SparseNullsOperationInputOutput,
+export var OptionalInputOutput: StaticOperationSchema = [9, n1, _OIO,
+  0
+  , () => SimpleStructure, () => SimpleStructure
+];
+export var RecursiveShapes: StaticOperationSchema = [9, n1, _RS,
+  0
+  , () => RecursiveShapesInputOutput, () => RecursiveShapesInputOutput
+];
+export var RpcV2CborDenseMaps: StaticOperationSchema = [9, n1, _RVCDM,
+  0
+  , () => RpcV2CborDenseMapsInputOutput, () => RpcV2CborDenseMapsInputOutput
+];
+export var RpcV2CborLists: StaticOperationSchema = [9, n1, _RVCL,
+  2
+  , () => RpcV2CborListInputOutput, () => RpcV2CborListInputOutput
+];
+export var RpcV2CborSparseMaps: StaticOperationSchema = [9, n1, _RVCSM,
+  0
+  , () => RpcV2CborSparseMapsInputOutput, () => RpcV2CborSparseMapsInputOutput
+];
+export var SimpleScalarProperties: StaticOperationSchema = [9, n1, _SSP,
+  0
+  , () => SimpleScalarStructure, () => SimpleScalarStructure
+];
+export var SparseNullsOperation: StaticOperationSchema = [9, n1, _SNO,
+  0
+  , () => SparseNullsOperationInputOutput, () => SparseNullsOperationInputOutput
 ];

--- a/private/smithy-rpcv2-cbor-schema/test/functional/rpcv2cbor.spec.ts
+++ b/private/smithy-rpcv2-cbor-schema/test/functional/rpcv2cbor.spec.ts
@@ -14,7 +14,10 @@ import { RpcV2CborSparseMapsCommand } from "../../src/commands/RpcV2CborSparseMa
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
 import { SparseNullsOperationCommand } from "../../src/commands/SparseNullsOperationCommand";
 import { cbor } from "@smithy/core/cbor";
-import { expect, test as it } from "vitest";
+import {
+  expect,
+  test as it,
+} from "vitest";
 import { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
 import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "stream";
@@ -223,10 +226,13 @@ it("empty_input:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new EmptyInputOutputCommand({} as any);
+  const command = new EmptyInputOutputCommand(
+  {
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -237,8 +243,8 @@ it("empty_input:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/EmptyInputOutput");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(
@@ -267,11 +273,11 @@ it("empty_output:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -284,7 +290,7 @@ it("empty_output:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -297,11 +303,11 @@ it("empty_output_no_body:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      ``
-    ),
+      ``,
+    )
   });
 
   const params: any = {};
@@ -314,7 +320,7 @@ it("empty_output_no_body:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -327,11 +333,11 @@ it("RpcV2CborFloat16Inf:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfl8AA==`
-    ),
+      `oWV2YWx1Zfl8AA==`,
+    )
   });
 
   const params: any = {};
@@ -344,16 +350,17 @@ it("RpcV2CborFloat16Inf:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: Infinity,
-    },
+  {
+    "value":
+    Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -369,11 +376,11 @@ it("RpcV2CborFloat16NegInf:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfn8AA==`
-    ),
+      `oWV2YWx1Zfn8AA==`,
+    )
   });
 
   const params: any = {};
@@ -386,16 +393,17 @@ it("RpcV2CborFloat16NegInf:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: -Infinity,
-    },
+  {
+    "value":
+    -Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -411,11 +419,11 @@ it("RpcV2CborFloat16LSBNaN:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfl8AQ==`
-    ),
+      `oWV2YWx1Zfl8AQ==`,
+    )
   });
 
   const params: any = {};
@@ -428,16 +436,17 @@ it("RpcV2CborFloat16LSBNaN:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: NaN,
-    },
+  {
+    "value":
+    NaN,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -453,11 +462,11 @@ it("RpcV2CborFloat16MSBNaN:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfl+AA==`
-    ),
+      `oWV2YWx1Zfl+AA==`,
+    )
   });
 
   const params: any = {};
@@ -470,16 +479,17 @@ it("RpcV2CborFloat16MSBNaN:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: NaN,
-    },
+  {
+    "value":
+    NaN,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -495,11 +505,11 @@ it("RpcV2CborFloat16Subnormal:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1ZfkAUA==`
-    ),
+      `oWV2YWx1ZfkAUA==`,
+    )
   });
 
   const params: any = {};
@@ -512,16 +522,17 @@ it("RpcV2CborFloat16Subnormal:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: 4.76837158203125e-6,
-    },
+  {
+    "value":
+    4.76837158203125E-6,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -537,11 +548,11 @@ it("RpcV2CborDateTimeWithFractionalSeconds:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2hkYXRldGltZcH7Qcw32zgPvnf/`
-    ),
+      `v2hkYXRldGltZcH7Qcw32zgPvnf/`,
+    )
   });
 
   const params: any = {};
@@ -554,16 +565,17 @@ it("RpcV2CborDateTimeWithFractionalSeconds:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      datetime: new Date(9.46845296123e8 * 1000),
-    },
+  {
+    "datetime":
+    new Date(9.46845296123E8 * 1000),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -572,18 +584,18 @@ it("RpcV2CborDateTimeWithFractionalSeconds:Response", async () => {
 /**
  * Parses simple RpcV2 Cbor errors
  */
-it.skip("RpcV2CborInvalidGreetingError:Error:GreetingWithErrors", async () => {
+it.skip("RpcV2CborInvalidGreetingError:Error:GreetingWithErrors", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZfX3R5cGV4LnNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNJbnZhbGlkR3JlZXRpbmdnTWVzc2FnZWJIaf8=`
-    ),
+      `v2ZfX3R5cGV4LnNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNJbnZhbGlkR3JlZXRpbmdnTWVzc2FnZWJIaf8=`,
+    )
   });
 
   const params: any = {};
@@ -598,39 +610,40 @@ it.skip("RpcV2CborInvalidGreetingError:Error:GreetingWithErrors", async () => {
       return;
     }
     const r: any = err;
-    expect(r["$metadata"].httpStatusCode).toBe(400);
+    expect(r['$metadata'].httpStatusCode).toBe(400);
     const paramsToValidate: any = [
-      {
-        message: "Hi",
-      },
+    {
+      "message":
+      "Hi",
+    },
     ][0];
-    Object.keys(paramsToValidate).forEach((param) => {
+    Object.keys(paramsToValidate).forEach(param => {
       expect(
-        r[param],
-        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+          r[param],
+          `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
       ).toBeDefined();
       expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
     });
     return;
   }
-  fail("Expected an exception to be thrown from response");
+  fail('Expected an exception to be thrown from response');
 });
 
 /**
  * Parses a complex error with no message member
  */
-it.skip("RpcV2CborComplexError:Error:GreetingWithErrors", async () => {
+it.skip("RpcV2CborComplexError:Error:GreetingWithErrors", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3JoVG9wTGV2ZWxpVG9wIGxldmVsZk5lc3RlZL9jRm9vY2Jhcv//`
-    ),
+      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3JoVG9wTGV2ZWxpVG9wIGxldmVsZk5lc3RlZL9jRm9vY2Jhcv//`,
+    )
   });
 
   const params: any = {};
@@ -645,39 +658,42 @@ it.skip("RpcV2CborComplexError:Error:GreetingWithErrors", async () => {
       return;
     }
     const r: any = err;
-    expect(r["$metadata"].httpStatusCode).toBe(400);
+    expect(r['$metadata'].httpStatusCode).toBe(400);
     const paramsToValidate: any = [
+    {
+      "TopLevel":
+      "Top level",
+      "Nested":
       {
-        TopLevel: "Top level",
-        Nested: {
-          Foo: "bar",
-        },
+        "Foo":
+        "bar",
       },
+    },
     ][0];
-    Object.keys(paramsToValidate).forEach((param) => {
+    Object.keys(paramsToValidate).forEach(param => {
       expect(
-        r[param],
-        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+          r[param],
+          `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
       ).toBeDefined();
       expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
     });
     return;
   }
-  fail("Expected an exception to be thrown from response");
+  fail('Expected an exception to be thrown from response');
 });
 
-it.skip("RpcV2CborEmptyComplexError:Error:GreetingWithErrors", async () => {
+it.skip("RpcV2CborEmptyComplexError:Error:GreetingWithErrors", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3L/`
-    ),
+      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3L/`,
+    )
   });
 
   const params: any = {};
@@ -692,10 +708,10 @@ it.skip("RpcV2CborEmptyComplexError:Error:GreetingWithErrors", async () => {
       return;
     }
     const r: any = err;
-    expect(r["$metadata"].httpStatusCode).toBe(400);
+    expect(r['$metadata'].httpStatusCode).toBe(400);
     return;
   }
-  fail("Expected an exception to be thrown from response");
+  fail('Expected an exception to be thrown from response');
 });
 
 /**
@@ -710,7 +726,7 @@ it("no_input:Request", async () => {
   const command = new NoInputOutputCommand({});
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -747,10 +763,10 @@ it("no_output:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
+          "smithy-protocol": "rpc-v2-cbor"
       },
-      ``
-    ),
+      ``,
+    )
   });
 
   const params: any = {};
@@ -763,7 +779,7 @@ it("no_output:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -776,11 +792,11 @@ it("NoOutputClientAllowsEmptyCbor:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -793,7 +809,7 @@ it("NoOutputClientAllowsEmptyCbor:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -807,11 +823,11 @@ it("NoOutputClientAllowsEmptyBody:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      ``
-    ),
+      ``,
+    )
   });
 
   const params: any = {};
@@ -824,24 +840,27 @@ it("NoOutputClientAllowsEmptyBody:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
  * Client populates default values in input.
  */
-it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async () => {
+it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    defaults: {} as any,
-  } as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+    "defaults": {
+    } as any,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -852,8 +871,8 @@ it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -870,16 +889,19 @@ it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async () => {
 /**
  * Client skips top level default values in input.
  */
-it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async () => {
+it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({} as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -890,8 +912,8 @@ it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async () => 
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -908,44 +930,48 @@ it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async () => 
 /**
  * Client uses explicitly provided member values over defaults
  */
-it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request", async () => {
+it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    defaults: {
-      defaultString: "bye",
-      defaultBoolean: true,
-      defaultList: ["a"],
-      defaultTimestamp: new Date(1000),
-      defaultBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      defaultByte: 2,
-      defaultShort: 2,
-      defaultInteger: 20,
-      defaultLong: 200,
-      defaultFloat: 2.0,
-      defaultDouble: 2.0,
-      defaultMap: {
-        name: "Jack",
+  const command = new OperationWithDefaultsCommand(
+  {
+    "defaults": {
+      "defaultString": "bye",
+      "defaultBoolean": true,
+      "defaultList": [
+        "a",
+      ],
+      "defaultTimestamp": new Date(1000),
+      "defaultBlob": Uint8Array.from("hi", c => c.charCodeAt(0)),
+      "defaultByte": 2,
+      "defaultShort": 2,
+      "defaultInteger": 20,
+      "defaultLong": 200,
+      "defaultFloat": 2.0,
+      "defaultDouble": 2.0,
+      "defaultMap": {
+        "name": "Jack",
       } as any,
-      defaultEnum: "BAR",
-      defaultIntEnum: 2,
-      emptyString: "foo",
-      falseBoolean: true,
-      emptyBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      zeroByte: 1,
-      zeroShort: 1,
-      zeroInteger: 1,
-      zeroLong: 1,
-      zeroFloat: 1.0,
-      zeroDouble: 1.0,
+      "defaultEnum": "BAR",
+      "defaultIntEnum": 2,
+      "emptyString": "foo",
+      "falseBoolean": true,
+      "emptyBlob": Uint8Array.from("hi", c => c.charCodeAt(0)),
+      "zeroByte": 1,
+      "zeroShort": 1,
+      "zeroInteger": 1,
+      "zeroLong": 1,
+      "zeroFloat": 1.0,
+      "zeroDouble": 1.0,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -956,8 +982,8 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request",
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -974,19 +1000,21 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request",
 /**
  * Any time a value is provided for a member in the top level of input, it is used, regardless of if its the default.
  */
-it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async () => {
+it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    topLevelDefault: "hi",
-    otherTopLevelDefault: 0,
-  } as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+    "topLevelDefault": "hi",
+    "otherTopLevelDefault": 0,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -997,8 +1025,8 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async (
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1015,18 +1043,21 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async (
 /**
  * Typically, non top-level members would have defaults filled in, but if they have the clientOptional trait, the defaults should be ignored.
  */
-it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Request", async () => {
+it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    clientOptionalDefaults: {} as any,
-  } as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+    "clientOptionalDefaults": {
+    } as any,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1037,8 +1068,8 @@ it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Re
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1055,18 +1086,18 @@ it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Re
 /**
  * Client populates default values when missing in response.
  */
-it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", async () => {
+it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -1079,38 +1110,63 @@ it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", 
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "defaultString":
+    "hi",
+    "defaultBoolean":
+    true,
+    "defaultList":
+    [
+    ],
+    "defaultTimestamp":
+    new Date(0 * 1000),
+    "defaultBlob":
+    Uint8Array.from("abc", c => c.charCodeAt(0)),
+    "defaultByte":
+    1,
+    "defaultShort":
+    1,
+    "defaultInteger":
+    10,
+    "defaultLong":
+    100,
+    "defaultFloat":
+    1.0,
+    "defaultDouble":
+    1.0,
+    "defaultMap":
     {
-      defaultString: "hi",
-      defaultBoolean: true,
-      defaultList: [],
-      defaultTimestamp: new Date(0 * 1000),
-      defaultBlob: Uint8Array.from("abc", (c) => c.charCodeAt(0)),
-      defaultByte: 1,
-      defaultShort: 1,
-      defaultInteger: 10,
-      defaultLong: 100,
-      defaultFloat: 1.0,
-      defaultDouble: 1.0,
-      defaultMap: {},
-      defaultEnum: "FOO",
-      defaultIntEnum: 1,
-      emptyString: "",
-      falseBoolean: false,
-      emptyBlob: Uint8Array.from("", (c) => c.charCodeAt(0)),
-      zeroByte: 0,
-      zeroShort: 0,
-      zeroInteger: 0,
-      zeroLong: 0,
-      zeroFloat: 0.0,
-      zeroDouble: 0.0,
     },
+    "defaultEnum":
+    "FOO",
+    "defaultIntEnum":
+    1,
+    "emptyString":
+    "",
+    "falseBoolean":
+    false,
+    "emptyBlob":
+    Uint8Array.from("", c => c.charCodeAt(0)),
+    "zeroByte":
+    0,
+    "zeroShort":
+    0,
+    "zeroInteger":
+    0,
+    "zeroLong":
+    0,
+    "zeroFloat":
+    0.0,
+    "zeroDouble":
+    0.0,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1119,18 +1175,18 @@ it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", 
 /**
  * Client ignores default values if member values are present in the response.
  */
-it.skip("RpcV2CborClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse:Response", async () => {
+it.skip("RpcV2CborClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse:Response", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v21kZWZhdWx0U3RyaW5nY2J5ZW5kZWZhdWx0Qm9vbGVhbvRrZGVmYXVsdExpc3SBYWFwZGVmYXVsdFRpbWVzdGFtcMH7QAAAAAAAAABrZGVmYXVsdEJsb2JCaGlrZGVmYXVsdEJ5dGUCbGRlZmF1bHRTaG9ydAJuZGVmYXVsdEludGVnZXIUa2RlZmF1bHRMb25nGMhsZGVmYXVsdEZsb2F0+kAAAABtZGVmYXVsdERvdWJsZftAAAAAAAAAAGpkZWZhdWx0TWFwoWRuYW1lZEphY2trZGVmYXVsdEVudW1jQkFSbmRlZmF1bHRJbnRFbnVtAmtlbXB0eVN0cmluZ2Nmb29sZmFsc2VCb29sZWFu9WllbXB0eUJsb2JCaGloemVyb0J5dGUBaXplcm9TaG9ydAFremVyb0ludGVnZXIBaHplcm9Mb25nAWl6ZXJvRmxvYXT6P4AAAGp6ZXJvRG91Ymxl+z/wAAAAAAAA/w==`
-    ),
+      `v21kZWZhdWx0U3RyaW5nY2J5ZW5kZWZhdWx0Qm9vbGVhbvRrZGVmYXVsdExpc3SBYWFwZGVmYXVsdFRpbWVzdGFtcMH7QAAAAAAAAABrZGVmYXVsdEJsb2JCaGlrZGVmYXVsdEJ5dGUCbGRlZmF1bHRTaG9ydAJuZGVmYXVsdEludGVnZXIUa2RlZmF1bHRMb25nGMhsZGVmYXVsdEZsb2F0+kAAAABtZGVmYXVsdERvdWJsZftAAAAAAAAAAGpkZWZhdWx0TWFwoWRuYW1lZEphY2trZGVmYXVsdEVudW1jQkFSbmRlZmF1bHRJbnRFbnVtAmtlbXB0eVN0cmluZ2Nmb29sZmFsc2VCb29sZWFu9WllbXB0eUJsb2JCaGloemVyb0J5dGUBaXplcm9TaG9ydAFremVyb0ludGVnZXIBaHplcm9Mb25nAWl6ZXJvRmxvYXT6P4AAAGp6ZXJvRG91Ymxl+z/wAAAAAAAA/w==`,
+    )
   });
 
   const params: any = {};
@@ -1143,40 +1199,66 @@ it.skip("RpcV2CborClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse:R
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "defaultString":
+    "bye",
+    "defaultBoolean":
+    false,
+    "defaultList":
+    [
+      "a",
+    ],
+    "defaultTimestamp":
+    new Date(2 * 1000),
+    "defaultBlob":
+    Uint8Array.from("hi", c => c.charCodeAt(0)),
+    "defaultByte":
+    2,
+    "defaultShort":
+    2,
+    "defaultInteger":
+    20,
+    "defaultLong":
+    200,
+    "defaultFloat":
+    2.0,
+    "defaultDouble":
+    2.0,
+    "defaultMap":
     {
-      defaultString: "bye",
-      defaultBoolean: false,
-      defaultList: ["a"],
-      defaultTimestamp: new Date(2 * 1000),
-      defaultBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      defaultByte: 2,
-      defaultShort: 2,
-      defaultInteger: 20,
-      defaultLong: 200,
-      defaultFloat: 2.0,
-      defaultDouble: 2.0,
-      defaultMap: {
-        name: "Jack",
-      },
-      defaultEnum: "BAR",
-      defaultIntEnum: 2,
-      emptyString: "foo",
-      falseBoolean: true,
-      emptyBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      zeroByte: 1,
-      zeroShort: 1,
-      zeroInteger: 1,
-      zeroLong: 1,
-      zeroFloat: 1.0,
-      zeroDouble: 1.0,
+      "name":
+      "Jack",
     },
+    "defaultEnum":
+    "BAR",
+    "defaultIntEnum":
+    2,
+    "emptyString":
+    "foo",
+    "falseBoolean":
+    true,
+    "emptyBlob":
+    Uint8Array.from("hi", c => c.charCodeAt(0)),
+    "zeroByte":
+    1,
+    "zeroShort":
+    1,
+    "zeroInteger":
+    1,
+    "zeroLong":
+    1,
+    "zeroFloat":
+    1.0,
+    "zeroDouble":
+    1.0,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1191,10 +1273,13 @@ it("optional_input:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OptionalInputOutputCommand({} as any);
+  const command = new OptionalInputOutputCommand(
+  {
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1231,11 +1316,11 @@ it("optional_output:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -1248,7 +1333,7 @@ it("optional_output:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -1260,23 +1345,25 @@ it("RpcV2CborRecursiveShapes:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RecursiveShapesCommand({
-    nested: {
-      foo: "Foo1",
-      nested: {
-        bar: "Bar1",
-        recursiveMember: {
-          foo: "Foo2",
-          nested: {
-            bar: "Bar2",
+  const command = new RecursiveShapesCommand(
+  {
+    "nested": {
+      "foo": "Foo1",
+      "nested": {
+        "bar": "Bar1",
+        "recursiveMember": {
+          "foo": "Foo2",
+          "nested": {
+            "bar": "Bar2",
           } as any,
         } as any,
       } as any,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1287,8 +1374,8 @@ it("RpcV2CborRecursiveShapes:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RecursiveShapes");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1312,11 +1399,11 @@ it("RpcV2CborRecursiveShapes:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8=`
-    ),
+      `v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8=`,
+    )
   });
 
   const params: any = {};
@@ -1329,27 +1416,35 @@ it("RpcV2CborRecursiveShapes:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "nested":
     {
-      nested: {
-        foo: "Foo1",
-        nested: {
-          bar: "Bar1",
-          recursiveMember: {
-            foo: "Foo2",
-            nested: {
-              bar: "Bar2",
-            },
+      "foo":
+      "Foo1",
+      "nested":
+      {
+        "bar":
+        "Bar1",
+        "recursiveMember":
+        {
+          "foo":
+          "Foo2",
+          "nested":
+          {
+            "bar":
+            "Bar2",
           },
         },
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1365,11 +1460,11 @@ it("RpcV2CborRecursiveShapesUsingDefiniteLength:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWZuZXN0ZWSiY2Zvb2RGb28xZm5lc3RlZKJjYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyomNmb29kRm9vMmZuZXN0ZWShY2JhcmRCYXIy`
-    ),
+      `oWZuZXN0ZWSiY2Zvb2RGb28xZm5lc3RlZKJjYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyomNmb29kRm9vMmZuZXN0ZWShY2JhcmRCYXIy`,
+    )
   });
 
   const params: any = {};
@@ -1382,27 +1477,35 @@ it("RpcV2CborRecursiveShapesUsingDefiniteLength:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "nested":
     {
-      nested: {
-        foo: "Foo1",
-        nested: {
-          bar: "Bar1",
-          recursiveMember: {
-            foo: "Foo2",
-            nested: {
-              bar: "Bar2",
-            },
+      "foo":
+      "Foo1",
+      "nested":
+      {
+        "bar":
+        "Bar1",
+        "recursiveMember":
+        {
+          "foo":
+          "Foo2",
+          "nested":
+          {
+            "bar":
+            "Bar2",
           },
         },
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1417,19 +1520,21 @@ it("RpcV2CborMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborDenseMapsCommand({
-    denseStructMap: {
-      foo: {
-        hi: "there",
+  const command = new RpcV2CborDenseMapsCommand(
+  {
+    "denseStructMap": {
+      "foo": {
+        "hi": "there",
       } as any,
-      baz: {
-        hi: "bye",
+      "baz": {
+        "hi": "bye",
       } as any,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1440,8 +1545,8 @@ it("RpcV2CborMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborDenseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1464,17 +1569,19 @@ it("RpcV2CborSerializesZeroValuesInMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborDenseMapsCommand({
-    denseNumberMap: {
-      x: 0,
+  const command = new RpcV2CborDenseMapsCommand(
+  {
+    "denseNumberMap": {
+      "x": 0,
     } as any,
-    denseBooleanMap: {
-      x: false,
+    "denseBooleanMap": {
+      "x": false,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1485,8 +1592,8 @@ it("RpcV2CborSerializesZeroValuesInMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborDenseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1509,15 +1616,21 @@ it("RpcV2CborSerializesDenseSetMap:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborDenseMapsCommand({
-    denseSetMap: {
-      x: [],
-      y: ["a", "b"],
+  const command = new RpcV2CborDenseMapsCommand(
+  {
+    "denseSetMap": {
+      "x": [
+      ],
+      "y": [
+        "a",
+        "b",
+      ],
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1528,8 +1641,8 @@ it("RpcV2CborSerializesDenseSetMap:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborDenseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1553,11 +1666,11 @@ it("RpcV2CborMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ==`
-    ),
+      `oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ==`,
+    )
   });
 
   const params: any = {};
@@ -1570,23 +1683,28 @@ it("RpcV2CborMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseStructMap":
     {
-      denseStructMap: {
-        foo: {
-          hi: "there",
-        },
-        baz: {
-          hi: "bye",
-        },
+      "foo":
+      {
+        "hi":
+        "there",
+      },
+      "baz":
+      {
+        "hi":
+        "bye",
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1602,11 +1720,11 @@ it("RpcV2CborDeserializesZeroValuesInMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A==`
-    ),
+      `om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A==`,
+    )
   });
 
   const params: any = {};
@@ -1619,21 +1737,25 @@ it("RpcV2CborDeserializesZeroValuesInMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseNumberMap":
     {
-      denseNumberMap: {
-        x: 0,
-      },
-      denseBooleanMap: {
-        x: false,
-      },
+      "x":
+      0,
     },
+    "denseBooleanMap":
+    {
+      "x":
+      false,
+    },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1649,11 +1771,11 @@ it("RpcV2CborDeserializesDenseSetMap:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWtkZW5zZVNldE1hcKJheIBheYJhYWFi`
-    ),
+      `oWtkZW5zZVNldE1hcKJheIBheYJhYWFi`,
+    )
   });
 
   const params: any = {};
@@ -1666,19 +1788,26 @@ it("RpcV2CborDeserializesDenseSetMap:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseSetMap":
     {
-      denseSetMap: {
-        x: [],
-        y: ["a", "b"],
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1688,18 +1817,18 @@ it("RpcV2CborDeserializesDenseSetMap:Response", async () => {
  * Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD
  * drop the null key-value pair.
  */
-it.skip("RpcV2CborDeserializesDenseSetMapAndSkipsNull:Response", async () => {
+it.skip("RpcV2CborDeserializesDenseSetMapAndSkipsNull:Response", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWtkZW5zZVNldE1hcKNheIBheYJhYWFiYXr2`
-    ),
+      `oWtkZW5zZVNldE1hcKNheIBheYJhYWFiYXr2`,
+    )
   });
 
   const params: any = {};
@@ -1712,19 +1841,26 @@ it.skip("RpcV2CborDeserializesDenseSetMapAndSkipsNull:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseSetMap":
     {
-      denseSetMap: {
-        x: [],
-        y: ["a", "b"],
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1739,33 +1875,65 @@ it("RpcV2CborLists:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborListsCommand({
-    stringList: ["foo", "bar"],
-    stringSet: ["foo", "bar"],
-    integerList: [1, 2],
-    booleanList: [true, false],
-    timestampList: [new Date(1398796238000), new Date(1398796238000)],
-    enumList: ["Foo", "0"],
-    intEnumList: [1, 2],
-    nestedStringList: [
-      ["foo", "bar"],
-      ["baz", "qux"],
+  const command = new RpcV2CborListsCommand(
+  {
+    "stringList": [
+      "foo",
+      "bar",
     ],
-    structureList: [
+    "stringSet": [
+      "foo",
+      "bar",
+    ],
+    "integerList": [
+      1,
+      2,
+    ],
+    "booleanList": [
+      true,
+      false,
+    ],
+    "timestampList": [
+      new Date(1398796238000),
+      new Date(1398796238000),
+    ],
+    "enumList": [
+      "Foo",
+      "0",
+    ],
+    "intEnumList": [
+      1,
+      2,
+    ],
+    "nestedStringList": [
+      [
+        "foo",
+        "bar",
+      ],
+      [
+        "baz",
+        "qux",
+      ],
+    ],
+    "structureList": [
       {
-        a: "1",
-        b: "2",
+        "a": "1",
+        "b": "2",
       } as any,
       {
-        a: "3",
-        b: "4",
+        "a": "3",
+        "b": "4",
       } as any,
     ],
-    blobList: [Uint8Array.from("foo", (c) => c.charCodeAt(0)), Uint8Array.from("bar", (c) => c.charCodeAt(0))],
-  } as any);
+    "blobList": [
+      Uint8Array.from("foo", c => c.charCodeAt(0)),
+      Uint8Array.from("bar", c => c.charCodeAt(0)),
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1776,8 +1944,8 @@ it("RpcV2CborLists:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborLists");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1800,12 +1968,15 @@ it("RpcV2CborListsEmpty:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborListsCommand({
-    stringList: [],
-  } as any);
+  const command = new RpcV2CborListsCommand(
+  {
+    "stringList": [
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1816,8 +1987,8 @@ it("RpcV2CborListsEmpty:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborLists");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1840,12 +2011,15 @@ it("RpcV2CborListsEmptyUsingDefiniteLength:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborListsCommand({
-    stringList: [],
-  } as any);
+  const command = new RpcV2CborListsCommand(
+  {
+    "stringList": [
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1856,8 +2030,8 @@ it("RpcV2CborListsEmptyUsingDefiniteLength:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborLists");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1881,11 +2055,11 @@ it("RpcV2CborLists:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2pzdHJpbmdMaXN0n2Nmb29jYmFy/2lzdHJpbmdTZXSfY2Zvb2NiYXL/a2ludGVnZXJMaXN0nwEC/2tib29sZWFuTGlzdJ/19P9tdGltZXN0YW1wTGlzdJ/B+0HU1/vzgAAAwftB1Nf784AAAP9oZW51bUxpc3SfY0Zvb2Ew/2tpbnRFbnVtTGlzdJ8BAv9wbmVzdGVkU3RyaW5nTGlzdJ+fY2Zvb2NiYXL/n2NiYXpjcXV4//9tc3RydWN0dXJlTGlzdJ+/YWFhMWFiYTL/v2FhYTNhYmE0//9oYmxvYkxpc3SfQ2Zvb0NiYXL//w==`
-    ),
+      `v2pzdHJpbmdMaXN0n2Nmb29jYmFy/2lzdHJpbmdTZXSfY2Zvb2NiYXL/a2ludGVnZXJMaXN0nwEC/2tib29sZWFuTGlzdJ/19P9tdGltZXN0YW1wTGlzdJ/B+0HU1/vzgAAAwftB1Nf784AAAP9oZW51bUxpc3SfY0Zvb2Ew/2tpbnRFbnVtTGlzdJ8BAv9wbmVzdGVkU3RyaW5nTGlzdJ+fY2Zvb2NiYXL/n2NiYXpjcXV4//9tc3RydWN0dXJlTGlzdJ+/YWFhMWFiYTL/v2FhYTNhYmE0//9oYmxvYkxpc3SfQ2Zvb0NiYXL//w==`,
+    )
   });
 
   const params: any = {};
@@ -1898,37 +2072,81 @@ it("RpcV2CborLists:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: ["foo", "bar"],
-      stringSet: ["foo", "bar"],
-      integerList: [1, 2],
-      booleanList: [true, false],
-      timestampList: [new Date(1398796238 * 1000), new Date(1398796238 * 1000)],
-      enumList: ["Foo", "0"],
-      intEnumList: [1, 2],
-      nestedStringList: [
-        ["foo", "bar"],
-        ["baz", "qux"],
+  {
+    "stringList":
+    [
+      "foo",
+      "bar",
+    ],
+    "stringSet":
+    [
+      "foo",
+      "bar",
+    ],
+    "integerList":
+    [
+      1,
+      2,
+    ],
+    "booleanList":
+    [
+      true,
+      false,
+    ],
+    "timestampList":
+    [
+      new Date(1398796238 * 1000),
+      new Date(1398796238 * 1000),
+    ],
+    "enumList":
+    [
+      "Foo",
+      "0",
+    ],
+    "intEnumList":
+    [
+      1,
+      2,
+    ],
+    "nestedStringList":
+    [
+      [
+        "foo",
+        "bar",
       ],
-      structureList: [
-        {
-          a: "1",
-          b: "2",
-        },
-        {
-          a: "3",
-          b: "4",
-        },
+      [
+        "baz",
+        "qux",
       ],
-      blobList: [Uint8Array.from("foo", (c) => c.charCodeAt(0)), Uint8Array.from("bar", (c) => c.charCodeAt(0))],
-    },
+    ],
+    "structureList":
+    [
+      {
+        "a":
+        "1",
+        "b":
+        "2",
+      },
+      {
+        "a":
+        "3",
+        "b":
+        "4",
+      },
+    ],
+    "blobList":
+    [
+      Uint8Array.from("foo", c => c.charCodeAt(0)),
+      Uint8Array.from("bar", c => c.charCodeAt(0)),
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1944,11 +2162,11 @@ it("RpcV2CborListsEmpty:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2pzdHJpbmdMaXN0n///`
-    ),
+      `v2pzdHJpbmdMaXN0n///`,
+    )
   });
 
   const params: any = {};
@@ -1961,16 +2179,18 @@ it("RpcV2CborListsEmpty:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: [],
-    },
+  {
+    "stringList":
+    [
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1986,11 +2206,11 @@ it("RpcV2CborIndefiniteStringInsideIndefiniteListCanDeserialize:Response", async
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2pzdHJpbmdMaXN0n394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n//8=`
-    ),
+      `v2pzdHJpbmdMaXN0n394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n//8=`,
+    )
   });
 
   const params: any = {};
@@ -2003,20 +2223,21 @@ it("RpcV2CborIndefiniteStringInsideIndefiniteListCanDeserialize:Response", async
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: [
-        "An example indefinite string, which will be chunked, on each comma",
-        "Another example indefinite string with only one chunk",
-        "This is a plain string",
-      ],
-    },
+  {
+    "stringList":
+    [
+      "An example indefinite string, which will be chunked, on each comma",
+      "Another example indefinite string with only one chunk",
+      "This is a plain string",
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2032,11 +2253,11 @@ it("RpcV2CborIndefiniteStringInsideDefiniteListCanDeserialize:Response", async (
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWpzdHJpbmdMaXN0g394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n`
-    ),
+      `oWpzdHJpbmdMaXN0g394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n`,
+    )
   });
 
   const params: any = {};
@@ -2049,20 +2270,21 @@ it("RpcV2CborIndefiniteStringInsideDefiniteListCanDeserialize:Response", async (
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: [
-        "An example indefinite string, which will be chunked, on each comma",
-        "Another example indefinite string with only one chunk",
-        "This is a plain string",
-      ],
-    },
+  {
+    "stringList":
+    [
+      "An example indefinite string, which will be chunked, on each comma",
+      "Another example indefinite string with only one chunk",
+      "This is a plain string",
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2077,19 +2299,21 @@ it("RpcV2CborSparseMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseStructMap: {
-      foo: {
-        hi: "there",
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseStructMap": {
+      "foo": {
+        "hi": "there",
       } as any,
-      baz: {
-        hi: "bye",
+      "baz": {
+        "hi": "bye",
       } as any,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2100,8 +2324,8 @@ it("RpcV2CborSparseMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2124,23 +2348,25 @@ it("RpcV2CborSerializesNullMapValues:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseBooleanMap: {
-      x: null,
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseBooleanMap": {
+      "x": null,
     } as any,
-    sparseNumberMap: {
-      x: null,
+    "sparseNumberMap": {
+      "x": null,
     } as any,
-    sparseStringMap: {
-      x: null,
+    "sparseStringMap": {
+      "x": null,
     } as any,
-    sparseStructMap: {
-      x: null,
+    "sparseStructMap": {
+      "x": null,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2151,8 +2377,8 @@ it("RpcV2CborSerializesNullMapValues:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2175,15 +2401,21 @@ it("RpcV2CborSerializesSparseSetMap:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseSetMap: {
-      x: [],
-      y: ["a", "b"],
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseSetMap": {
+      "x": [
+      ],
+      "y": [
+        "a",
+        "b",
+      ],
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2194,8 +2426,8 @@ it("RpcV2CborSerializesSparseSetMap:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2218,16 +2450,22 @@ it("RpcV2CborSerializesSparseSetMapAndRetainsNull:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseSetMap: {
-      x: [],
-      y: ["a", "b"],
-      z: null,
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseSetMap": {
+      "x": [
+      ],
+      "y": [
+        "a",
+        "b",
+      ],
+      "z": null,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2238,8 +2476,8 @@ it("RpcV2CborSerializesSparseSetMapAndRetainsNull:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2262,17 +2500,19 @@ it("RpcV2CborSerializesZeroValuesInSparseMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseNumberMap: {
-      x: 0,
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseNumberMap": {
+      "x": 0,
     } as any,
-    sparseBooleanMap: {
-      x: false,
+    "sparseBooleanMap": {
+      "x": false,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2283,8 +2523,8 @@ it("RpcV2CborSerializesZeroValuesInSparseMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2308,11 +2548,11 @@ it("RpcV2CborSparseJsonMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v29zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb79iaGlldGhlcmX/Y2Jher9iaGljYnll////`
-    ),
+      `v29zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb79iaGlldGhlcmX/Y2Jher9iaGljYnll////`,
+    )
   });
 
   const params: any = {};
@@ -2325,23 +2565,28 @@ it("RpcV2CborSparseJsonMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseStructMap":
     {
-      sparseStructMap: {
-        foo: {
-          hi: "there",
-        },
-        baz: {
-          hi: "bye",
-        },
+      "foo":
+      {
+        "hi":
+        "there",
+      },
+      "baz":
+      {
+        "hi":
+        "bye",
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2357,11 +2602,11 @@ it("RpcV2CborDeserializesNullMapValues:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//`
-    ),
+      `v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//`,
+    )
   });
 
   const params: any = {};
@@ -2374,27 +2619,35 @@ it("RpcV2CborDeserializesNullMapValues:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseBooleanMap":
     {
-      sparseBooleanMap: {
-        x: null,
-      },
-      sparseNumberMap: {
-        x: null,
-      },
-      sparseStringMap: {
-        x: null,
-      },
-      sparseStructMap: {
-        x: null,
-      },
+      "x":
+      null,
     },
+    "sparseNumberMap":
+    {
+      "x":
+      null,
+    },
+    "sparseStringMap":
+    {
+      "x":
+      null,
+    },
+    "sparseStructMap":
+    {
+      "x":
+      null,
+    },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2410,11 +2663,11 @@ it("RpcV2CborDeserializesSparseSetMap:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8=`
-    ),
+      `v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8=`,
+    )
   });
 
   const params: any = {};
@@ -2427,19 +2680,26 @@ it("RpcV2CborDeserializesSparseSetMap:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseSetMap":
     {
-      sparseSetMap: {
-        x: [],
-        y: ["a", "b"],
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2455,11 +2715,11 @@ it("RpcV2CborDeserializesSparseSetMapAndRetainsNull:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL/YXr2//8=`
-    ),
+      `v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL/YXr2//8=`,
+    )
   });
 
   const params: any = {};
@@ -2472,20 +2732,28 @@ it("RpcV2CborDeserializesSparseSetMapAndRetainsNull:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseSetMap":
     {
-      sparseSetMap: {
-        x: [],
-        y: ["a", "b"],
-        z: null,
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
+      "z":
+      null,
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2501,11 +2769,11 @@ it("RpcV2CborDeserializesZeroValuesInSparseMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v29zcGFyc2VOdW1iZXJNYXC/YXgA/3BzcGFyc2VCb29sZWFuTWFwv2F49P//`
-    ),
+      `v29zcGFyc2VOdW1iZXJNYXC/YXgA/3BzcGFyc2VCb29sZWFuTWFwv2F49P//`,
+    )
   });
 
   const params: any = {};
@@ -2518,21 +2786,25 @@ it("RpcV2CborDeserializesZeroValuesInSparseMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseNumberMap":
     {
-      sparseNumberMap: {
-        x: 0,
-      },
-      sparseBooleanMap: {
-        x: false,
-      },
+      "x":
+      0,
     },
+    "sparseBooleanMap":
+    {
+      "x":
+      false,
+    },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2547,21 +2819,23 @@ it("RpcV2CborSimpleScalarProperties:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    byteValue: 5,
-    doubleValue: 1.889,
-    falseBooleanValue: false,
-    floatValue: 7.625,
-    integerValue: 256,
-    longValue: 9873,
-    shortValue: 9898,
-    stringValue: "simple",
-    trueBooleanValue: true,
-    blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "byteValue": 5,
+    "doubleValue": 1.889,
+    "falseBooleanValue": false,
+    "floatValue": 7.625,
+    "integerValue": 256,
+    "longValue": 9873,
+    "shortValue": 9898,
+    "stringValue": "simple",
+    "trueBooleanValue": true,
+    "blobValue": Uint8Array.from("foo", c => c.charCodeAt(0)),
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2572,8 +2846,8 @@ it("RpcV2CborSimpleScalarProperties:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2596,12 +2870,14 @@ it("RpcV2CborClientDoesntSerializeNullStructureValues:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    stringValue: null,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "stringValue": null,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2612,8 +2888,8 @@ it("RpcV2CborClientDoesntSerializeNullStructureValues:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2636,13 +2912,15 @@ it("RpcV2CborSupportsNaNFloatInputs:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    doubleValue: NaN,
-    floatValue: NaN,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "doubleValue": NaN,
+    "floatValue": NaN,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2653,8 +2931,8 @@ it("RpcV2CborSupportsNaNFloatInputs:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2677,13 +2955,15 @@ it("RpcV2CborSupportsInfinityFloatInputs:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    doubleValue: Infinity,
-    floatValue: Infinity,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "doubleValue": Infinity,
+    "floatValue": Infinity,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2694,8 +2974,8 @@ it("RpcV2CborSupportsInfinityFloatInputs:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2718,13 +2998,15 @@ it("RpcV2CborSupportsNegativeInfinityFloatInputs:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    doubleValue: -Infinity,
-    floatValue: -Infinity,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "doubleValue": -Infinity,
+    "floatValue": -Infinity,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2735,8 +3017,8 @@ it("RpcV2CborSupportsNegativeInfinityFloatInputs:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2760,11 +3042,11 @@ it("RpcV2CborSimpleScalarProperties:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v3B0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb2//`
-    ),
+      `v3B0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb2//`,
+    )
   });
 
   const params: any = {};
@@ -2777,24 +3059,33 @@ it("RpcV2CborSimpleScalarProperties:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      trueBooleanValue: true,
-      falseBooleanValue: false,
-      byteValue: 5,
-      doubleValue: 1.889,
-      floatValue: 7.625,
-      integerValue: 256,
-      shortValue: 9898,
-      stringValue: "simple",
-      blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-    },
+  {
+    "trueBooleanValue":
+    true,
+    "falseBooleanValue":
+    false,
+    "byteValue":
+    5,
+    "doubleValue":
+    1.889,
+    "floatValue":
+    7.625,
+    "integerValue":
+    256,
+    "shortValue":
+    9898,
+    "stringValue":
+    "simple",
+    "blobValue":
+    Uint8Array.from("foo", c => c.charCodeAt(0)),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2810,11 +3101,11 @@ it("RpcV2CborSimpleScalarPropertiesUsingDefiniteLength:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `qXB0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb28=`
-    ),
+      `qXB0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb28=`,
+    )
   });
 
   const params: any = {};
@@ -2827,24 +3118,33 @@ it("RpcV2CborSimpleScalarPropertiesUsingDefiniteLength:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      trueBooleanValue: true,
-      falseBooleanValue: false,
-      byteValue: 5,
-      doubleValue: 1.889,
-      floatValue: 7.625,
-      integerValue: 256,
-      shortValue: 9898,
-      stringValue: "simple",
-      blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-    },
+  {
+    "trueBooleanValue":
+    true,
+    "falseBooleanValue":
+    false,
+    "byteValue":
+    5,
+    "doubleValue":
+    1.889,
+    "floatValue":
+    7.625,
+    "integerValue":
+    256,
+    "shortValue":
+    9898,
+    "stringValue":
+    "simple",
+    "blobValue":
+    Uint8Array.from("foo", c => c.charCodeAt(0)),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2860,11 +3160,11 @@ it("RpcV2CborClientDoesntDeserializeNullStructureValues:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tzdHJpbmdWYWx1Zfb/`
-    ),
+      `v2tzdHJpbmdWYWx1Zfb/`,
+    )
   });
 
   const params: any = {};
@@ -2877,7 +3177,7 @@ it("RpcV2CborClientDoesntDeserializeNullStructureValues:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -2890,11 +3190,11 @@ it("RpcV2CborSupportsNaNFloatOutputs:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/`
-    ),
+      `v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/`,
+    )
   });
 
   const params: any = {};
@@ -2907,17 +3207,19 @@ it("RpcV2CborSupportsNaNFloatOutputs:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: NaN,
-      floatValue: NaN,
-    },
+  {
+    "doubleValue":
+    NaN,
+    "floatValue":
+    NaN,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2933,11 +3235,11 @@ it("RpcV2CborSupportsInfinityFloatOutputs:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/`
-    ),
+      `v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/`,
+    )
   });
 
   const params: any = {};
@@ -2950,17 +3252,19 @@ it("RpcV2CborSupportsInfinityFloatOutputs:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: Infinity,
-      floatValue: Infinity,
-    },
+  {
+    "doubleValue":
+    Infinity,
+    "floatValue":
+    Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2976,11 +3280,11 @@ it("RpcV2CborSupportsNegativeInfinityFloatOutputs:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/`
-    ),
+      `v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/`,
+    )
   });
 
   const params: any = {};
@@ -2993,17 +3297,19 @@ it("RpcV2CborSupportsNegativeInfinityFloatOutputs:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: -Infinity,
-      floatValue: -Infinity,
-    },
+  {
+    "doubleValue":
+    -Infinity,
+    "floatValue":
+    -Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3019,11 +3325,11 @@ it("RpcV2CborSupportsUpcastingDataOnDeserialize:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zfk+AGpmbG9hdFZhbHVl+UegbGludGVnZXJWYWx1ZRg4aWxvbmdWYWx1ZRkBAGpzaG9ydFZhbHVlCv8=`
-    ),
+      `v2tkb3VibGVWYWx1Zfk+AGpmbG9hdFZhbHVl+UegbGludGVnZXJWYWx1ZRg4aWxvbmdWYWx1ZRkBAGpzaG9ydFZhbHVlCv8=`,
+    )
   });
 
   const params: any = {};
@@ -3036,20 +3342,25 @@ it("RpcV2CborSupportsUpcastingDataOnDeserialize:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: 1.5,
-      floatValue: 7.625,
-      integerValue: 56,
-      longValue: 256,
-      shortValue: 10,
-    },
+  {
+    "doubleValue":
+    1.5,
+    "floatValue":
+    7.625,
+    "integerValue":
+    56,
+    "longValue":
+    256,
+    "shortValue":
+    10,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3067,11 +3378,11 @@ it("RpcV2CborExtraFieldsInTheBodyShouldBeSkippedByClients:Response", async () =>
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABrZXh0cmFPYmplY3S/c2luZGVmaW5pdGVMZW5ndGhNYXC/a3dpdGhBbkFycmF5nwECA///cWRlZmluaXRlTGVuZ3RoTWFwo3J3aXRoQURlZmluaXRlQXJyYXmDAQIDeB1hbmRTb21lSW5kZWZpbml0ZUxlbmd0aFN0cmluZ3gfdGhhdCBoYXMsIGJlZW4gY2h1bmtlZCBvbiBjb21tYWxub3JtYWxTdHJpbmdjZm9vanNob3J0VmFsdWUZJw9uc29tZU90aGVyRmllbGR2dGhpcyBzaG91bGQgYmUgc2tpcHBlZP9saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w==`
-    ),
+      `v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABrZXh0cmFPYmplY3S/c2luZGVmaW5pdGVMZW5ndGhNYXC/a3dpdGhBbkFycmF5nwECA///cWRlZmluaXRlTGVuZ3RoTWFwo3J3aXRoQURlZmluaXRlQXJyYXmDAQIDeB1hbmRTb21lSW5kZWZpbml0ZUxlbmd0aFN0cmluZ3gfdGhhdCBoYXMsIGJlZW4gY2h1bmtlZCBvbiBjb21tYWxub3JtYWxTdHJpbmdjZm9vanNob3J0VmFsdWUZJw9uc29tZU90aGVyRmllbGR2dGhpcyBzaG91bGQgYmUgc2tpcHBlZP9saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w==`,
+    )
   });
 
   const params: any = {};
@@ -3084,25 +3395,35 @@ it("RpcV2CborExtraFieldsInTheBodyShouldBeSkippedByClients:Response", async () =>
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      byteValue: 5,
-      doubleValue: 1.889,
-      falseBooleanValue: false,
-      floatValue: 7.625,
-      integerValue: 256,
-      longValue: 9873,
-      shortValue: 9898,
-      stringValue: "simple",
-      trueBooleanValue: true,
-      blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-    },
+  {
+    "byteValue":
+    5,
+    "doubleValue":
+    1.889,
+    "falseBooleanValue":
+    false,
+    "floatValue":
+    7.625,
+    "integerValue":
+    256,
+    "longValue":
+    9873,
+    "shortValue":
+    9898,
+    "stringValue":
+    "simple",
+    "trueBooleanValue":
+    true,
+    "blobValue":
+    Uint8Array.from("foo", c => c.charCodeAt(0)),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3117,14 +3438,16 @@ it("RpcV2CborSparseMapsSerializeNullValues:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SparseNullsOperationCommand({
-    sparseStringMap: {
-      foo: null,
+  const command = new SparseNullsOperationCommand(
+  {
+    "sparseStringMap": {
+      "foo": null,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -3135,8 +3458,8 @@ it("RpcV2CborSparseMapsSerializeNullValues:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SparseNullsOperation");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -3159,12 +3482,16 @@ it("RpcV2CborSparseListsSerializeNull:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SparseNullsOperationCommand({
-    sparseStringList: [null],
-  } as any);
+  const command = new SparseNullsOperationCommand(
+  {
+    "sparseStringList": [
+      null,
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -3175,8 +3502,8 @@ it("RpcV2CborSparseListsSerializeNull:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SparseNullsOperation");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -3200,11 +3527,11 @@ it("RpcV2CborSparseMapsDeserializeNullValues:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v29zcGFyc2VTdHJpbmdNYXC/Y2Zvb/b//w==`
-    ),
+      `v29zcGFyc2VTdHJpbmdNYXC/Y2Zvb/b//w==`,
+    )
   });
 
   const params: any = {};
@@ -3217,18 +3544,20 @@ it("RpcV2CborSparseMapsDeserializeNullValues:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseStringMap":
     {
-      sparseStringMap: {
-        foo: null,
-      },
+      "foo":
+      null,
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3244,11 +3573,11 @@ it("RpcV2CborSparseListsDeserializeNull:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v3BzcGFyc2VTdHJpbmdMaXN0n/b//w==`
-    ),
+      `v3BzcGFyc2VTdHJpbmdMaXN0n/b//w==`,
+    )
   });
 
   const params: any = {};
@@ -3261,16 +3590,19 @@ it("RpcV2CborSparseListsDeserializeNull:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      sparseStringList: [null],
-    },
+  {
+    "sparseStringList":
+    [
+      null,
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });

--- a/private/smithy-rpcv2-cbor/src/RpcV2Protocol.ts
+++ b/private/smithy-rpcv2-cbor/src/RpcV2Protocol.ts
@@ -1,11 +1,18 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClient, RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClient,
+  RpcV2ProtocolClientConfig,
+} from "./RpcV2ProtocolClient";
 import {
   EmptyInputOutputCommand,
   EmptyInputOutputCommandInput,
   EmptyInputOutputCommandOutput,
 } from "./commands/EmptyInputOutputCommand";
-import { Float16Command, Float16CommandInput, Float16CommandOutput } from "./commands/Float16Command";
+import {
+  Float16Command,
+  Float16CommandInput,
+  Float16CommandOutput,
+} from "./commands/Float16Command";
 import {
   FractionalSecondsCommand,
   FractionalSecondsCommandInput,
@@ -78,7 +85,7 @@ const commands = {
   RpcV2CborSparseMapsCommand,
   SimpleScalarPropertiesCommand,
   SparseNullsOperationCommand,
-};
+}
 
 export interface RpcV2Protocol {
   /**
@@ -87,7 +94,7 @@ export interface RpcV2Protocol {
   emptyInputOutput(): Promise<EmptyInputOutputCommandOutput>;
   emptyInputOutput(
     args: EmptyInputOutputCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<EmptyInputOutputCommandOutput>;
   emptyInputOutput(
     args: EmptyInputOutputCommandInput,
@@ -103,8 +110,14 @@ export interface RpcV2Protocol {
    * @see {@link Float16Command}
    */
   float16(): Promise<Float16CommandOutput>;
-  float16(args: Float16CommandInput, options?: __HttpHandlerOptions): Promise<Float16CommandOutput>;
-  float16(args: Float16CommandInput, cb: (err: any, data?: Float16CommandOutput) => void): void;
+  float16(
+    args: Float16CommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<Float16CommandOutput>;
+  float16(
+    args: Float16CommandInput,
+    cb: (err: any, data?: Float16CommandOutput) => void
+  ): void;
   float16(
     args: Float16CommandInput,
     options: __HttpHandlerOptions,
@@ -117,7 +130,7 @@ export interface RpcV2Protocol {
   fractionalSeconds(): Promise<FractionalSecondsCommandOutput>;
   fractionalSeconds(
     args: FractionalSecondsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<FractionalSecondsCommandOutput>;
   fractionalSeconds(
     args: FractionalSecondsCommandInput,
@@ -135,7 +148,7 @@ export interface RpcV2Protocol {
   greetingWithErrors(): Promise<GreetingWithErrorsCommandOutput>;
   greetingWithErrors(
     args: GreetingWithErrorsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<GreetingWithErrorsCommandOutput>;
   greetingWithErrors(
     args: GreetingWithErrorsCommandInput,
@@ -151,8 +164,14 @@ export interface RpcV2Protocol {
    * @see {@link NoInputOutputCommand}
    */
   noInputOutput(): Promise<NoInputOutputCommandOutput>;
-  noInputOutput(args: NoInputOutputCommandInput, options?: __HttpHandlerOptions): Promise<NoInputOutputCommandOutput>;
-  noInputOutput(args: NoInputOutputCommandInput, cb: (err: any, data?: NoInputOutputCommandOutput) => void): void;
+  noInputOutput(
+    args: NoInputOutputCommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<NoInputOutputCommandOutput>;
+  noInputOutput(
+    args: NoInputOutputCommandInput,
+    cb: (err: any, data?: NoInputOutputCommandOutput) => void
+  ): void;
   noInputOutput(
     args: NoInputOutputCommandInput,
     options: __HttpHandlerOptions,
@@ -165,7 +184,7 @@ export interface RpcV2Protocol {
   operationWithDefaults(): Promise<OperationWithDefaultsCommandOutput>;
   operationWithDefaults(
     args: OperationWithDefaultsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<OperationWithDefaultsCommandOutput>;
   operationWithDefaults(
     args: OperationWithDefaultsCommandInput,
@@ -183,7 +202,7 @@ export interface RpcV2Protocol {
   optionalInputOutput(): Promise<OptionalInputOutputCommandOutput>;
   optionalInputOutput(
     args: OptionalInputOutputCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<OptionalInputOutputCommandOutput>;
   optionalInputOutput(
     args: OptionalInputOutputCommandInput,
@@ -201,9 +220,12 @@ export interface RpcV2Protocol {
   recursiveShapes(): Promise<RecursiveShapesCommandOutput>;
   recursiveShapes(
     args: RecursiveShapesCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RecursiveShapesCommandOutput>;
-  recursiveShapes(args: RecursiveShapesCommandInput, cb: (err: any, data?: RecursiveShapesCommandOutput) => void): void;
+  recursiveShapes(
+    args: RecursiveShapesCommandInput,
+    cb: (err: any, data?: RecursiveShapesCommandOutput) => void
+  ): void;
   recursiveShapes(
     args: RecursiveShapesCommandInput,
     options: __HttpHandlerOptions,
@@ -216,7 +238,7 @@ export interface RpcV2Protocol {
   rpcV2CborDenseMaps(): Promise<RpcV2CborDenseMapsCommandOutput>;
   rpcV2CborDenseMaps(
     args: RpcV2CborDenseMapsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RpcV2CborDenseMapsCommandOutput>;
   rpcV2CborDenseMaps(
     args: RpcV2CborDenseMapsCommandInput,
@@ -234,9 +256,12 @@ export interface RpcV2Protocol {
   rpcV2CborLists(): Promise<RpcV2CborListsCommandOutput>;
   rpcV2CborLists(
     args: RpcV2CborListsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RpcV2CborListsCommandOutput>;
-  rpcV2CborLists(args: RpcV2CborListsCommandInput, cb: (err: any, data?: RpcV2CborListsCommandOutput) => void): void;
+  rpcV2CborLists(
+    args: RpcV2CborListsCommandInput,
+    cb: (err: any, data?: RpcV2CborListsCommandOutput) => void
+  ): void;
   rpcV2CborLists(
     args: RpcV2CborListsCommandInput,
     options: __HttpHandlerOptions,
@@ -249,7 +274,7 @@ export interface RpcV2Protocol {
   rpcV2CborSparseMaps(): Promise<RpcV2CborSparseMapsCommandOutput>;
   rpcV2CborSparseMaps(
     args: RpcV2CborSparseMapsCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<RpcV2CborSparseMapsCommandOutput>;
   rpcV2CborSparseMaps(
     args: RpcV2CborSparseMapsCommandInput,
@@ -267,7 +292,7 @@ export interface RpcV2Protocol {
   simpleScalarProperties(): Promise<SimpleScalarPropertiesCommandOutput>;
   simpleScalarProperties(
     args: SimpleScalarPropertiesCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<SimpleScalarPropertiesCommandOutput>;
   simpleScalarProperties(
     args: SimpleScalarPropertiesCommandInput,
@@ -285,7 +310,7 @@ export interface RpcV2Protocol {
   sparseNullsOperation(): Promise<SparseNullsOperationCommandOutput>;
   sparseNullsOperation(
     args: SparseNullsOperationCommandInput,
-    options?: __HttpHandlerOptions
+    options?: __HttpHandlerOptions,
   ): Promise<SparseNullsOperationCommandOutput>;
   sparseNullsOperation(
     args: SparseNullsOperationCommandInput,
@@ -296,6 +321,7 @@ export interface RpcV2Protocol {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: SparseNullsOperationCommandOutput) => void
   ): void;
+
 }
 
 /**

--- a/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
@@ -5,11 +5,26 @@ import {
   defaultRpcV2ProtocolHttpAuthSchemeParametersProvider,
   resolveHttpAuthSchemeConfig,
 } from "./auth/httpAuthSchemeProvider";
-import { EmptyInputOutputCommandInput, EmptyInputOutputCommandOutput } from "./commands/EmptyInputOutputCommand";
-import { Float16CommandInput, Float16CommandOutput } from "./commands/Float16Command";
-import { FractionalSecondsCommandInput, FractionalSecondsCommandOutput } from "./commands/FractionalSecondsCommand";
-import { GreetingWithErrorsCommandInput, GreetingWithErrorsCommandOutput } from "./commands/GreetingWithErrorsCommand";
-import { NoInputOutputCommandInput, NoInputOutputCommandOutput } from "./commands/NoInputOutputCommand";
+import {
+  EmptyInputOutputCommandInput,
+  EmptyInputOutputCommandOutput,
+} from "./commands/EmptyInputOutputCommand";
+import {
+  Float16CommandInput,
+  Float16CommandOutput,
+} from "./commands/Float16Command";
+import {
+  FractionalSecondsCommandInput,
+  FractionalSecondsCommandOutput,
+} from "./commands/FractionalSecondsCommand";
+import {
+  GreetingWithErrorsCommandInput,
+  GreetingWithErrorsCommandOutput,
+} from "./commands/GreetingWithErrorsCommand";
+import {
+  NoInputOutputCommandInput,
+  NoInputOutputCommandOutput,
+} from "./commands/NoInputOutputCommand";
 import {
   OperationWithDefaultsCommandInput,
   OperationWithDefaultsCommandOutput,
@@ -18,9 +33,18 @@ import {
   OptionalInputOutputCommandInput,
   OptionalInputOutputCommandOutput,
 } from "./commands/OptionalInputOutputCommand";
-import { RecursiveShapesCommandInput, RecursiveShapesCommandOutput } from "./commands/RecursiveShapesCommand";
-import { RpcV2CborDenseMapsCommandInput, RpcV2CborDenseMapsCommandOutput } from "./commands/RpcV2CborDenseMapsCommand";
-import { RpcV2CborListsCommandInput, RpcV2CborListsCommandOutput } from "./commands/RpcV2CborListsCommand";
+import {
+  RecursiveShapesCommandInput,
+  RecursiveShapesCommandOutput,
+} from "./commands/RecursiveShapesCommand";
+import {
+  RpcV2CborDenseMapsCommandInput,
+  RpcV2CborDenseMapsCommandOutput,
+} from "./commands/RpcV2CborDenseMapsCommand";
+import {
+  RpcV2CborListsCommandInput,
+  RpcV2CborListsCommandOutput,
+} from "./commands/RpcV2CborListsCommand";
 import {
   RpcV2CborSparseMapsCommandInput,
   RpcV2CborSparseMapsCommandOutput,
@@ -40,7 +64,11 @@ import {
   resolveClientEndpointParameters,
 } from "./endpoint/EndpointParameters";
 import { getRuntimeConfig as __getRuntimeConfig } from "./runtimeConfig";
-import { RuntimeExtension, RuntimeExtensionsConfig, resolveRuntimeExtensions } from "./runtimeExtensions";
+import {
+  RuntimeExtension,
+  RuntimeExtensionsConfig,
+  resolveRuntimeExtensions,
+} from "./runtimeExtensions";
 import {
   DefaultIdentityProviderConfig,
   getHttpAuthSchemeEndpointRuleSetPlugin,
@@ -55,7 +83,12 @@ import {
   resolveEndpointConfig,
   resolveEndpointRequiredConfig,
 } from "@smithy/middleware-endpoint";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@smithy/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@smithy/middleware-retry";
 import { HttpHandlerUserInput as __HttpHandlerUserInput } from "@smithy/protocol-http";
 import {
   Client as __Client,
@@ -77,7 +110,7 @@ import {
   UrlParser as __UrlParser,
 } from "@smithy/types";
 
-export { __Client };
+export { __Client }
 
 /**
  * @public
@@ -118,7 +151,8 @@ export type ServiceOutputTypes =
 /**
  * @public
  */
-export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
+export interface ClientDefaults
+  extends Partial<__SmithyConfiguration<__HttpHandlerOptions>> {
   /**
    * The HTTP handler to use or its constructor options. Fetch in browser and Https in Nodejs.
    */
@@ -211,18 +245,19 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * The {@link @smithy/smithy-client#DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;
+
 }
 
 /**
  * @public
  */
-export type RpcV2ProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
-  ClientDefaults &
-  RetryInputConfig &
-  EndpointInputConfig<EndpointParameters> &
-  EndpointRequiredInputConfig &
-  HttpAuthSchemeInputConfig &
-  ClientInputEndpointParameters;
+export type RpcV2ProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>>
+  & ClientDefaults
+  & RetryInputConfig
+  & EndpointInputConfig<EndpointParameters>
+  & EndpointRequiredInputConfig
+  & HttpAuthSchemeInputConfig
+  & ClientInputEndpointParameters
 /**
  * @public
  *
@@ -233,14 +268,14 @@ export interface RpcV2ProtocolClientConfig extends RpcV2ProtocolClientConfigType
 /**
  * @public
  */
-export type RpcV2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
-  Required<ClientDefaults> &
-  RuntimeExtensionsConfig &
-  RetryResolvedConfig &
-  EndpointResolvedConfig<EndpointParameters> &
-  EndpointRequiredResolvedConfig &
-  HttpAuthSchemeResolvedConfig &
-  ClientResolvedEndpointParameters;
+export type RpcV2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions>
+  & Required<ClientDefaults>
+  & RuntimeExtensionsConfig
+  & RetryResolvedConfig
+  & EndpointResolvedConfig<EndpointParameters>
+  & EndpointRequiredResolvedConfig
+  & HttpAuthSchemeResolvedConfig
+  & ClientResolvedEndpointParameters
 /**
  * @public
  *
@@ -273,16 +308,17 @@ export class RpcV2ProtocolClient extends __Client<
     let _config_5 = resolveHttpAuthSchemeConfig(_config_4);
     let _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
     this.config = _config_6;
-    this.middlewareStack.use(getRetryPlugin(this.config));
-    this.middlewareStack.use(getContentLengthPlugin(this.config));
-    this.middlewareStack.use(
-      getHttpAuthSchemeEndpointRuleSetPlugin(this.config, {
-        httpAuthSchemeParametersProvider: defaultRpcV2ProtocolHttpAuthSchemeParametersProvider,
-        identityProviderConfigProvider: async (config: RpcV2ProtocolClientResolvedConfig) =>
-          new DefaultIdentityProviderConfig({}),
-      })
-    );
-    this.middlewareStack.use(getHttpSigningPlugin(this.config));
+    this.middlewareStack.use(getRetryPlugin(this.config
+    ));
+    this.middlewareStack.use(getContentLengthPlugin(this.config
+    ));
+    this.middlewareStack.use(getHttpAuthSchemeEndpointRuleSetPlugin(this.config
+      , {
+        httpAuthSchemeParametersProvider: defaultRpcV2ProtocolHttpAuthSchemeParametersProvider,identityProviderConfigProvider: async (config: RpcV2ProtocolClientResolvedConfig) => new DefaultIdentityProviderConfig({
+        }), }
+    ));
+    this.middlewareStack.use(getHttpSigningPlugin(this.config
+    ));
   }
 
   /**

--- a/private/smithy-rpcv2-cbor/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/smithy-rpcv2-cbor/src/auth/httpAuthExtensionConfiguration.ts
@@ -23,14 +23,12 @@ export type HttpAuthRuntimeConfig = Partial<{
 /**
  * @internal
  */
-export const getHttpAuthExtensionConfiguration = (
-  runtimeConfig: HttpAuthRuntimeConfig
-): HttpAuthExtensionConfiguration => {
+export const getHttpAuthExtensionConfiguration = (runtimeConfig: HttpAuthRuntimeConfig): HttpAuthExtensionConfiguration => {
   let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
-      const index = _httpAuthSchemes.findIndex((scheme) => scheme.schemeId === httpAuthScheme.schemeId);
+      const index = _httpAuthSchemes.findIndex(scheme => scheme.schemeId === httpAuthScheme.schemeId);
       if (index === -1) {
         _httpAuthSchemes.push(httpAuthScheme);
       } else {
@@ -46,7 +44,7 @@ export const getHttpAuthExtensionConfiguration = (
     httpAuthSchemeProvider(): RpcV2ProtocolHttpAuthSchemeProvider {
       return _httpAuthSchemeProvider;
     },
-  };
+  }
 };
 
 /**

--- a/private/smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
+++ b/private/smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
@@ -9,32 +9,26 @@ import {
   HttpAuthSchemeProvider,
   Provider,
 } from "@smithy/types";
-import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
+import {
+  getSmithyContext,
+  normalizeProvider,
+} from "@smithy/util-middleware";
 
 /**
  * @internal
  */
-export interface RpcV2ProtocolHttpAuthSchemeParameters extends HttpAuthSchemeParameters {}
+export interface RpcV2ProtocolHttpAuthSchemeParameters extends HttpAuthSchemeParameters {
+}
 
 /**
  * @internal
  */
-export interface RpcV2ProtocolHttpAuthSchemeParametersProvider
-  extends HttpAuthSchemeParametersProvider<
-    RpcV2ProtocolClientResolvedConfig,
-    HandlerExecutionContext,
-    RpcV2ProtocolHttpAuthSchemeParameters,
-    object
-  > {}
+export interface RpcV2ProtocolHttpAuthSchemeParametersProvider extends HttpAuthSchemeParametersProvider<RpcV2ProtocolClientResolvedConfig, HandlerExecutionContext, RpcV2ProtocolHttpAuthSchemeParameters, object> {}
 
 /**
  * @internal
  */
-export const defaultRpcV2ProtocolHttpAuthSchemeParametersProvider = async (
-  config: RpcV2ProtocolClientResolvedConfig,
-  context: HandlerExecutionContext,
-  input: object
-): Promise<RpcV2ProtocolHttpAuthSchemeParameters> => {
+export const defaultRpcV2ProtocolHttpAuthSchemeParametersProvider = async (config: RpcV2ProtocolClientResolvedConfig, context: HandlerExecutionContext, input: object): Promise<RpcV2ProtocolHttpAuthSchemeParameters> => {
   return {
     operation: getSmithyContext(context).operation as string,
   };
@@ -44,13 +38,12 @@ function createSmithyApiNoAuthHttpAuthOption(authParameters: RpcV2ProtocolHttpAu
   return {
     schemeId: "smithy.api#noAuth",
   };
-}
+};
 
 /**
  * @internal
  */
-export interface RpcV2ProtocolHttpAuthSchemeProvider
-  extends HttpAuthSchemeProvider<RpcV2ProtocolHttpAuthSchemeParameters> {}
+export interface RpcV2ProtocolHttpAuthSchemeProvider extends HttpAuthSchemeProvider<RpcV2ProtocolHttpAuthSchemeParameters> {}
 
 /**
  * @internal
@@ -60,8 +53,8 @@ export const defaultRpcV2ProtocolHttpAuthSchemeProvider: RpcV2ProtocolHttpAuthSc
   switch (authParameters.operation) {
     default: {
       options.push(createSmithyApiNoAuthHttpAuthOption(authParameters));
-    }
-  }
+    };
+  };
   return options;
 };
 
@@ -88,6 +81,7 @@ export interface HttpAuthSchemeInputConfig {
    * @internal
    */
   httpAuthSchemeProvider?: RpcV2ProtocolHttpAuthSchemeProvider;
+
 }
 
 /**
@@ -113,15 +107,15 @@ export interface HttpAuthSchemeResolvedConfig {
    * @internal
    */
   readonly httpAuthSchemeProvider: RpcV2ProtocolHttpAuthSchemeProvider;
+
 }
 
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
-): T & HttpAuthSchemeResolvedConfig => {
-  return Object.assign(config, {
+export const resolveHttpAuthSchemeConfig = <T>(config: T & HttpAuthSchemeInputConfig): T & HttpAuthSchemeResolvedConfig => {
+  return Object.assign(
+    config, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/private/smithy-rpcv2-cbor/src/commands/EmptyInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/EmptyInputOutputCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { EmptyStructure } from "../models/models_0";
-import { de_EmptyInputOutputCommand, se_EmptyInputOutputCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_EmptyInputOutputCommand,
+  se_EmptyInputOutputCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -55,36 +62,31 @@ export interface EmptyInputOutputCommandOutput extends EmptyStructure, __Metadat
  *
  *
  */
-export class EmptyInputOutputCommand extends $Command
-  .classBuilder<
-    EmptyInputOutputCommandInput,
-    EmptyInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class EmptyInputOutputCommand extends $Command.classBuilder<EmptyInputOutputCommandInput, EmptyInputOutputCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "EmptyInputOutput", {})
-  .n("RpcV2ProtocolClient", "EmptyInputOutputCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "EmptyInputOutput", {
+
+  })
+  .n("RpcV2ProtocolClient", "EmptyInputOutputCommand").f(void 0, void 0)
   .ser(se_EmptyInputOutputCommand)
   .de(de_EmptyInputOutputCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: {};
-    };
-    sdk: {
+  };
+  sdk: {
       input: EmptyInputOutputCommandInput;
       output: EmptyInputOutputCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/Float16Command.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/Float16Command.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { Float16Output } from "../models/models_0";
-import { de_Float16Command, se_Float16Command } from "../protocols/Rpcv2cbor";
+import {
+  de_Float16Command,
+  se_Float16Command,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -57,36 +64,31 @@ export interface Float16CommandOutput extends Float16Output, __MetadataBearer {}
  *
  *
  */
-export class Float16Command extends $Command
-  .classBuilder<
-    Float16CommandInput,
-    Float16CommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class Float16Command extends $Command.classBuilder<Float16CommandInput, Float16CommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "Float16", {})
-  .n("RpcV2ProtocolClient", "Float16Command")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "Float16", {
+
+  })
+  .n("RpcV2ProtocolClient", "Float16Command").f(void 0, void 0)
   .ser(se_Float16Command)
   .de(de_Float16Command)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: Float16Output;
-    };
-    sdk: {
+  };
+  sdk: {
       input: Float16CommandInput;
       output: Float16CommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/FractionalSecondsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/FractionalSecondsCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { FractionalSecondsOutput } from "../models/models_0";
-import { de_FractionalSecondsCommand, se_FractionalSecondsCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_FractionalSecondsCommand,
+  se_FractionalSecondsCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -57,36 +64,31 @@ export interface FractionalSecondsCommandOutput extends FractionalSecondsOutput,
  *
  *
  */
-export class FractionalSecondsCommand extends $Command
-  .classBuilder<
-    FractionalSecondsCommandInput,
-    FractionalSecondsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class FractionalSecondsCommand extends $Command.classBuilder<FractionalSecondsCommandInput, FractionalSecondsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "FractionalSeconds", {})
-  .n("RpcV2ProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "FractionalSeconds", {
+
+  })
+  .n("RpcV2ProtocolClient", "FractionalSecondsCommand").f(void 0, void 0)
   .ser(se_FractionalSecondsCommand)
   .de(de_FractionalSecondsCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: FractionalSecondsOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: FractionalSecondsCommandInput;
       output: FractionalSecondsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/GreetingWithErrorsCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { GreetingWithErrorsOutput } from "../models/models_0";
-import { de_GreetingWithErrorsCommand, se_GreetingWithErrorsCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_GreetingWithErrorsCommand,
+  se_GreetingWithErrorsCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -70,36 +77,31 @@ export interface GreetingWithErrorsCommandOutput extends GreetingWithErrorsOutpu
  *
  * @public
  */
-export class GreetingWithErrorsCommand extends $Command
-  .classBuilder<
-    GreetingWithErrorsCommandInput,
-    GreetingWithErrorsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class GreetingWithErrorsCommand extends $Command.classBuilder<GreetingWithErrorsCommandInput, GreetingWithErrorsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "GreetingWithErrors", {})
-  .n("RpcV2ProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "GreetingWithErrors", {
+
+  })
+  .n("RpcV2ProtocolClient", "GreetingWithErrorsCommand").f(void 0, void 0)
   .ser(se_GreetingWithErrorsCommand)
   .de(de_GreetingWithErrorsCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: GreetingWithErrorsOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: GreetingWithErrorsCommandInput;
       output: GreetingWithErrorsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/NoInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/NoInputOutputCommand.ts
@@ -1,7 +1,14 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
-import { de_NoInputOutputCommand, se_NoInputOutputCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_NoInputOutputCommand,
+  se_NoInputOutputCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -54,36 +61,31 @@ export interface NoInputOutputCommandOutput extends __MetadataBearer {}
  *
  *
  */
-export class NoInputOutputCommand extends $Command
-  .classBuilder<
-    NoInputOutputCommandInput,
-    NoInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class NoInputOutputCommand extends $Command.classBuilder<NoInputOutputCommandInput, NoInputOutputCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "NoInputOutput", {})
-  .n("RpcV2ProtocolClient", "NoInputOutputCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "NoInputOutput", {
+
+  })
+  .n("RpcV2ProtocolClient", "NoInputOutputCommand").f(void 0, void 0)
   .ser(se_NoInputOutputCommand)
   .de(de_NoInputOutputCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: {};
       output: {};
-    };
-    sdk: {
+  };
+  sdk: {
       input: NoInputOutputCommandInput;
       output: NoInputOutputCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/OperationWithDefaultsCommand.ts
@@ -1,8 +1,18 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
-import { OperationWithDefaultsInput, OperationWithDefaultsOutput } from "../models/models_0";
-import { de_OperationWithDefaultsCommand, se_OperationWithDefaultsCommand } from "../protocols/Rpcv2cbor";
+import {
+  OperationWithDefaultsInput,
+  OperationWithDefaultsOutput,
+} from "../models/models_0";
+import {
+  de_OperationWithDefaultsCommand,
+  se_OperationWithDefaultsCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -123,36 +133,31 @@ export interface OperationWithDefaultsCommandOutput extends OperationWithDefault
  *
  *
  */
-export class OperationWithDefaultsCommand extends $Command
-  .classBuilder<
-    OperationWithDefaultsCommandInput,
-    OperationWithDefaultsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class OperationWithDefaultsCommand extends $Command.classBuilder<OperationWithDefaultsCommandInput, OperationWithDefaultsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "OperationWithDefaults", {})
-  .n("RpcV2ProtocolClient", "OperationWithDefaultsCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "OperationWithDefaults", {
+
+  })
+  .n("RpcV2ProtocolClient", "OperationWithDefaultsCommand").f(void 0, void 0)
   .ser(se_OperationWithDefaultsCommand)
   .de(de_OperationWithDefaultsCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: OperationWithDefaultsInput;
       output: OperationWithDefaultsOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: OperationWithDefaultsCommandInput;
       output: OperationWithDefaultsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/OptionalInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/OptionalInputOutputCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { SimpleStructure } from "../models/models_0";
-import { de_OptionalInputOutputCommand, se_OptionalInputOutputCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_OptionalInputOutputCommand,
+  se_OptionalInputOutputCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -59,36 +66,31 @@ export interface OptionalInputOutputCommandOutput extends SimpleStructure, __Met
  *
  *
  */
-export class OptionalInputOutputCommand extends $Command
-  .classBuilder<
-    OptionalInputOutputCommandInput,
-    OptionalInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class OptionalInputOutputCommand extends $Command.classBuilder<OptionalInputOutputCommandInput, OptionalInputOutputCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "OptionalInputOutput", {})
-  .n("RpcV2ProtocolClient", "OptionalInputOutputCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "OptionalInputOutput", {
+
+  })
+  .n("RpcV2ProtocolClient", "OptionalInputOutputCommand").f(void 0, void 0)
   .ser(se_OptionalInputOutputCommand)
   .de(de_OptionalInputOutputCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: SimpleStructure;
       output: SimpleStructure;
-    };
-    sdk: {
+  };
+  sdk: {
       input: OptionalInputOutputCommandInput;
       output: OptionalInputOutputCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/RecursiveShapesCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RecursiveShapesCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RecursiveShapesInputOutput } from "../models/models_0";
-import { de_RecursiveShapesCommand, se_RecursiveShapesCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_RecursiveShapesCommand,
+  se_RecursiveShapesCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -83,36 +90,31 @@ export interface RecursiveShapesCommandOutput extends RecursiveShapesInputOutput
  *
  *
  */
-export class RecursiveShapesCommand extends $Command
-  .classBuilder<
-    RecursiveShapesCommandInput,
-    RecursiveShapesCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RecursiveShapesCommand extends $Command.classBuilder<RecursiveShapesCommandInput, RecursiveShapesCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RecursiveShapes", {})
-  .n("RpcV2ProtocolClient", "RecursiveShapesCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "RecursiveShapes", {
+
+  })
+  .n("RpcV2ProtocolClient", "RecursiveShapesCommand").f(void 0, void 0)
   .ser(se_RecursiveShapesCommand)
   .de(de_RecursiveShapesCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RecursiveShapesInputOutput;
       output: RecursiveShapesInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RecursiveShapesCommandInput;
       output: RecursiveShapesCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RpcV2CborDenseMapsInputOutput } from "../models/models_0";
-import { de_RpcV2CborDenseMapsCommand, se_RpcV2CborDenseMapsCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_RpcV2CborDenseMapsCommand,
+  se_RpcV2CborDenseMapsCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -100,36 +107,31 @@ export interface RpcV2CborDenseMapsCommandOutput extends RpcV2CborDenseMapsInput
  *
  * @public
  */
-export class RpcV2CborDenseMapsCommand extends $Command
-  .classBuilder<
-    RpcV2CborDenseMapsCommandInput,
-    RpcV2CborDenseMapsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RpcV2CborDenseMapsCommand extends $Command.classBuilder<RpcV2CborDenseMapsCommandInput, RpcV2CborDenseMapsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RpcV2CborDenseMaps", {})
-  .n("RpcV2ProtocolClient", "RpcV2CborDenseMapsCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "RpcV2CborDenseMaps", {
+
+  })
+  .n("RpcV2ProtocolClient", "RpcV2CborDenseMapsCommand").f(void 0, void 0)
   .ser(se_RpcV2CborDenseMapsCommand)
   .de(de_RpcV2CborDenseMapsCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RpcV2CborDenseMapsInputOutput;
       output: RpcV2CborDenseMapsInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RpcV2CborDenseMapsCommandInput;
       output: RpcV2CborDenseMapsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborListsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborListsCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RpcV2CborListInputOutput } from "../models/models_0";
-import { de_RpcV2CborListsCommand, se_RpcV2CborListsCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_RpcV2CborListsCommand,
+  se_RpcV2CborListsCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -138,36 +145,31 @@ export interface RpcV2CborListsCommandOutput extends RpcV2CborListInputOutput, _
  *
  * @public
  */
-export class RpcV2CborListsCommand extends $Command
-  .classBuilder<
-    RpcV2CborListsCommandInput,
-    RpcV2CborListsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RpcV2CborListsCommand extends $Command.classBuilder<RpcV2CborListsCommandInput, RpcV2CborListsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RpcV2CborLists", {})
-  .n("RpcV2ProtocolClient", "RpcV2CborListsCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "RpcV2CborLists", {
+
+  })
+  .n("RpcV2ProtocolClient", "RpcV2CborListsCommand").f(void 0, void 0)
   .ser(se_RpcV2CborListsCommand)
   .de(de_RpcV2CborListsCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RpcV2CborListInputOutput;
       output: RpcV2CborListInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RpcV2CborListsCommandInput;
       output: RpcV2CborListsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { RpcV2CborSparseMapsInputOutput } from "../models/models_0";
-import { de_RpcV2CborSparseMapsCommand, se_RpcV2CborSparseMapsCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_RpcV2CborSparseMapsCommand,
+  se_RpcV2CborSparseMapsCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -100,36 +107,31 @@ export interface RpcV2CborSparseMapsCommandOutput extends RpcV2CborSparseMapsInp
  *
  *
  */
-export class RpcV2CborSparseMapsCommand extends $Command
-  .classBuilder<
-    RpcV2CborSparseMapsCommandInput,
-    RpcV2CborSparseMapsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class RpcV2CborSparseMapsCommand extends $Command.classBuilder<RpcV2CborSparseMapsCommandInput, RpcV2CborSparseMapsCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "RpcV2CborSparseMaps", {})
-  .n("RpcV2ProtocolClient", "RpcV2CborSparseMapsCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "RpcV2CborSparseMaps", {
+
+  })
+  .n("RpcV2ProtocolClient", "RpcV2CborSparseMapsCommand").f(void 0, void 0)
   .ser(se_RpcV2CborSparseMapsCommand)
   .de(de_RpcV2CborSparseMapsCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: RpcV2CborSparseMapsInputOutput;
       output: RpcV2CborSparseMapsInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: RpcV2CborSparseMapsCommandInput;
       output: RpcV2CborSparseMapsCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/SimpleScalarPropertiesCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { SimpleScalarStructure } from "../models/models_0";
-import { de_SimpleScalarPropertiesCommand, se_SimpleScalarPropertiesCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_SimpleScalarPropertiesCommand,
+  se_SimpleScalarPropertiesCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -77,36 +84,31 @@ export interface SimpleScalarPropertiesCommandOutput extends SimpleScalarStructu
  *
  *
  */
-export class SimpleScalarPropertiesCommand extends $Command
-  .classBuilder<
-    SimpleScalarPropertiesCommandInput,
-    SimpleScalarPropertiesCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class SimpleScalarPropertiesCommand extends $Command.classBuilder<SimpleScalarPropertiesCommandInput, SimpleScalarPropertiesCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "SimpleScalarProperties", {})
-  .n("RpcV2ProtocolClient", "SimpleScalarPropertiesCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "SimpleScalarProperties", {
+
+  })
+  .n("RpcV2ProtocolClient", "SimpleScalarPropertiesCommand").f(void 0, void 0)
   .ser(se_SimpleScalarPropertiesCommand)
   .de(de_SimpleScalarPropertiesCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: SimpleScalarStructure;
       output: SimpleScalarStructure;
-    };
-    sdk: {
+  };
+  sdk: {
       input: SimpleScalarPropertiesCommandInput;
       output: SimpleScalarPropertiesCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/commands/SparseNullsOperationCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/SparseNullsOperationCommand.ts
@@ -1,8 +1,15 @@
 // smithy-typescript generated code
-import { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import {
+  RpcV2ProtocolClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../RpcV2ProtocolClient";
 import { commonParams } from "../endpoint/EndpointParameters";
 import { SparseNullsOperationInputOutput } from "../models/models_0";
-import { de_SparseNullsOperationCommand, se_SparseNullsOperationCommand } from "../protocols/Rpcv2cbor";
+import {
+  de_SparseNullsOperationCommand,
+  se_SparseNullsOperationCommand,
+} from "../protocols/Rpcv2cbor";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -69,36 +76,31 @@ export interface SparseNullsOperationCommandOutput extends SparseNullsOperationI
  *
  *
  */
-export class SparseNullsOperationCommand extends $Command
-  .classBuilder<
-    SparseNullsOperationCommandInput,
-    SparseNullsOperationCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
+export class SparseNullsOperationCommand extends $Command.classBuilder<SparseNullsOperationCommandInput, SparseNullsOperationCommandOutput, RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
   .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [
-      getSerdePlugin(config, this.serialize, this.deserialize),
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-    ];
+      .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+  getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      ];
   })
-  .s("RpcV2Protocol", "SparseNullsOperation", {})
-  .n("RpcV2ProtocolClient", "SparseNullsOperationCommand")
-  .f(void 0, void 0)
+  .s("RpcV2Protocol", "SparseNullsOperation", {
+
+  })
+  .n("RpcV2ProtocolClient", "SparseNullsOperationCommand").f(void 0, void 0)
   .ser(se_SparseNullsOperationCommand)
   .de(de_SparseNullsOperationCommand)
-  .build() {
-  /** @internal type navigation helper, not in runtime. */
-  protected declare static __types: {
-    api: {
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
       input: SparseNullsOperationInputOutput;
       output: SparseNullsOperationInputOutput;
-    };
-    sdk: {
+  };
+  sdk: {
       input: SparseNullsOperationCommandInput;
       output: SparseNullsOperationCommandOutput;
-    };
   };
+};
 }

--- a/private/smithy-rpcv2-cbor/src/endpoint/EndpointParameters.ts
+++ b/private/smithy-rpcv2-cbor/src/endpoint/EndpointParameters.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { Endpoint, EndpointV2, Provider, EndpointParameters as __EndpointParameters } from "@smithy/types";
+import {
+  Endpoint,
+  EndpointV2,
+  Provider,
+  EndpointParameters as __EndpointParameters,
+} from "@smithy/types";
 
 /**
  * @public
@@ -9,20 +14,19 @@ export interface ClientInputEndpointParameters {
 }
 
 export type ClientResolvedEndpointParameters = Omit<ClientInputEndpointParameters, "endpoint"> & {
+
   defaultSigningName: string;
 };
 
-export const resolveClientEndpointParameters = <T>(
-  options: T & ClientInputEndpointParameters
-): T & ClientResolvedEndpointParameters => {
+export const resolveClientEndpointParameters = <T>(options: T & ClientInputEndpointParameters): T & ClientResolvedEndpointParameters => {
   return Object.assign(options, {
     defaultSigningName: "",
   });
-};
+}
 
 export const commonParams = {
   endpoint: { type: "builtInParams", name: "endpoint" },
-} as const;
+} as const
 
 export interface EndpointParameters extends __EndpointParameters {
   endpoint?: string | undefined;

--- a/private/smithy-rpcv2-cbor/src/endpoint/endpointResolver.ts
+++ b/private/smithy-rpcv2-cbor/src/endpoint/endpointResolver.ts
@@ -1,22 +1,27 @@
 // smithy-typescript generated code
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
-import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointCache, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import {
+  EndpointV2,
+  Logger,
+} from "@smithy/types";
+import {
+  EndpointCache,
+  EndpointParams,
+  resolveEndpoint,
+} from "@smithy/util-endpoints";
 
 const cache = new EndpointCache({
-  size: 50,
-  params: ["endpoint"],
+    size: 50,
+    params: ["endpoint"]
 });
 
 export const defaultEndpointResolver = (
-  endpointParams: EndpointParameters,
-  context: { logger?: Logger } = {}
+    endpointParams: EndpointParameters,
+    context: { logger?: Logger } = {}
 ): EndpointV2 => {
-  return cache.get(endpointParams as EndpointParams, () =>
-    resolveEndpoint(ruleSet, {
-      endpointParams: endpointParams as EndpointParams,
-      logger: context.logger,
-    })
-  );
+    return cache.get(endpointParams as EndpointParams, () => resolveEndpoint(ruleSet, {
+        endpointParams: endpointParams as EndpointParams,
+        logger: context.logger,
+    }));
 };

--- a/private/smithy-rpcv2-cbor/src/endpoint/ruleset.ts
+++ b/private/smithy-rpcv2-cbor/src/endpoint/ruleset.ts
@@ -1,38 +1,41 @@
 // smithy-typescript generated code
 import { RuleSetObject } from "@smithy/types";
 
-export const ruleSet: RuleSetObject = {
-  version: "1.0",
-  parameters: {
-    endpoint: {
-      type: "string",
-      builtIn: "SDK::Endpoint",
-      documentation: "Endpoint used for making requests. Should be formatted as a URI.",
-    },
-  },
-  rules: [
-    {
-      conditions: [
-        {
-          fn: "isSet",
-          argv: [
-            {
-              ref: "endpoint",
-            },
-          ],
-        },
-      ],
-      endpoint: {
-        url: {
-          ref: "endpoint",
-        },
+export const ruleSet: RuleSetObject =
+  {
+    "version": "1.0",
+    "parameters": {
+      "endpoint": {
+        "type": "string",
+        "builtIn": "SDK::Endpoint",
+        "documentation": "Endpoint used for making requests. Should be formatted as a URI.",
       },
-      type: "endpoint",
     },
-    {
-      conditions: [],
-      error: "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
-      type: "error",
-    },
-  ],
-};
+    "rules": [
+      {
+        "conditions": [
+          {
+            "fn": "isSet",
+            "argv": [
+              {
+                "ref": "endpoint",
+              },
+            ],
+          },
+        ],
+        "endpoint": {
+          "url": {
+            "ref": "endpoint",
+          },
+        },
+        "type": "endpoint",
+      },
+      {
+        "conditions": [
+        ],
+        "error": "(default endpointRuleSet) endpoint is not set - you must configure an endpoint.",
+        "type": "error",
+      },
+    ],
+  }
+;

--- a/private/smithy-rpcv2-cbor/src/extensionConfiguration.ts
+++ b/private/smithy-rpcv2-cbor/src/extensionConfiguration.ts
@@ -6,7 +6,4 @@ import { DefaultExtensionConfiguration } from "@smithy/types";
 /**
  * @internal
  */
-export interface RpcV2ProtocolExtensionConfiguration
-  extends HttpHandlerExtensionConfiguration,
-    DefaultExtensionConfiguration,
-    HttpAuthExtensionConfiguration {}
+export interface RpcV2ProtocolExtensionConfiguration extends HttpHandlerExtensionConfiguration, DefaultExtensionConfiguration, HttpAuthExtensionConfiguration {}

--- a/private/smithy-rpcv2-cbor/src/models/RpcV2ProtocolServiceException.ts
+++ b/private/smithy-rpcv2-cbor/src/models/RpcV2ProtocolServiceException.ts
@@ -4,9 +4,9 @@ import {
   ServiceExceptionOptions as __ServiceExceptionOptions,
 } from "@smithy/smithy-client";
 
-export type { __ServiceExceptionOptions };
+export type { __ServiceExceptionOptions }
 
-export { __ServiceException };
+export { __ServiceException }
 
 /**
  * @public

--- a/private/smithy-rpcv2-cbor/src/models/enums.ts
+++ b/private/smithy-rpcv2-cbor/src/models/enums.ts
@@ -7,11 +7,11 @@ export const TestEnum = {
   BAR: "BAR",
   BAZ: "BAZ",
   FOO: "FOO",
-} as const;
+} as const
 /**
  * @public
  */
-export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
+export type TestEnum = typeof TestEnum[keyof typeof TestEnum]
 
 export enum TestIntEnum {
   ONE = 1,
@@ -28,11 +28,11 @@ export const FooEnum = {
   FOO: "Foo",
   ONE: "1",
   ZERO: "0",
-} as const;
+} as const
 /**
  * @public
  */
-export type FooEnum = (typeof FooEnum)[keyof typeof FooEnum];
+export type FooEnum = typeof FooEnum[keyof typeof FooEnum]
 
 export enum IntegerEnum {
   A = 1,

--- a/private/smithy-rpcv2-cbor/src/models/errors.ts
+++ b/private/smithy-rpcv2-cbor/src/models/errors.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { RpcV2ProtocolServiceException as __BaseException } from "./RpcV2ProtocolServiceException";
-import { ComplexNestedErrorData, ValidationExceptionField } from "./models_0";
+import {
+  ComplexNestedErrorData,
+  ValidationExceptionField,
+} from "./models_0";
 import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
 
 /**
@@ -17,7 +20,7 @@ export class ValidationException extends __BaseException {
    * A member can appear in this list more than once if it failed to satisfy multiple constraints.
    * @public
    */
-  fieldList?: ValidationExceptionField[] | undefined;
+  fieldList?: (ValidationExceptionField)[] | undefined;
 
   /**
    * @internal
@@ -26,7 +29,7 @@ export class ValidationException extends __BaseException {
     super({
       name: "ValidationException",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, ValidationException.prototype);
     this.fieldList = opts.fieldList;
@@ -49,7 +52,7 @@ export class ComplexError extends __BaseException {
     super({
       name: "ComplexError",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, ComplexError.prototype);
     this.TopLevel = opts.TopLevel;
@@ -72,7 +75,7 @@ export class InvalidGreeting extends __BaseException {
     super({
       name: "InvalidGreeting",
       $fault: "client",
-      ...opts,
+      ...opts
     });
     Object.setPrototypeOf(this, InvalidGreeting.prototype);
     this.Message = opts.Message;

--- a/private/smithy-rpcv2-cbor/src/models/models_0.ts
+++ b/private/smithy-rpcv2-cbor/src/models/models_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { FooEnum, IntegerEnum, TestEnum, TestIntEnum } from "./enums";
+import {
+  FooEnum,
+  IntegerEnum,
+  TestEnum,
+  TestIntEnum,
+} from "./enums";
 
 /**
  * Describes one specific validation failure for an input member.
@@ -39,7 +44,7 @@ export interface ComplexNestedErrorData {
 export interface Defaults {
   defaultString?: string | undefined;
   defaultBoolean?: boolean | undefined;
-  defaultList?: string[] | undefined;
+  defaultList?: (string)[] | undefined;
   defaultTimestamp?: Date | undefined;
   defaultBlob?: Uint8Array | undefined;
   defaultByte?: number | undefined;
@@ -72,7 +77,8 @@ export interface GreetingStruct {
 /**
  * @public
  */
-export interface EmptyStructure {}
+export interface EmptyStructure {
+}
 
 /**
  * @public
@@ -111,7 +117,7 @@ export interface OperationWithDefaultsInput {
 export interface OperationWithDefaultsOutput {
   defaultString?: string | undefined;
   defaultBoolean?: boolean | undefined;
-  defaultList?: string[] | undefined;
+  defaultList?: (string)[] | undefined;
   defaultTimestamp?: Date | undefined;
   defaultBlob?: Uint8Array | undefined;
   defaultByte?: number | undefined;
@@ -149,7 +155,7 @@ export interface RpcV2CborDenseMapsInputOutput {
   denseNumberMap?: Record<string, number> | undefined;
   denseBooleanMap?: Record<string, boolean> | undefined;
   denseStringMap?: Record<string, string> | undefined;
-  denseSetMap?: Record<string, string[]> | undefined;
+  denseSetMap?: Record<string, (string)[]> | undefined;
 }
 
 /**
@@ -164,21 +170,21 @@ export interface StructureListMember {
  * @public
  */
 export interface RpcV2CborListInputOutput {
-  stringList?: string[] | undefined;
-  stringSet?: string[] | undefined;
-  integerList?: number[] | undefined;
-  booleanList?: boolean[] | undefined;
-  timestampList?: Date[] | undefined;
-  enumList?: FooEnum[] | undefined;
-  intEnumList?: IntegerEnum[] | undefined;
+  stringList?: (string)[] | undefined;
+  stringSet?: (string)[] | undefined;
+  integerList?: (number)[] | undefined;
+  booleanList?: (boolean)[] | undefined;
+  timestampList?: (Date)[] | undefined;
+  enumList?: (FooEnum)[] | undefined;
+  intEnumList?: (IntegerEnum)[] | undefined;
   /**
    * A list of lists of strings.
    * @public
    */
-  nestedStringList?: string[][] | undefined;
+  nestedStringList?: ((string)[])[] | undefined;
 
-  structureList?: StructureListMember[] | undefined;
-  blobList?: Uint8Array[] | undefined;
+  structureList?: (StructureListMember)[] | undefined;
+  blobList?: (Uint8Array)[] | undefined;
 }
 
 /**
@@ -189,7 +195,7 @@ export interface RpcV2CborSparseMapsInputOutput {
   sparseNumberMap?: Record<string, number> | undefined;
   sparseBooleanMap?: Record<string, boolean> | undefined;
   sparseStringMap?: Record<string, string> | undefined;
-  sparseSetMap?: Record<string, string[]> | undefined;
+  sparseSetMap?: Record<string, (string)[]> | undefined;
 }
 
 /**
@@ -212,7 +218,7 @@ export interface SimpleScalarStructure {
  * @public
  */
 export interface SparseNullsOperationInputOutput {
-  sparseStringList?: string[] | undefined;
+  sparseStringList?: (string)[] | undefined;
   sparseStringMap?: Record<string, string> | undefined;
 }
 

--- a/private/smithy-rpcv2-cbor/src/protocols/Rpcv2cbor.ts
+++ b/private/smithy-rpcv2-cbor/src/protocols/Rpcv2cbor.ts
@@ -1,9 +1,24 @@
 // smithy-typescript generated code
-import { EmptyInputOutputCommandInput, EmptyInputOutputCommandOutput } from "../commands/EmptyInputOutputCommand";
-import { Float16CommandInput, Float16CommandOutput } from "../commands/Float16Command";
-import { FractionalSecondsCommandInput, FractionalSecondsCommandOutput } from "../commands/FractionalSecondsCommand";
-import { GreetingWithErrorsCommandInput, GreetingWithErrorsCommandOutput } from "../commands/GreetingWithErrorsCommand";
-import { NoInputOutputCommandInput, NoInputOutputCommandOutput } from "../commands/NoInputOutputCommand";
+import {
+  EmptyInputOutputCommandInput,
+  EmptyInputOutputCommandOutput,
+} from "../commands/EmptyInputOutputCommand";
+import {
+  Float16CommandInput,
+  Float16CommandOutput,
+} from "../commands/Float16Command";
+import {
+  FractionalSecondsCommandInput,
+  FractionalSecondsCommandOutput,
+} from "../commands/FractionalSecondsCommand";
+import {
+  GreetingWithErrorsCommandInput,
+  GreetingWithErrorsCommandOutput,
+} from "../commands/GreetingWithErrorsCommand";
+import {
+  NoInputOutputCommandInput,
+  NoInputOutputCommandOutput,
+} from "../commands/NoInputOutputCommand";
 import {
   OperationWithDefaultsCommandInput,
   OperationWithDefaultsCommandOutput,
@@ -12,9 +27,18 @@ import {
   OptionalInputOutputCommandInput,
   OptionalInputOutputCommandOutput,
 } from "../commands/OptionalInputOutputCommand";
-import { RecursiveShapesCommandInput, RecursiveShapesCommandOutput } from "../commands/RecursiveShapesCommand";
-import { RpcV2CborDenseMapsCommandInput, RpcV2CborDenseMapsCommandOutput } from "../commands/RpcV2CborDenseMapsCommand";
-import { RpcV2CborListsCommandInput, RpcV2CborListsCommandOutput } from "../commands/RpcV2CborListsCommand";
+import {
+  RecursiveShapesCommandInput,
+  RecursiveShapesCommandOutput,
+} from "../commands/RecursiveShapesCommand";
+import {
+  RpcV2CborDenseMapsCommandInput,
+  RpcV2CborDenseMapsCommandOutput,
+} from "../commands/RpcV2CborDenseMapsCommand";
+import {
+  RpcV2CborListsCommandInput,
+  RpcV2CborListsCommandOutput,
+} from "../commands/RpcV2CborListsCommand";
 import {
   RpcV2CborSparseMapsCommandInput,
   RpcV2CborSparseMapsCommandOutput,
@@ -28,8 +52,15 @@ import {
   SparseNullsOperationCommandOutput,
 } from "../commands/SparseNullsOperationCommand";
 import { RpcV2ProtocolServiceException as __BaseException } from "../models/RpcV2ProtocolServiceException";
-import { FooEnum, IntegerEnum } from "../models/enums";
-import { ComplexError, InvalidGreeting, ValidationException } from "../models/errors";
+import {
+  FooEnum,
+  IntegerEnum,
+} from "../models/enums";
+import {
+  ComplexError,
+  InvalidGreeting,
+  ValidationException,
+} from "../models/errors";
 import {
   ClientOptionalDefaults,
   Defaults,
@@ -59,7 +90,10 @@ import {
   parseCborBody as parseBody,
   parseCborErrorBody as parseErrorBody,
 } from "@smithy/core/cbor";
-import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
+import {
+  HttpRequest as __HttpRequest,
+  HttpResponse as __HttpResponse,
+} from "@smithy/protocol-http";
 import {
   decorateServiceException as __decorateServiceException,
   expectBoolean as __expectBoolean,
@@ -87,7 +121,7 @@ import {
 /**
  * serializeRpcv2cborEmptyInputOutputCommand
  */
-export const se_EmptyInputOutputCommand = async (
+export const se_EmptyInputOutputCommand = async(
   input: EmptyInputOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -95,12 +129,12 @@ export const se_EmptyInputOutputCommand = async (
   let body: any;
   body = cbor.serialize(_json(input));
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/EmptyInputOutput", undefined, body);
-};
+}
 
 /**
  * serializeRpcv2cborFloat16Command
  */
-export const se_Float16Command = async (
+export const se_Float16Command = async(
   input: Float16CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -108,50 +142,38 @@ export const se_Float16Command = async (
   delete headers["content-type"];
 
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/Float16", undefined, undefined);
-};
+}
 
 /**
  * serializeRpcv2cborFractionalSecondsCommand
  */
-export const se_FractionalSecondsCommand = async (
+export const se_FractionalSecondsCommand = async(
   input: FractionalSecondsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = { ...SHARED_HEADERS };
   delete headers["content-type"];
 
-  return buildHttpRpcRequest(
-    context,
-    headers,
-    "/service/RpcV2Protocol/operation/FractionalSeconds",
-    undefined,
-    undefined
-  );
-};
+  return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/FractionalSeconds", undefined, undefined);
+}
 
 /**
  * serializeRpcv2cborGreetingWithErrorsCommand
  */
-export const se_GreetingWithErrorsCommand = async (
+export const se_GreetingWithErrorsCommand = async(
   input: GreetingWithErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = { ...SHARED_HEADERS };
   delete headers["content-type"];
 
-  return buildHttpRpcRequest(
-    context,
-    headers,
-    "/service/RpcV2Protocol/operation/GreetingWithErrors",
-    undefined,
-    undefined
-  );
-};
+  return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/GreetingWithErrors", undefined, undefined);
+}
 
 /**
  * serializeRpcv2cborNoInputOutputCommand
  */
-export const se_NoInputOutputCommand = async (
+export const se_NoInputOutputCommand = async(
   input: NoInputOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -159,31 +181,25 @@ export const se_NoInputOutputCommand = async (
   delete headers["content-type"];
 
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/NoInputOutput", undefined, undefined);
-};
+}
 
 /**
  * serializeRpcv2cborOperationWithDefaultsCommand
  */
-export const se_OperationWithDefaultsCommand = async (
+export const se_OperationWithDefaultsCommand = async(
   input: OperationWithDefaultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = cbor.serialize(se_OperationWithDefaultsInput(input, context));
-  return buildHttpRpcRequest(
-    context,
-    headers,
-    "/service/RpcV2Protocol/operation/OperationWithDefaults",
-    undefined,
-    body
-  );
-};
+  return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/OperationWithDefaults", undefined, body);
+}
 
 /**
  * serializeRpcv2cborOptionalInputOutputCommand
  */
-export const se_OptionalInputOutputCommand = async (
+export const se_OptionalInputOutputCommand = async(
   input: OptionalInputOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -191,12 +207,12 @@ export const se_OptionalInputOutputCommand = async (
   let body: any;
   body = cbor.serialize(_json(input));
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/OptionalInputOutput", undefined, body);
-};
+}
 
 /**
  * serializeRpcv2cborRecursiveShapesCommand
  */
-export const se_RecursiveShapesCommand = async (
+export const se_RecursiveShapesCommand = async(
   input: RecursiveShapesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -204,12 +220,12 @@ export const se_RecursiveShapesCommand = async (
   let body: any;
   body = cbor.serialize(se_RecursiveShapesInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/RecursiveShapes", undefined, body);
-};
+}
 
 /**
  * serializeRpcv2cborRpcV2CborDenseMapsCommand
  */
-export const se_RpcV2CborDenseMapsCommand = async (
+export const se_RpcV2CborDenseMapsCommand = async(
   input: RpcV2CborDenseMapsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -217,12 +233,12 @@ export const se_RpcV2CborDenseMapsCommand = async (
   let body: any;
   body = cbor.serialize(_json(input));
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/RpcV2CborDenseMaps", undefined, body);
-};
+}
 
 /**
  * serializeRpcv2cborRpcV2CborListsCommand
  */
-export const se_RpcV2CborListsCommand = async (
+export const se_RpcV2CborListsCommand = async(
   input: RpcV2CborListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -230,12 +246,12 @@ export const se_RpcV2CborListsCommand = async (
   let body: any;
   body = cbor.serialize(se_RpcV2CborListInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/RpcV2CborLists", undefined, body);
-};
+}
 
 /**
  * serializeRpcv2cborRpcV2CborSparseMapsCommand
  */
-export const se_RpcV2CborSparseMapsCommand = async (
+export const se_RpcV2CborSparseMapsCommand = async(
   input: RpcV2CborSparseMapsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
@@ -243,50 +259,38 @@ export const se_RpcV2CborSparseMapsCommand = async (
   let body: any;
   body = cbor.serialize(se_RpcV2CborSparseMapsInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/RpcV2CborSparseMaps", undefined, body);
-};
+}
 
 /**
  * serializeRpcv2cborSimpleScalarPropertiesCommand
  */
-export const se_SimpleScalarPropertiesCommand = async (
+export const se_SimpleScalarPropertiesCommand = async(
   input: SimpleScalarPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = cbor.serialize(se_SimpleScalarStructure(input, context));
-  return buildHttpRpcRequest(
-    context,
-    headers,
-    "/service/RpcV2Protocol/operation/SimpleScalarProperties",
-    undefined,
-    body
-  );
-};
+  return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/SimpleScalarProperties", undefined, body);
+}
 
 /**
  * serializeRpcv2cborSparseNullsOperationCommand
  */
-export const se_SparseNullsOperationCommand = async (
+export const se_SparseNullsOperationCommand = async(
   input: SparseNullsOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = cbor.serialize(se_SparseNullsOperationInputOutput(input, context));
-  return buildHttpRpcRequest(
-    context,
-    headers,
-    "/service/RpcV2Protocol/operation/SparseNullsOperation",
-    undefined,
-    body
-  );
-};
+  return buildHttpRpcRequest(context, headers, "/service/RpcV2Protocol/operation/SparseNullsOperation", undefined, body);
+}
 
 /**
  * deserializeRpcv2cborEmptyInputOutputCommand
  */
-export const de_EmptyInputOutputCommand = async (
+export const de_EmptyInputOutputCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EmptyInputOutputCommandOutput> => {
@@ -295,20 +299,20 @@ export const de_EmptyInputOutputCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = _json(data);
   const response: EmptyInputOutputCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborFloat16Command
  */
-export const de_Float16Command = async (
+export const de_Float16Command = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<Float16CommandOutput> => {
@@ -317,20 +321,20 @@ export const de_Float16Command = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_Float16Output(data, context);
   const response: Float16CommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborFractionalSecondsCommand
  */
-export const de_FractionalSecondsCommand = async (
+export const de_FractionalSecondsCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FractionalSecondsCommandOutput> => {
@@ -339,20 +343,20 @@ export const de_FractionalSecondsCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_FractionalSecondsOutput(data, context);
   const response: FractionalSecondsCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborGreetingWithErrorsCommand
  */
-export const de_GreetingWithErrorsCommand = async (
+export const de_GreetingWithErrorsCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GreetingWithErrorsCommandOutput> => {
@@ -361,20 +365,20 @@ export const de_GreetingWithErrorsCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = _json(data);
   const response: GreetingWithErrorsCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborNoInputOutputCommand
  */
-export const de_NoInputOutputCommand = async (
+export const de_NoInputOutputCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputOutputCommandOutput> => {
@@ -385,15 +389,16 @@ export const de_NoInputOutputCommand = async (
 
   await collectBody(output.body, context);
   const response: NoInputOutputCommandOutput = {
-    $metadata: deserializeMetadata(output),
+      $metadata: deserializeMetadata(output),
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborOperationWithDefaultsCommand
  */
-export const de_OperationWithDefaultsCommand = async (
+export const de_OperationWithDefaultsCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OperationWithDefaultsCommandOutput> => {
@@ -402,20 +407,20 @@ export const de_OperationWithDefaultsCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_OperationWithDefaultsOutput(data, context);
   const response: OperationWithDefaultsCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborOptionalInputOutputCommand
  */
-export const de_OptionalInputOutputCommand = async (
+export const de_OptionalInputOutputCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OptionalInputOutputCommandOutput> => {
@@ -424,20 +429,20 @@ export const de_OptionalInputOutputCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = _json(data);
   const response: OptionalInputOutputCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborRecursiveShapesCommand
  */
-export const de_RecursiveShapesCommand = async (
+export const de_RecursiveShapesCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecursiveShapesCommandOutput> => {
@@ -446,20 +451,20 @@ export const de_RecursiveShapesCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_RecursiveShapesInputOutput(data, context);
   const response: RecursiveShapesCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborRpcV2CborDenseMapsCommand
  */
-export const de_RpcV2CborDenseMapsCommand = async (
+export const de_RpcV2CborDenseMapsCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RpcV2CborDenseMapsCommandOutput> => {
@@ -468,20 +473,20 @@ export const de_RpcV2CborDenseMapsCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = _json(data);
   const response: RpcV2CborDenseMapsCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborRpcV2CborListsCommand
  */
-export const de_RpcV2CborListsCommand = async (
+export const de_RpcV2CborListsCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RpcV2CborListsCommandOutput> => {
@@ -490,20 +495,20 @@ export const de_RpcV2CborListsCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_RpcV2CborListInputOutput(data, context);
   const response: RpcV2CborListsCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborRpcV2CborSparseMapsCommand
  */
-export const de_RpcV2CborSparseMapsCommand = async (
+export const de_RpcV2CborSparseMapsCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RpcV2CborSparseMapsCommandOutput> => {
@@ -512,20 +517,20 @@ export const de_RpcV2CborSparseMapsCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_RpcV2CborSparseMapsInputOutput(data, context);
   const response: RpcV2CborSparseMapsCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborSimpleScalarPropertiesCommand
  */
-export const de_SimpleScalarPropertiesCommand = async (
+export const de_SimpleScalarPropertiesCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimpleScalarPropertiesCommandOutput> => {
@@ -534,20 +539,20 @@ export const de_SimpleScalarPropertiesCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_SimpleScalarStructure(data, context);
   const response: SimpleScalarPropertiesCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserializeRpcv2cborSparseNullsOperationCommand
  */
-export const de_SparseNullsOperationCommand = async (
+export const de_SparseNullsOperationCommand = async(
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SparseNullsOperationCommandOutput> => {
@@ -556,23 +561,26 @@ export const de_SparseNullsOperationCommand = async (
     return de_CommandError(output, context);
   }
 
-  const data: any = await parseBody(output.body, context);
+  const data: any = await parseBody(output.body, context)
   let contents: any = {};
   contents = de_SparseNullsOperationInputOutput(data, context);
   const response: SparseNullsOperationCommandOutput = {
-    $metadata: deserializeMetadata(output),
-    ...contents,
+      $metadata: deserializeMetadata(output), ...contents,
   };
   return response;
-};
+
+}
 
 /**
  * deserialize_Rpcv2cborCommandError
  */
-const de_CommandError = async (output: __HttpResponse, context: __SerdeContext): Promise<never> => {
+const de_CommandError = async(
+  output: __HttpResponse,
+  context: __SerdeContext,
+): Promise<never> => {
   const parsedOutput: any = {
     ...output,
-    body: await parseErrorBody(output.body, context),
+    body: await parseErrorBody(output.body, context)
   };
   const errorCode = loadSmithyRpcV2CborErrorCode(output, parsedOutput.body);
   switch (errorCode) {
@@ -590,655 +598,753 @@ const de_CommandError = async (output: __HttpResponse, context: __SerdeContext):
       return throwDefaultError({
         output,
         parsedBody,
-        errorCode,
-      }) as never;
+        errorCode
+      }) as never
+    }
   }
-};
 
-/**
- * deserializeRpcv2cborValidationExceptionRes
- */
-const de_ValidationExceptionRes = async (parsedOutput: any, context: __SerdeContext): Promise<ValidationException> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new ValidationException({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
+  /**
+   * deserializeRpcv2cborValidationExceptionRes
+   */
+  const de_ValidationExceptionRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<ValidationException> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new ValidationException({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
+    });
+    return __decorateServiceException(exception, body);
+  };
 
-/**
- * deserializeRpcv2cborComplexErrorRes
- */
-const de_ComplexErrorRes = async (parsedOutput: any, context: __SerdeContext): Promise<ComplexError> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new ComplexError({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
+  /**
+   * deserializeRpcv2cborComplexErrorRes
+   */
+  const de_ComplexErrorRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<ComplexError> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new ComplexError({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
+    });
+    return __decorateServiceException(exception, body);
+  };
 
-/**
- * deserializeRpcv2cborInvalidGreetingRes
- */
-const de_InvalidGreetingRes = async (parsedOutput: any, context: __SerdeContext): Promise<InvalidGreeting> => {
-  const body = parsedOutput.body;
-  const deserialized: any = _json(body);
-  const exception = new InvalidGreeting({
-    $metadata: deserializeMetadata(parsedOutput),
-    ...deserialized,
-  });
-  return __decorateServiceException(exception, body);
-};
+  /**
+   * deserializeRpcv2cborInvalidGreetingRes
+   */
+  const de_InvalidGreetingRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+  ): Promise<InvalidGreeting> => {
+    const body = parsedOutput.body
+    const deserialized: any = _json(body);
+    const exception = new InvalidGreeting({
+      $metadata: deserializeMetadata(parsedOutput),
+      ...deserialized
+    });
+    return __decorateServiceException(exception, body);
+  };
 
-// se_ClientOptionalDefaults omitted.
+  // se_ClientOptionalDefaults omitted.
 
-/**
- * serializeRpcv2cborDefaults
- */
-const se_Defaults = (input: Defaults, context: __SerdeContext): any => {
-  return take(input, {
-    defaultBlob: [],
-    defaultBoolean: [],
-    defaultByte: [],
-    defaultDouble: [],
-    defaultEnum: [],
-    defaultFloat: [],
-    defaultIntEnum: [],
-    defaultInteger: [],
-    defaultList: _json,
-    defaultLong: [],
-    defaultMap: _json,
-    defaultShort: [],
-    defaultString: [],
-    defaultTimestamp: __dateToTag,
-    emptyBlob: [],
-    emptyString: [],
-    falseBoolean: [],
-    zeroByte: [],
-    zeroDouble: [],
-    zeroFloat: [],
-    zeroInteger: [],
-    zeroLong: [],
-    zeroShort: [],
-  });
-};
+  /**
+   * serializeRpcv2cborDefaults
+   */
+  const se_Defaults = (
+    input: Defaults,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'defaultBlob': [],
+      'defaultBoolean': [],
+      'defaultByte': [],
+      'defaultDouble': [],
+      'defaultEnum': [],
+      'defaultFloat': [],
+      'defaultIntEnum': [],
+      'defaultInteger': [],
+      'defaultList': _json,
+      'defaultLong': [],
+      'defaultMap': _json,
+      'defaultShort': [],
+      'defaultString': [],
+      'defaultTimestamp': __dateToTag,
+      'emptyBlob': [],
+      'emptyString': [],
+      'falseBoolean': [],
+      'zeroByte': [],
+      'zeroDouble': [],
+      'zeroFloat': [],
+      'zeroInteger': [],
+      'zeroLong': [],
+      'zeroShort': [],
+    });
+  }
 
-// se_DenseBooleanMap omitted.
+  // se_DenseBooleanMap omitted.
 
-// se_DenseNumberMap omitted.
+  // se_DenseNumberMap omitted.
 
-// se_DenseSetMap omitted.
+  // se_DenseSetMap omitted.
 
-// se_DenseStringMap omitted.
+  // se_DenseStringMap omitted.
 
-// se_DenseStructMap omitted.
+  // se_DenseStructMap omitted.
 
-// se_EmptyStructure omitted.
+  // se_EmptyStructure omitted.
 
-/**
- * serializeRpcv2cborOperationWithDefaultsInput
- */
-const se_OperationWithDefaultsInput = (input: OperationWithDefaultsInput, context: __SerdeContext): any => {
-  return take(input, {
-    clientOptionalDefaults: _json,
-    defaults: (_) => se_Defaults(_, context),
-    otherTopLevelDefault: [],
-    topLevelDefault: [],
-  });
-};
+  /**
+   * serializeRpcv2cborOperationWithDefaultsInput
+   */
+  const se_OperationWithDefaultsInput = (
+    input: OperationWithDefaultsInput,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'clientOptionalDefaults': _json,
+      'defaults': _ => se_Defaults(_, context),
+      'otherTopLevelDefault': [],
+      'topLevelDefault': [],
+    });
+  }
 
-/**
- * serializeRpcv2cborRecursiveShapesInputOutput
- */
-const se_RecursiveShapesInputOutput = (input: RecursiveShapesInputOutput, context: __SerdeContext): any => {
-  return take(input, {
-    nested: (_) => se_RecursiveShapesInputOutputNested1(_, context),
-  });
-};
+  /**
+   * serializeRpcv2cborRecursiveShapesInputOutput
+   */
+  const se_RecursiveShapesInputOutput = (
+    input: RecursiveShapesInputOutput,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'nested': _ => se_RecursiveShapesInputOutputNested1(_, context),
+    });
+  }
 
-/**
- * serializeRpcv2cborRecursiveShapesInputOutputNested1
- */
-const se_RecursiveShapesInputOutputNested1 = (
-  input: RecursiveShapesInputOutputNested1,
-  context: __SerdeContext
-): any => {
-  return take(input, {
-    foo: [],
-    nested: (_) => se_RecursiveShapesInputOutputNested2(_, context),
-  });
-};
+  /**
+   * serializeRpcv2cborRecursiveShapesInputOutputNested1
+   */
+  const se_RecursiveShapesInputOutputNested1 = (
+    input: RecursiveShapesInputOutputNested1,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'foo': [],
+      'nested': _ => se_RecursiveShapesInputOutputNested2(_, context),
+    });
+  }
 
-/**
- * serializeRpcv2cborRecursiveShapesInputOutputNested2
- */
-const se_RecursiveShapesInputOutputNested2 = (
-  input: RecursiveShapesInputOutputNested2,
-  context: __SerdeContext
-): any => {
-  return take(input, {
-    bar: [],
-    recursiveMember: (_) => se_RecursiveShapesInputOutputNested1(_, context),
-  });
-};
+  /**
+   * serializeRpcv2cborRecursiveShapesInputOutputNested2
+   */
+  const se_RecursiveShapesInputOutputNested2 = (
+    input: RecursiveShapesInputOutputNested2,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'bar': [],
+      'recursiveMember': _ => se_RecursiveShapesInputOutputNested1(_, context),
+    });
+  }
 
-// se_RpcV2CborDenseMapsInputOutput omitted.
+  // se_RpcV2CborDenseMapsInputOutput omitted.
 
-/**
- * serializeRpcv2cborRpcV2CborListInputOutput
- */
-const se_RpcV2CborListInputOutput = (input: RpcV2CborListInputOutput, context: __SerdeContext): any => {
-  return take(input, {
-    blobList: (_) => se_BlobList(_, context),
-    booleanList: _json,
-    enumList: _json,
-    intEnumList: _json,
-    integerList: _json,
-    nestedStringList: _json,
-    stringList: _json,
-    stringSet: _json,
-    structureList: _json,
-    timestampList: (_) => se_TimestampList(_, context),
-  });
-};
+  /**
+   * serializeRpcv2cborRpcV2CborListInputOutput
+   */
+  const se_RpcV2CborListInputOutput = (
+    input: RpcV2CborListInputOutput,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'blobList': _ => se_BlobList(_, context),
+      'booleanList': _json,
+      'enumList': _json,
+      'intEnumList': _json,
+      'integerList': _json,
+      'nestedStringList': _json,
+      'stringList': _json,
+      'stringSet': _json,
+      'structureList': _json,
+      'timestampList': _ => se_TimestampList(_, context),
+    });
+  }
 
-/**
- * serializeRpcv2cborRpcV2CborSparseMapsInputOutput
- */
-const se_RpcV2CborSparseMapsInputOutput = (input: RpcV2CborSparseMapsInputOutput, context: __SerdeContext): any => {
-  return take(input, {
-    sparseBooleanMap: (_) => se_SparseBooleanMap(_, context),
-    sparseNumberMap: (_) => se_SparseNumberMap(_, context),
-    sparseSetMap: (_) => se_SparseSetMap(_, context),
-    sparseStringMap: (_) => se_SparseStringMap(_, context),
-    sparseStructMap: (_) => se_SparseStructMap(_, context),
-  });
-};
+  /**
+   * serializeRpcv2cborRpcV2CborSparseMapsInputOutput
+   */
+  const se_RpcV2CborSparseMapsInputOutput = (
+    input: RpcV2CborSparseMapsInputOutput,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'sparseBooleanMap': _ => se_SparseBooleanMap(_, context),
+      'sparseNumberMap': _ => se_SparseNumberMap(_, context),
+      'sparseSetMap': _ => se_SparseSetMap(_, context),
+      'sparseStringMap': _ => se_SparseStringMap(_, context),
+      'sparseStructMap': _ => se_SparseStructMap(_, context),
+    });
+  }
 
-/**
- * serializeRpcv2cborSimpleScalarStructure
- */
-const se_SimpleScalarStructure = (input: SimpleScalarStructure, context: __SerdeContext): any => {
-  return take(input, {
-    blobValue: [],
-    byteValue: [],
-    doubleValue: [],
-    falseBooleanValue: [],
-    floatValue: [],
-    integerValue: [],
-    longValue: [],
-    shortValue: [],
-    stringValue: [],
-    trueBooleanValue: [],
-  });
-};
+  /**
+   * serializeRpcv2cborSimpleScalarStructure
+   */
+  const se_SimpleScalarStructure = (
+    input: SimpleScalarStructure,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'blobValue': [],
+      'byteValue': [],
+      'doubleValue': [],
+      'falseBooleanValue': [],
+      'floatValue': [],
+      'integerValue': [],
+      'longValue': [],
+      'shortValue': [],
+      'stringValue': [],
+      'trueBooleanValue': [],
+    });
+  }
 
-// se_SimpleStructure omitted.
+  // se_SimpleStructure omitted.
 
-/**
- * serializeRpcv2cborSparseBooleanMap
- */
-const se_SparseBooleanMap = (input: Record<string, boolean>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
-    if (value !== null) {
-      acc[key] = value;
-    } else {
-      acc[key] = null as any;
-    }
+  /**
+   * serializeRpcv2cborSparseBooleanMap
+   */
+  const se_SparseBooleanMap = (
+    input: Record<string, boolean>,
+    context: __SerdeContext
+  ): any => {
+    return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+      if (value !== null) {
+          acc[key] = value;
+      }
 
-    return acc;
-  }, {});
-};
+      else {
+          acc[key] = null as any;
+      }
 
-/**
- * serializeRpcv2cborSparseNullsOperationInputOutput
- */
-const se_SparseNullsOperationInputOutput = (input: SparseNullsOperationInputOutput, context: __SerdeContext): any => {
-  return take(input, {
-    sparseStringList: (_) => se_SparseStringList(_, context),
-    sparseStringMap: (_) => se_SparseStringMap(_, context),
-  });
-};
+      return acc;
+    }, {});
+  }
 
-/**
- * serializeRpcv2cborSparseNumberMap
- */
-const se_SparseNumberMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
-    if (value !== null) {
-      acc[key] = value;
-    } else {
-      acc[key] = null as any;
-    }
+  /**
+   * serializeRpcv2cborSparseNullsOperationInputOutput
+   */
+  const se_SparseNullsOperationInputOutput = (
+    input: SparseNullsOperationInputOutput,
+    context: __SerdeContext
+  ): any => {
+    return take(input, {
+      'sparseStringList': _ => se_SparseStringList(_, context),
+      'sparseStringMap': _ => se_SparseStringMap(_, context),
+    });
+  }
 
-    return acc;
-  }, {});
-};
+  /**
+   * serializeRpcv2cborSparseNumberMap
+   */
+  const se_SparseNumberMap = (
+    input: Record<string, number>,
+    context: __SerdeContext
+  ): any => {
+    return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+      if (value !== null) {
+          acc[key] = value;
+      }
 
-/**
- * serializeRpcv2cborSparseSetMap
- */
-const se_SparseSetMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
-    if (value !== null) {
-      acc[key] = _json(value);
-    } else {
-      acc[key] = null as any;
-    }
+      else {
+          acc[key] = null as any;
+      }
 
-    return acc;
-  }, {});
-};
+      return acc;
+    }, {});
+  }
 
-/**
- * serializeRpcv2cborSparseStructMap
- */
-const se_SparseStructMap = (input: Record<string, GreetingStruct>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
-    if (value !== null) {
-      acc[key] = _json(value);
-    } else {
-      acc[key] = null as any;
-    }
+  /**
+   * serializeRpcv2cborSparseSetMap
+   */
+  const se_SparseSetMap = (
+    input: Record<string, (string)[]>,
+    context: __SerdeContext
+  ): any => {
+    return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+      if (value !== null) {
+          acc[key] = _json(value);
+      }
 
-    return acc;
-  }, {});
-};
+      else {
+          acc[key] = null as any;
+      }
 
-// se_StructureList omitted.
+      return acc;
+    }, {});
+  }
 
-// se_StructureListMember omitted.
+  /**
+   * serializeRpcv2cborSparseStructMap
+   */
+  const se_SparseStructMap = (
+    input: Record<string, GreetingStruct>,
+    context: __SerdeContext
+  ): any => {
+    return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+      if (value !== null) {
+          acc[key] = _json(value);
+      }
 
-// se_TestStringList omitted.
+      else {
+          acc[key] = null as any;
+      }
 
-// se_TestStringMap omitted.
+      return acc;
+    }, {});
+  }
 
-/**
- * serializeRpcv2cborBlobList
- */
-const se_BlobList = (input: Uint8Array[], context: __SerdeContext): any => {
-  return input.filter((e: any) => e != null);
-};
+  // se_StructureList omitted.
 
-// se_BooleanList omitted.
+  // se_StructureListMember omitted.
 
-// se_FooEnumList omitted.
+  // se_TestStringList omitted.
 
-// se_GreetingStruct omitted.
+  // se_TestStringMap omitted.
 
-// se_IntegerEnumList omitted.
+  /**
+   * serializeRpcv2cborBlobList
+   */
+  const se_BlobList = (
+    input: (Uint8Array)[],
+    context: __SerdeContext
+  ): any => {
+    return input.filter((e: any) => e != null);
+  }
 
-// se_IntegerList omitted.
+  // se_BooleanList omitted.
 
-// se_NestedStringList omitted.
+  // se_FooEnumList omitted.
 
-/**
- * serializeRpcv2cborSparseStringList
- */
-const se_SparseStringList = (input: string[], context: __SerdeContext): any => {
-  return input;
-};
+  // se_GreetingStruct omitted.
 
-/**
- * serializeRpcv2cborSparseStringMap
- */
-const se_SparseStringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
-    if (value !== null) {
-      acc[key] = value;
-    } else {
-      acc[key] = null as any;
-    }
+  // se_IntegerEnumList omitted.
 
-    return acc;
-  }, {});
-};
+  // se_IntegerList omitted.
 
-// se_StringList omitted.
+  // se_NestedStringList omitted.
 
-// se_StringSet omitted.
+  /**
+   * serializeRpcv2cborSparseStringList
+   */
+  const se_SparseStringList = (
+    input: (string)[],
+    context: __SerdeContext
+  ): any => {
+    return input;
+  }
 
-/**
- * serializeRpcv2cborTimestampList
- */
-const se_TimestampList = (input: Date[], context: __SerdeContext): any => {
-  return input
-    .filter((e: any) => e != null)
-    .map((entry) => {
+  /**
+   * serializeRpcv2cborSparseStringMap
+   */
+  const se_SparseStringMap = (
+    input: Record<string, string>,
+    context: __SerdeContext
+  ): any => {
+    return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+      if (value !== null) {
+          acc[key] = value;
+      }
+
+      else {
+          acc[key] = null as any;
+      }
+
+      return acc;
+    }, {});
+  }
+
+  // se_StringList omitted.
+
+  // se_StringSet omitted.
+
+  /**
+   * serializeRpcv2cborTimestampList
+   */
+  const se_TimestampList = (
+    input: (Date)[],
+    context: __SerdeContext
+  ): any => {
+    return input.filter((e: any) => e != null).map(entry => {
       return __dateToTag(entry);
     });
-};
+  }
 
-// de_ValidationException omitted.
+  // de_ValidationException omitted.
 
-// de_ValidationExceptionField omitted.
+  // de_ValidationExceptionField omitted.
 
-// de_ValidationExceptionFieldList omitted.
+  // de_ValidationExceptionFieldList omitted.
 
-// de_ComplexError omitted.
+  // de_ComplexError omitted.
 
-// de_ComplexNestedErrorData omitted.
+  // de_ComplexNestedErrorData omitted.
 
-// de_DenseBooleanMap omitted.
+  // de_DenseBooleanMap omitted.
 
-// de_DenseNumberMap omitted.
+  // de_DenseNumberMap omitted.
 
-// de_DenseSetMap omitted.
+  // de_DenseSetMap omitted.
 
-// de_DenseStringMap omitted.
+  // de_DenseStringMap omitted.
 
-// de_DenseStructMap omitted.
+  // de_DenseStructMap omitted.
 
-// de_EmptyStructure omitted.
+  // de_EmptyStructure omitted.
 
-/**
- * deserializeRpcv2cborFloat16Output
- */
-const de_Float16Output = (output: any, context: __SerdeContext): Float16Output => {
-  return take(output, {
-    value: __limitedParseDouble,
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborFloat16Output
+   */
+  const de_Float16Output = (
+    output: any,
+    context: __SerdeContext
+  ): Float16Output => {
+    return take(output, {
+      'value': __limitedParseDouble,
+    }) as any;
+  }
 
-/**
- * deserializeRpcv2cborFractionalSecondsOutput
- */
-const de_FractionalSecondsOutput = (output: any, context: __SerdeContext): FractionalSecondsOutput => {
-  return take(output, {
-    datetime: (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborFractionalSecondsOutput
+   */
+  const de_FractionalSecondsOutput = (
+    output: any,
+    context: __SerdeContext
+  ): FractionalSecondsOutput => {
+    return take(output, {
+      'datetime': (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
+    }) as any;
+  }
 
-// de_GreetingWithErrorsOutput omitted.
+  // de_GreetingWithErrorsOutput omitted.
 
-// de_InvalidGreeting omitted.
+  // de_InvalidGreeting omitted.
 
-/**
- * deserializeRpcv2cborOperationWithDefaultsOutput
- */
-const de_OperationWithDefaultsOutput = (output: any, context: __SerdeContext): OperationWithDefaultsOutput => {
-  return take(output, {
-    defaultBlob: [],
-    defaultBoolean: __expectBoolean,
-    defaultByte: __expectByte,
-    defaultDouble: __limitedParseDouble,
-    defaultEnum: __expectString,
-    defaultFloat: __limitedParseFloat32,
-    defaultIntEnum: __expectInt32,
-    defaultInteger: __expectInt32,
-    defaultList: _json,
-    defaultLong: __expectLong,
-    defaultMap: _json,
-    defaultShort: __expectShort,
-    defaultString: __expectString,
-    defaultTimestamp: (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
-    emptyBlob: [],
-    emptyString: __expectString,
-    falseBoolean: __expectBoolean,
-    zeroByte: __expectByte,
-    zeroDouble: __limitedParseDouble,
-    zeroFloat: __limitedParseFloat32,
-    zeroInteger: __expectInt32,
-    zeroLong: __expectLong,
-    zeroShort: __expectShort,
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborOperationWithDefaultsOutput
+   */
+  const de_OperationWithDefaultsOutput = (
+    output: any,
+    context: __SerdeContext
+  ): OperationWithDefaultsOutput => {
+    return take(output, {
+      'defaultBlob': [],
+      'defaultBoolean': __expectBoolean,
+      'defaultByte': __expectByte,
+      'defaultDouble': __limitedParseDouble,
+      'defaultEnum': __expectString,
+      'defaultFloat': __limitedParseFloat32,
+      'defaultIntEnum': __expectInt32,
+      'defaultInteger': __expectInt32,
+      'defaultList': _json,
+      'defaultLong': __expectLong,
+      'defaultMap': _json,
+      'defaultShort': __expectShort,
+      'defaultString': __expectString,
+      'defaultTimestamp': (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
+      'emptyBlob': [],
+      'emptyString': __expectString,
+      'falseBoolean': __expectBoolean,
+      'zeroByte': __expectByte,
+      'zeroDouble': __limitedParseDouble,
+      'zeroFloat': __limitedParseFloat32,
+      'zeroInteger': __expectInt32,
+      'zeroLong': __expectLong,
+      'zeroShort': __expectShort,
+    }) as any;
+  }
 
-/**
- * deserializeRpcv2cborRecursiveShapesInputOutput
- */
-const de_RecursiveShapesInputOutput = (output: any, context: __SerdeContext): RecursiveShapesInputOutput => {
-  return take(output, {
-    nested: (_: any) => de_RecursiveShapesInputOutputNested1(_, context),
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborRecursiveShapesInputOutput
+   */
+  const de_RecursiveShapesInputOutput = (
+    output: any,
+    context: __SerdeContext
+  ): RecursiveShapesInputOutput => {
+    return take(output, {
+      'nested': (_: any) => de_RecursiveShapesInputOutputNested1(_, context),
+    }) as any;
+  }
 
-/**
- * deserializeRpcv2cborRecursiveShapesInputOutputNested1
- */
-const de_RecursiveShapesInputOutputNested1 = (
-  output: any,
-  context: __SerdeContext
-): RecursiveShapesInputOutputNested1 => {
-  return take(output, {
-    foo: __expectString,
-    nested: (_: any) => de_RecursiveShapesInputOutputNested2(_, context),
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborRecursiveShapesInputOutputNested1
+   */
+  const de_RecursiveShapesInputOutputNested1 = (
+    output: any,
+    context: __SerdeContext
+  ): RecursiveShapesInputOutputNested1 => {
+    return take(output, {
+      'foo': __expectString,
+      'nested': (_: any) => de_RecursiveShapesInputOutputNested2(_, context),
+    }) as any;
+  }
 
-/**
- * deserializeRpcv2cborRecursiveShapesInputOutputNested2
- */
-const de_RecursiveShapesInputOutputNested2 = (
-  output: any,
-  context: __SerdeContext
-): RecursiveShapesInputOutputNested2 => {
-  return take(output, {
-    bar: __expectString,
-    recursiveMember: (_: any) => de_RecursiveShapesInputOutputNested1(_, context),
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborRecursiveShapesInputOutputNested2
+   */
+  const de_RecursiveShapesInputOutputNested2 = (
+    output: any,
+    context: __SerdeContext
+  ): RecursiveShapesInputOutputNested2 => {
+    return take(output, {
+      'bar': __expectString,
+      'recursiveMember': (_: any) => de_RecursiveShapesInputOutputNested1(_, context),
+    }) as any;
+  }
 
-// de_RpcV2CborDenseMapsInputOutput omitted.
+  // de_RpcV2CborDenseMapsInputOutput omitted.
 
-/**
- * deserializeRpcv2cborRpcV2CborListInputOutput
- */
-const de_RpcV2CborListInputOutput = (output: any, context: __SerdeContext): RpcV2CborListInputOutput => {
-  return take(output, {
-    blobList: (_: any) => de_BlobList(_, context),
-    booleanList: _json,
-    enumList: _json,
-    intEnumList: _json,
-    integerList: _json,
-    nestedStringList: _json,
-    stringList: _json,
-    stringSet: _json,
-    structureList: _json,
-    timestampList: (_: any) => de_TimestampList(_, context),
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborRpcV2CborListInputOutput
+   */
+  const de_RpcV2CborListInputOutput = (
+    output: any,
+    context: __SerdeContext
+  ): RpcV2CborListInputOutput => {
+    return take(output, {
+      'blobList': (_: any) => de_BlobList(_, context),
+      'booleanList': _json,
+      'enumList': _json,
+      'intEnumList': _json,
+      'integerList': _json,
+      'nestedStringList': _json,
+      'stringList': _json,
+      'stringSet': _json,
+      'structureList': _json,
+      'timestampList': (_: any) => de_TimestampList(_, context),
+    }) as any;
+  }
 
-/**
- * deserializeRpcv2cborRpcV2CborSparseMapsInputOutput
- */
-const de_RpcV2CborSparseMapsInputOutput = (output: any, context: __SerdeContext): RpcV2CborSparseMapsInputOutput => {
-  return take(output, {
-    sparseBooleanMap: (_: any) => de_SparseBooleanMap(_, context),
-    sparseNumberMap: (_: any) => de_SparseNumberMap(_, context),
-    sparseSetMap: (_: any) => de_SparseSetMap(_, context),
-    sparseStringMap: (_: any) => de_SparseStringMap(_, context),
-    sparseStructMap: (_: any) => de_SparseStructMap(_, context),
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborRpcV2CborSparseMapsInputOutput
+   */
+  const de_RpcV2CborSparseMapsInputOutput = (
+    output: any,
+    context: __SerdeContext
+  ): RpcV2CborSparseMapsInputOutput => {
+    return take(output, {
+      'sparseBooleanMap': (_: any) => de_SparseBooleanMap(_, context),
+      'sparseNumberMap': (_: any) => de_SparseNumberMap(_, context),
+      'sparseSetMap': (_: any) => de_SparseSetMap(_, context),
+      'sparseStringMap': (_: any) => de_SparseStringMap(_, context),
+      'sparseStructMap': (_: any) => de_SparseStructMap(_, context),
+    }) as any;
+  }
 
-/**
- * deserializeRpcv2cborSimpleScalarStructure
- */
-const de_SimpleScalarStructure = (output: any, context: __SerdeContext): SimpleScalarStructure => {
-  return take(output, {
-    blobValue: [],
-    byteValue: __expectByte,
-    doubleValue: __limitedParseDouble,
-    falseBooleanValue: __expectBoolean,
-    floatValue: __limitedParseFloat32,
-    integerValue: __expectInt32,
-    longValue: __expectLong,
-    shortValue: __expectShort,
-    stringValue: __expectString,
-    trueBooleanValue: __expectBoolean,
-  }) as any;
-};
+  /**
+   * deserializeRpcv2cborSimpleScalarStructure
+   */
+  const de_SimpleScalarStructure = (
+    output: any,
+    context: __SerdeContext
+  ): SimpleScalarStructure => {
+    return take(output, {
+      'blobValue': [],
+      'byteValue': __expectByte,
+      'doubleValue': __limitedParseDouble,
+      'falseBooleanValue': __expectBoolean,
+      'floatValue': __limitedParseFloat32,
+      'integerValue': __expectInt32,
+      'longValue': __expectLong,
+      'shortValue': __expectShort,
+      'stringValue': __expectString,
+      'trueBooleanValue': __expectBoolean,
+    }) as any;
+  }
 
-// de_SimpleStructure omitted.
+  // de_SimpleStructure omitted.
 
-/**
- * deserializeRpcv2cborSparseBooleanMap
- */
-const de_SparseBooleanMap = (output: any, context: __SerdeContext): Record<string, boolean> => {
-  return Object.entries(output).reduce(
-    (acc: Record<string, boolean>, [key, value]: [string, any]) => {
+  /**
+   * deserializeRpcv2cborSparseBooleanMap
+   */
+  const de_SparseBooleanMap = (
+    output: any,
+    context: __SerdeContext
+  ): Record<string, boolean> => {
+    return Object.entries(output).reduce((acc: Record<string, boolean>, [key, value]: [string, any]) => {
       if (value !== null) {
         acc[key as string] = __expectBoolean(value) as any;
-      } else {
+      }
+      else {
         acc[key as string] = null as any;
       }
       return acc;
-    },
-    {} as Record<string, boolean>
-  );
-};
 
-/**
- * deserializeRpcv2cborSparseNullsOperationInputOutput
- */
-const de_SparseNullsOperationInputOutput = (output: any, context: __SerdeContext): SparseNullsOperationInputOutput => {
-  return take(output, {
-    sparseStringList: (_: any) => de_SparseStringList(_, context),
-    sparseStringMap: (_: any) => de_SparseStringMap(_, context),
-  }) as any;
-};
+    }, {} as Record<string, boolean>);}
 
-/**
- * deserializeRpcv2cborSparseNumberMap
- */
-const de_SparseNumberMap = (output: any, context: __SerdeContext): Record<string, number> => {
-  return Object.entries(output).reduce(
-    (acc: Record<string, number>, [key, value]: [string, any]) => {
+  /**
+   * deserializeRpcv2cborSparseNullsOperationInputOutput
+   */
+  const de_SparseNullsOperationInputOutput = (
+    output: any,
+    context: __SerdeContext
+  ): SparseNullsOperationInputOutput => {
+    return take(output, {
+      'sparseStringList': (_: any) => de_SparseStringList(_, context),
+      'sparseStringMap': (_: any) => de_SparseStringMap(_, context),
+    }) as any;
+  }
+
+  /**
+   * deserializeRpcv2cborSparseNumberMap
+   */
+  const de_SparseNumberMap = (
+    output: any,
+    context: __SerdeContext
+  ): Record<string, number> => {
+    return Object.entries(output).reduce((acc: Record<string, number>, [key, value]: [string, any]) => {
       if (value !== null) {
         acc[key as string] = __expectInt32(value) as any;
-      } else {
+      }
+      else {
         acc[key as string] = null as any;
       }
       return acc;
-    },
-    {} as Record<string, number>
-  );
-};
 
-/**
- * deserializeRpcv2cborSparseSetMap
- */
-const de_SparseSetMap = (output: any, context: __SerdeContext): Record<string, string[]> => {
-  return Object.entries(output).reduce(
-    (acc: Record<string, string[]>, [key, value]: [string, any]) => {
+    }, {} as Record<string, number>);}
+
+  /**
+   * deserializeRpcv2cborSparseSetMap
+   */
+  const de_SparseSetMap = (
+    output: any,
+    context: __SerdeContext
+  ): Record<string, (string)[]> => {
+    return Object.entries(output).reduce((acc: Record<string, (string)[]>, [key, value]: [string, any]) => {
       if (value !== null) {
         acc[key as string] = _json(value);
-      } else {
+      }
+      else {
         acc[key as string] = null as any;
       }
       return acc;
-    },
-    {} as Record<string, string[]>
-  );
-};
 
-/**
- * deserializeRpcv2cborSparseStructMap
- */
-const de_SparseStructMap = (output: any, context: __SerdeContext): Record<string, GreetingStruct> => {
-  return Object.entries(output).reduce(
-    (acc: Record<string, GreetingStruct>, [key, value]: [string, any]) => {
+    }, {} as Record<string, (string)[]>);}
+
+  /**
+   * deserializeRpcv2cborSparseStructMap
+   */
+  const de_SparseStructMap = (
+    output: any,
+    context: __SerdeContext
+  ): Record<string, GreetingStruct> => {
+    return Object.entries(output).reduce((acc: Record<string, GreetingStruct>, [key, value]: [string, any]) => {
       if (value !== null) {
         acc[key as string] = _json(value);
-      } else {
+      }
+      else {
         acc[key as string] = null as any;
       }
       return acc;
-    },
-    {} as Record<string, GreetingStruct>
-  );
-};
 
-// de_StructureList omitted.
+    }, {} as Record<string, GreetingStruct>);}
 
-// de_StructureListMember omitted.
+  // de_StructureList omitted.
 
-// de_TestStringList omitted.
+  // de_StructureListMember omitted.
 
-// de_TestStringMap omitted.
+  // de_TestStringList omitted.
 
-/**
- * deserializeRpcv2cborBlobList
- */
-const de_BlobList = (output: any, context: __SerdeContext): Uint8Array[] => {
-  const collection = (output || []).filter((e: any) => e != null);
-  return collection;
-};
+  // de_TestStringMap omitted.
 
-// de_BooleanList omitted.
+  /**
+   * deserializeRpcv2cborBlobList
+   */
+  const de_BlobList = (
+    output: any,
+    context: __SerdeContext
+  ): (Uint8Array)[] => {
+    const collection = (output || []).filter((e: any) => e != null)
+    return collection;
+  }
 
-// de_FooEnumList omitted.
+  // de_BooleanList omitted.
 
-// de_GreetingStruct omitted.
+  // de_FooEnumList omitted.
 
-// de_IntegerEnumList omitted.
+  // de_GreetingStruct omitted.
 
-// de_IntegerList omitted.
+  // de_IntegerEnumList omitted.
 
-// de_NestedStringList omitted.
+  // de_IntegerList omitted.
 
-/**
- * deserializeRpcv2cborSparseStringList
- */
-const de_SparseStringList = (output: any, context: __SerdeContext): string[] => {
-  const collection = (output || []).map((entry: any) => {
-    if (entry === null) {
-      return null as any;
-    }
-    return __expectString(entry) as any;
-  });
-  return collection;
-};
+  // de_NestedStringList omitted.
 
-/**
- * deserializeRpcv2cborSparseStringMap
- */
-const de_SparseStringMap = (output: any, context: __SerdeContext): Record<string, string> => {
-  return Object.entries(output).reduce(
-    (acc: Record<string, string>, [key, value]: [string, any]) => {
+  /**
+   * deserializeRpcv2cborSparseStringList
+   */
+  const de_SparseStringList = (
+    output: any,
+    context: __SerdeContext
+  ): (string)[] => {
+    const collection = (output || []).map((entry: any) => {
+      if (entry === null) {
+        return null as any;
+      }
+      return __expectString(entry) as any;
+    });
+    return collection;
+  }
+
+  /**
+   * deserializeRpcv2cborSparseStringMap
+   */
+  const de_SparseStringMap = (
+    output: any,
+    context: __SerdeContext
+  ): Record<string, string> => {
+    return Object.entries(output).reduce((acc: Record<string, string>, [key, value]: [string, any]) => {
       if (value !== null) {
         acc[key as string] = __expectString(value) as any;
-      } else {
+      }
+      else {
         acc[key as string] = null as any;
       }
       return acc;
-    },
-    {} as Record<string, string>
-  );
-};
 
-// de_StringList omitted.
+    }, {} as Record<string, string>);}
 
-// de_StringSet omitted.
+  // de_StringList omitted.
 
-/**
- * deserializeRpcv2cborTimestampList
- */
-const de_TimestampList = (output: any, context: __SerdeContext): Date[] => {
-  const collection = (output || [])
-    .filter((e: any) => e != null)
-    .map((entry: any) => {
+  // de_StringSet omitted.
+
+  /**
+   * deserializeRpcv2cborTimestampList
+   */
+  const de_TimestampList = (
+    output: any,
+    context: __SerdeContext
+  ): (Date)[] => {
+    const collection = (output || []).filter((e: any) => e != null).map((entry: any) => {
       return __expectNonNull(__parseEpochTimestamp(entry));
     });
-  return collection;
-};
+    return collection;
+  }
 
-const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
-  httpStatusCode: output.statusCode,
-  requestId:
-    output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
-  extendedRequestId: output.headers["x-amz-id-2"],
-  cfId: output.headers["x-amz-cf-id"],
-});
+  const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
+    httpStatusCode: output.statusCode,
+    requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
+    extendedRequestId: output.headers["x-amz-id-2"],
+    cfId: output.headers["x-amz-cf-id"],
+  });
 
-const throwDefaultError = withBaseException(__BaseException);
-const SHARED_HEADERS: __HeaderBag = {
-  "content-type": "application/cbor",
-  "smithy-protocol": "rpc-v2-cbor",
-  accept: "application/cbor",
-};
+  const throwDefaultError = withBaseException(__BaseException);
+  const SHARED_HEADERS: __HeaderBag = {
+    'content-type': "application/cbor",
+    "smithy-protocol": "rpc-v2-cbor",
+    "accept": "application/cbor",
+
+  };

--- a/private/smithy-rpcv2-cbor/src/runtimeConfig.browser.ts
+++ b/private/smithy-rpcv2-cbor/src/runtimeConfig.browser.ts
@@ -1,8 +1,14 @@
 // smithy-typescript generated code
 import { Sha256 } from "@aws-crypto/sha256-browser";
-import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  FetchHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/fetch-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_MODE,
+} from "@smithy/util-retry";
 import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 import { loadConfigsForDefaultMode } from "@smithy/smithy-client";

--- a/private/smithy-rpcv2-cbor/src/runtimeConfig.shared.ts
+++ b/private/smithy-rpcv2-cbor/src/runtimeConfig.shared.ts
@@ -5,8 +5,14 @@ import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";
 import { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
-import { fromBase64, toBase64 } from "@smithy/util-base64";
-import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
+import {
+  fromBase64,
+  toBase64,
+} from "@smithy/util-base64";
+import {
+  fromUtf8,
+  toUtf8,
+} from "@smithy/util-utf8";
 import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
 
 /**
@@ -15,23 +21,21 @@ import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
 export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
   return {
     apiVersion: "2020-07-14",
-    base64Decoder: config?.base64Decoder ?? fromBase64,
-    base64Encoder: config?.base64Encoder ?? toBase64,
-    disableHostPrefix: config?.disableHostPrefix ?? false,
-    endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-    extensions: config?.extensions ?? [],
-    httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultRpcV2ProtocolHttpAuthSchemeProvider,
-    httpAuthSchemes: config?.httpAuthSchemes ?? [
-      {
+      base64Decoder: config?.base64Decoder ?? fromBase64,
+  base64Encoder: config?.base64Encoder ?? toBase64,
+  disableHostPrefix: config?.disableHostPrefix ?? false,
+  endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
+  extensions: config?.extensions ?? [],
+  httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultRpcV2ProtocolHttpAuthSchemeProvider,
+  httpAuthSchemes: config?.httpAuthSchemes ?? [{
         schemeId: "smithy.api#noAuth",
         identityProvider: (ipc: IdentityProviderConfig) =>
           ipc.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
         signer: new NoAuthSigner(),
-      },
-    ],
-    logger: config?.logger ?? new NoOpLogger(),
-    urlParser: config?.urlParser ?? parseUrl,
-    utf8Decoder: config?.utf8Decoder ?? fromUtf8,
-    utf8Encoder: config?.utf8Encoder ?? toUtf8,
-  };
+      }],
+  logger: config?.logger ?? new NoOpLogger(),
+  urlParser: config?.urlParser ?? parseUrl,
+  utf8Decoder: config?.utf8Decoder ?? fromUtf8,
+  utf8Encoder: config?.utf8Encoder ?? toUtf8,
+  }
 };

--- a/private/smithy-rpcv2-cbor/src/runtimeConfig.ts
+++ b/private/smithy-rpcv2-cbor/src/runtimeConfig.ts
@@ -1,8 +1,14 @@
 // smithy-typescript generated code
 import { Hash } from "@smithy/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
+import {
+  NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
+  NODE_RETRY_MODE_CONFIG_OPTIONS,
+} from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
-import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
+import {
+  NodeHttpHandler as RequestHandler,
+  streamCollector,
+} from "@smithy/node-http-handler";
 import { calculateBodyLength } from "@smithy/util-body-length-node";
 import { DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
@@ -27,15 +33,7 @@ export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
-    retryMode:
-      config?.retryMode ??
-      loadNodeConfig(
-        {
-          ...NODE_RETRY_MODE_CONFIG_OPTIONS,
-          default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
-        },
-        config
-      ),
+    retryMode: config?.retryMode ?? loadNodeConfig({...NODE_RETRY_MODE_CONFIG_OPTIONS,default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,}, config),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };

--- a/private/smithy-rpcv2-cbor/src/runtimeExtensions.ts
+++ b/private/smithy-rpcv2-cbor/src/runtimeExtensions.ts
@@ -1,39 +1,50 @@
 // smithy-typescript generated code
-import { getHttpAuthExtensionConfiguration, resolveHttpAuthRuntimeConfig } from "./auth/httpAuthExtensionConfiguration";
-import { getHttpHandlerExtensionConfiguration, resolveHttpHandlerRuntimeConfig } from "@smithy/protocol-http";
-import { getDefaultExtensionConfiguration, resolveDefaultRuntimeConfig } from "@smithy/smithy-client";
+import {
+  getHttpAuthExtensionConfiguration,
+  resolveHttpAuthRuntimeConfig,
+} from "./auth/httpAuthExtensionConfiguration";
+import {
+  getHttpHandlerExtensionConfiguration,
+  resolveHttpHandlerRuntimeConfig,
+} from "@smithy/protocol-http";
+import {
+  getDefaultExtensionConfiguration,
+  resolveDefaultRuntimeConfig,
+} from "@smithy/smithy-client";
 import { RpcV2ProtocolExtensionConfiguration } from "./extensionConfiguration";
 
 /**
  * @public
  */
 export interface RuntimeExtension {
-  configure(extensionConfiguration: RpcV2ProtocolExtensionConfiguration): void;
+    configure(extensionConfiguration: RpcV2ProtocolExtensionConfiguration): void;
 }
 
 /**
  * @public
  */
 export interface RuntimeExtensionsConfig {
-  extensions: RuntimeExtension[];
+    extensions: RuntimeExtension[]
 }
 
 /**
  * @internal
  */
-export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: RuntimeExtension[]) => {
+export const resolveRuntimeExtensions = (
+    runtimeConfig: any,
+    extensions: RuntimeExtension[]
+) => {
   const extensionConfiguration: RpcV2ProtocolExtensionConfiguration = Object.assign(
     getDefaultExtensionConfiguration(runtimeConfig),
     getHttpHandlerExtensionConfiguration(runtimeConfig),
-    getHttpAuthExtensionConfiguration(runtimeConfig)
+    getHttpAuthExtensionConfiguration(runtimeConfig),
   );
 
-  extensions.forEach((extension) => extension.configure(extensionConfiguration));
+  extensions.forEach(extension => extension.configure(extensionConfiguration));
 
-  return Object.assign(
-    runtimeConfig,
+  return Object.assign(runtimeConfig,
     resolveDefaultRuntimeConfig(extensionConfiguration),
     resolveHttpHandlerRuntimeConfig(extensionConfiguration),
-    resolveHttpAuthRuntimeConfig(extensionConfiguration)
+    resolveHttpAuthRuntimeConfig(extensionConfiguration),
   );
-};
+}

--- a/private/smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
+++ b/private/smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
@@ -14,7 +14,10 @@ import { RpcV2CborSparseMapsCommand } from "../../src/commands/RpcV2CborSparseMa
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
 import { SparseNullsOperationCommand } from "../../src/commands/SparseNullsOperationCommand";
 import { cbor } from "@smithy/core/cbor";
-import { expect, test as it } from "vitest";
+import {
+  expect,
+  test as it,
+} from "vitest";
 import { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
 import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "stream";
@@ -223,10 +226,13 @@ it("empty_input:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new EmptyInputOutputCommand({} as any);
+  const command = new EmptyInputOutputCommand(
+  {
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -237,8 +243,8 @@ it("empty_input:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/EmptyInputOutput");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(
@@ -267,11 +273,11 @@ it("empty_output:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -284,7 +290,7 @@ it("empty_output:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -297,11 +303,11 @@ it("empty_output_no_body:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      ``
-    ),
+      ``,
+    )
   });
 
   const params: any = {};
@@ -314,7 +320,7 @@ it("empty_output_no_body:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -327,11 +333,11 @@ it("RpcV2CborFloat16Inf:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfl8AA==`
-    ),
+      `oWV2YWx1Zfl8AA==`,
+    )
   });
 
   const params: any = {};
@@ -344,16 +350,17 @@ it("RpcV2CborFloat16Inf:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: Infinity,
-    },
+  {
+    "value":
+    Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -369,11 +376,11 @@ it("RpcV2CborFloat16NegInf:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfn8AA==`
-    ),
+      `oWV2YWx1Zfn8AA==`,
+    )
   });
 
   const params: any = {};
@@ -386,16 +393,17 @@ it("RpcV2CborFloat16NegInf:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: -Infinity,
-    },
+  {
+    "value":
+    -Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -411,11 +419,11 @@ it("RpcV2CborFloat16LSBNaN:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfl8AQ==`
-    ),
+      `oWV2YWx1Zfl8AQ==`,
+    )
   });
 
   const params: any = {};
@@ -428,16 +436,17 @@ it("RpcV2CborFloat16LSBNaN:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: NaN,
-    },
+  {
+    "value":
+    NaN,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -453,11 +462,11 @@ it("RpcV2CborFloat16MSBNaN:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1Zfl+AA==`
-    ),
+      `oWV2YWx1Zfl+AA==`,
+    )
   });
 
   const params: any = {};
@@ -470,16 +479,17 @@ it("RpcV2CborFloat16MSBNaN:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: NaN,
-    },
+  {
+    "value":
+    NaN,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -495,11 +505,11 @@ it("RpcV2CborFloat16Subnormal:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWV2YWx1ZfkAUA==`
-    ),
+      `oWV2YWx1ZfkAUA==`,
+    )
   });
 
   const params: any = {};
@@ -512,16 +522,17 @@ it("RpcV2CborFloat16Subnormal:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      value: 4.76837158203125e-6,
-    },
+  {
+    "value":
+    4.76837158203125E-6,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -537,11 +548,11 @@ it("RpcV2CborDateTimeWithFractionalSeconds:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2hkYXRldGltZcH7Qcw32zgPvnf/`
-    ),
+      `v2hkYXRldGltZcH7Qcw32zgPvnf/`,
+    )
   });
 
   const params: any = {};
@@ -554,16 +565,17 @@ it("RpcV2CborDateTimeWithFractionalSeconds:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      datetime: new Date(9.46845296123e8 * 1000),
-    },
+  {
+    "datetime":
+    new Date(9.46845296123E8 * 1000),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -579,11 +591,11 @@ it("RpcV2CborInvalidGreetingError:Error:GreetingWithErrors", async () => {
       false,
       400,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZfX3R5cGV4LnNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNJbnZhbGlkR3JlZXRpbmdnTWVzc2FnZWJIaf8=`
-    ),
+      `v2ZfX3R5cGV4LnNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNJbnZhbGlkR3JlZXRpbmdnTWVzc2FnZWJIaf8=`,
+    )
   });
 
   const params: any = {};
@@ -598,22 +610,23 @@ it("RpcV2CborInvalidGreetingError:Error:GreetingWithErrors", async () => {
       return;
     }
     const r: any = err;
-    expect(r["$metadata"].httpStatusCode).toBe(400);
+    expect(r['$metadata'].httpStatusCode).toBe(400);
     const paramsToValidate: any = [
-      {
-        message: "Hi",
-      },
+    {
+      "message":
+      "Hi",
+    },
     ][0];
-    Object.keys(paramsToValidate).forEach((param) => {
+    Object.keys(paramsToValidate).forEach(param => {
       expect(
-        r[param],
-        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+          r[param],
+          `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
       ).toBeDefined();
       expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
     });
     return;
   }
-  fail("Expected an exception to be thrown from response");
+  fail('Expected an exception to be thrown from response');
 });
 
 /**
@@ -626,11 +639,11 @@ it("RpcV2CborComplexError:Error:GreetingWithErrors", async () => {
       false,
       400,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3JoVG9wTGV2ZWxpVG9wIGxldmVsZk5lc3RlZL9jRm9vY2Jhcv//`
-    ),
+      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3JoVG9wTGV2ZWxpVG9wIGxldmVsZk5lc3RlZL9jRm9vY2Jhcv//`,
+    )
   });
 
   const params: any = {};
@@ -645,25 +658,28 @@ it("RpcV2CborComplexError:Error:GreetingWithErrors", async () => {
       return;
     }
     const r: any = err;
-    expect(r["$metadata"].httpStatusCode).toBe(400);
+    expect(r['$metadata'].httpStatusCode).toBe(400);
     const paramsToValidate: any = [
+    {
+      "TopLevel":
+      "Top level",
+      "Nested":
       {
-        TopLevel: "Top level",
-        Nested: {
-          Foo: "bar",
-        },
+        "Foo":
+        "bar",
       },
+    },
     ][0];
-    Object.keys(paramsToValidate).forEach((param) => {
+    Object.keys(paramsToValidate).forEach(param => {
       expect(
-        r[param],
-        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+          r[param],
+          `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
       ).toBeDefined();
       expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
     });
     return;
   }
-  fail("Expected an exception to be thrown from response");
+  fail('Expected an exception to be thrown from response');
 });
 
 it("RpcV2CborEmptyComplexError:Error:GreetingWithErrors", async () => {
@@ -673,11 +689,11 @@ it("RpcV2CborEmptyComplexError:Error:GreetingWithErrors", async () => {
       false,
       400,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3L/`
-    ),
+      `v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3L/`,
+    )
   });
 
   const params: any = {};
@@ -692,10 +708,10 @@ it("RpcV2CborEmptyComplexError:Error:GreetingWithErrors", async () => {
       return;
     }
     const r: any = err;
-    expect(r["$metadata"].httpStatusCode).toBe(400);
+    expect(r['$metadata'].httpStatusCode).toBe(400);
     return;
   }
-  fail("Expected an exception to be thrown from response");
+  fail('Expected an exception to be thrown from response');
 });
 
 /**
@@ -710,7 +726,7 @@ it("no_input:Request", async () => {
   const command = new NoInputOutputCommand({});
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -747,10 +763,10 @@ it("no_output:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
+          "smithy-protocol": "rpc-v2-cbor"
       },
-      ``
-    ),
+      ``,
+    )
   });
 
   const params: any = {};
@@ -763,7 +779,7 @@ it("no_output:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -776,11 +792,11 @@ it("NoOutputClientAllowsEmptyCbor:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -793,7 +809,7 @@ it("NoOutputClientAllowsEmptyCbor:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -807,11 +823,11 @@ it("NoOutputClientAllowsEmptyBody:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      ``
-    ),
+      ``,
+    )
   });
 
   const params: any = {};
@@ -824,24 +840,27 @@ it("NoOutputClientAllowsEmptyBody:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
  * Client populates default values in input.
  */
-it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async () => {
+it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    defaults: {} as any,
-  } as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+    "defaults": {
+    } as any,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -852,8 +871,8 @@ it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -870,16 +889,19 @@ it.skip("RpcV2CborClientPopulatesDefaultValuesInInput:Request", async () => {
 /**
  * Client skips top level default values in input.
  */
-it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async () => {
+it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({} as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -890,8 +912,8 @@ it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async () => 
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -908,44 +930,48 @@ it.skip("RpcV2CborClientSkipsTopLevelDefaultValuesInInput:Request", async () => 
 /**
  * Client uses explicitly provided member values over defaults
  */
-it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request", async () => {
+it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    defaults: {
-      defaultString: "bye",
-      defaultBoolean: true,
-      defaultList: ["a"],
-      defaultTimestamp: new Date(1000),
-      defaultBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      defaultByte: 2,
-      defaultShort: 2,
-      defaultInteger: 20,
-      defaultLong: 200,
-      defaultFloat: 2.0,
-      defaultDouble: 2.0,
-      defaultMap: {
-        name: "Jack",
+  const command = new OperationWithDefaultsCommand(
+  {
+    "defaults": {
+      "defaultString": "bye",
+      "defaultBoolean": true,
+      "defaultList": [
+        "a",
+      ],
+      "defaultTimestamp": new Date(1000),
+      "defaultBlob": Uint8Array.from("hi", c => c.charCodeAt(0)),
+      "defaultByte": 2,
+      "defaultShort": 2,
+      "defaultInteger": 20,
+      "defaultLong": 200,
+      "defaultFloat": 2.0,
+      "defaultDouble": 2.0,
+      "defaultMap": {
+        "name": "Jack",
       } as any,
-      defaultEnum: "BAR",
-      defaultIntEnum: 2,
-      emptyString: "foo",
-      falseBoolean: true,
-      emptyBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      zeroByte: 1,
-      zeroShort: 1,
-      zeroInteger: 1,
-      zeroLong: 1,
-      zeroFloat: 1.0,
-      zeroDouble: 1.0,
+      "defaultEnum": "BAR",
+      "defaultIntEnum": 2,
+      "emptyString": "foo",
+      "falseBoolean": true,
+      "emptyBlob": Uint8Array.from("hi", c => c.charCodeAt(0)),
+      "zeroByte": 1,
+      "zeroShort": 1,
+      "zeroInteger": 1,
+      "zeroLong": 1,
+      "zeroFloat": 1.0,
+      "zeroDouble": 1.0,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -956,8 +982,8 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request",
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -974,19 +1000,21 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults:Request",
 /**
  * Any time a value is provided for a member in the top level of input, it is used, regardless of if its the default.
  */
-it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async () => {
+it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    topLevelDefault: "hi",
-    otherTopLevelDefault: 0,
-  } as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+    "topLevelDefault": "hi",
+    "otherTopLevelDefault": 0,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -997,8 +1025,8 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async (
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1015,18 +1043,21 @@ it.skip("RpcV2CborClientUsesExplicitlyProvidedValuesInTopLevel:Request", async (
 /**
  * Typically, non top-level members would have defaults filled in, but if they have the clientOptional trait, the defaults should be ignored.
  */
-it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Request", async () => {
+it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Request", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OperationWithDefaultsCommand({
-    clientOptionalDefaults: {} as any,
-  } as any);
+  const command = new OperationWithDefaultsCommand(
+  {
+    "clientOptionalDefaults": {
+    } as any,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1037,8 +1068,8 @@ it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Re
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/OperationWithDefaults");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1055,18 +1086,18 @@ it.skip("RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional:Re
 /**
  * Client populates default values when missing in response.
  */
-it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", async () => {
+it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -1079,38 +1110,63 @@ it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", 
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "defaultString":
+    "hi",
+    "defaultBoolean":
+    true,
+    "defaultList":
+    [
+    ],
+    "defaultTimestamp":
+    new Date(0 * 1000),
+    "defaultBlob":
+    Uint8Array.from("abc", c => c.charCodeAt(0)),
+    "defaultByte":
+    1,
+    "defaultShort":
+    1,
+    "defaultInteger":
+    10,
+    "defaultLong":
+    100,
+    "defaultFloat":
+    1.0,
+    "defaultDouble":
+    1.0,
+    "defaultMap":
     {
-      defaultString: "hi",
-      defaultBoolean: true,
-      defaultList: [],
-      defaultTimestamp: new Date(0 * 1000),
-      defaultBlob: Uint8Array.from("abc", (c) => c.charCodeAt(0)),
-      defaultByte: 1,
-      defaultShort: 1,
-      defaultInteger: 10,
-      defaultLong: 100,
-      defaultFloat: 1.0,
-      defaultDouble: 1.0,
-      defaultMap: {},
-      defaultEnum: "FOO",
-      defaultIntEnum: 1,
-      emptyString: "",
-      falseBoolean: false,
-      emptyBlob: Uint8Array.from("", (c) => c.charCodeAt(0)),
-      zeroByte: 0,
-      zeroShort: 0,
-      zeroInteger: 0,
-      zeroLong: 0,
-      zeroFloat: 0.0,
-      zeroDouble: 0.0,
     },
+    "defaultEnum":
+    "FOO",
+    "defaultIntEnum":
+    1,
+    "emptyString":
+    "",
+    "falseBoolean":
+    false,
+    "emptyBlob":
+    Uint8Array.from("", c => c.charCodeAt(0)),
+    "zeroByte":
+    0,
+    "zeroShort":
+    0,
+    "zeroInteger":
+    0,
+    "zeroLong":
+    0,
+    "zeroFloat":
+    0.0,
+    "zeroDouble":
+    0.0,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1119,18 +1175,18 @@ it.skip("RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse:Response", 
 /**
  * Client ignores default values if member values are present in the response.
  */
-it.skip("RpcV2CborClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse:Response", async () => {
+it.skip("RpcV2CborClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse:Response", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v21kZWZhdWx0U3RyaW5nY2J5ZW5kZWZhdWx0Qm9vbGVhbvRrZGVmYXVsdExpc3SBYWFwZGVmYXVsdFRpbWVzdGFtcMH7QAAAAAAAAABrZGVmYXVsdEJsb2JCaGlrZGVmYXVsdEJ5dGUCbGRlZmF1bHRTaG9ydAJuZGVmYXVsdEludGVnZXIUa2RlZmF1bHRMb25nGMhsZGVmYXVsdEZsb2F0+kAAAABtZGVmYXVsdERvdWJsZftAAAAAAAAAAGpkZWZhdWx0TWFwoWRuYW1lZEphY2trZGVmYXVsdEVudW1jQkFSbmRlZmF1bHRJbnRFbnVtAmtlbXB0eVN0cmluZ2Nmb29sZmFsc2VCb29sZWFu9WllbXB0eUJsb2JCaGloemVyb0J5dGUBaXplcm9TaG9ydAFremVyb0ludGVnZXIBaHplcm9Mb25nAWl6ZXJvRmxvYXT6P4AAAGp6ZXJvRG91Ymxl+z/wAAAAAAAA/w==`
-    ),
+      `v21kZWZhdWx0U3RyaW5nY2J5ZW5kZWZhdWx0Qm9vbGVhbvRrZGVmYXVsdExpc3SBYWFwZGVmYXVsdFRpbWVzdGFtcMH7QAAAAAAAAABrZGVmYXVsdEJsb2JCaGlrZGVmYXVsdEJ5dGUCbGRlZmF1bHRTaG9ydAJuZGVmYXVsdEludGVnZXIUa2RlZmF1bHRMb25nGMhsZGVmYXVsdEZsb2F0+kAAAABtZGVmYXVsdERvdWJsZftAAAAAAAAAAGpkZWZhdWx0TWFwoWRuYW1lZEphY2trZGVmYXVsdEVudW1jQkFSbmRlZmF1bHRJbnRFbnVtAmtlbXB0eVN0cmluZ2Nmb29sZmFsc2VCb29sZWFu9WllbXB0eUJsb2JCaGloemVyb0J5dGUBaXplcm9TaG9ydAFremVyb0ludGVnZXIBaHplcm9Mb25nAWl6ZXJvRmxvYXT6P4AAAGp6ZXJvRG91Ymxl+z/wAAAAAAAA/w==`,
+    )
   });
 
   const params: any = {};
@@ -1143,40 +1199,66 @@ it.skip("RpcV2CborClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse:R
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "defaultString":
+    "bye",
+    "defaultBoolean":
+    false,
+    "defaultList":
+    [
+      "a",
+    ],
+    "defaultTimestamp":
+    new Date(2 * 1000),
+    "defaultBlob":
+    Uint8Array.from("hi", c => c.charCodeAt(0)),
+    "defaultByte":
+    2,
+    "defaultShort":
+    2,
+    "defaultInteger":
+    20,
+    "defaultLong":
+    200,
+    "defaultFloat":
+    2.0,
+    "defaultDouble":
+    2.0,
+    "defaultMap":
     {
-      defaultString: "bye",
-      defaultBoolean: false,
-      defaultList: ["a"],
-      defaultTimestamp: new Date(2 * 1000),
-      defaultBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      defaultByte: 2,
-      defaultShort: 2,
-      defaultInteger: 20,
-      defaultLong: 200,
-      defaultFloat: 2.0,
-      defaultDouble: 2.0,
-      defaultMap: {
-        name: "Jack",
-      },
-      defaultEnum: "BAR",
-      defaultIntEnum: 2,
-      emptyString: "foo",
-      falseBoolean: true,
-      emptyBlob: Uint8Array.from("hi", (c) => c.charCodeAt(0)),
-      zeroByte: 1,
-      zeroShort: 1,
-      zeroInteger: 1,
-      zeroLong: 1,
-      zeroFloat: 1.0,
-      zeroDouble: 1.0,
+      "name":
+      "Jack",
     },
+    "defaultEnum":
+    "BAR",
+    "defaultIntEnum":
+    2,
+    "emptyString":
+    "foo",
+    "falseBoolean":
+    true,
+    "emptyBlob":
+    Uint8Array.from("hi", c => c.charCodeAt(0)),
+    "zeroByte":
+    1,
+    "zeroShort":
+    1,
+    "zeroInteger":
+    1,
+    "zeroLong":
+    1,
+    "zeroFloat":
+    1.0,
+    "zeroDouble":
+    1.0,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1191,10 +1273,13 @@ it("optional_input:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new OptionalInputOutputCommand({} as any);
+  const command = new OptionalInputOutputCommand(
+  {
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1231,11 +1316,11 @@ it("optional_output:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v/8=`
-    ),
+      `v/8=`,
+    )
   });
 
   const params: any = {};
@@ -1248,7 +1333,7 @@ it("optional_output:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -1260,23 +1345,25 @@ it("RpcV2CborRecursiveShapes:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RecursiveShapesCommand({
-    nested: {
-      foo: "Foo1",
-      nested: {
-        bar: "Bar1",
-        recursiveMember: {
-          foo: "Foo2",
-          nested: {
-            bar: "Bar2",
+  const command = new RecursiveShapesCommand(
+  {
+    "nested": {
+      "foo": "Foo1",
+      "nested": {
+        "bar": "Bar1",
+        "recursiveMember": {
+          "foo": "Foo2",
+          "nested": {
+            "bar": "Bar2",
           } as any,
         } as any,
       } as any,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1287,8 +1374,8 @@ it("RpcV2CborRecursiveShapes:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RecursiveShapes");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1312,11 +1399,11 @@ it("RpcV2CborRecursiveShapes:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8=`
-    ),
+      `v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8=`,
+    )
   });
 
   const params: any = {};
@@ -1329,27 +1416,35 @@ it("RpcV2CborRecursiveShapes:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "nested":
     {
-      nested: {
-        foo: "Foo1",
-        nested: {
-          bar: "Bar1",
-          recursiveMember: {
-            foo: "Foo2",
-            nested: {
-              bar: "Bar2",
-            },
+      "foo":
+      "Foo1",
+      "nested":
+      {
+        "bar":
+        "Bar1",
+        "recursiveMember":
+        {
+          "foo":
+          "Foo2",
+          "nested":
+          {
+            "bar":
+            "Bar2",
           },
         },
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1365,11 +1460,11 @@ it("RpcV2CborRecursiveShapesUsingDefiniteLength:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWZuZXN0ZWSiY2Zvb2RGb28xZm5lc3RlZKJjYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyomNmb29kRm9vMmZuZXN0ZWShY2JhcmRCYXIy`
-    ),
+      `oWZuZXN0ZWSiY2Zvb2RGb28xZm5lc3RlZKJjYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyomNmb29kRm9vMmZuZXN0ZWShY2JhcmRCYXIy`,
+    )
   });
 
   const params: any = {};
@@ -1382,27 +1477,35 @@ it("RpcV2CborRecursiveShapesUsingDefiniteLength:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "nested":
     {
-      nested: {
-        foo: "Foo1",
-        nested: {
-          bar: "Bar1",
-          recursiveMember: {
-            foo: "Foo2",
-            nested: {
-              bar: "Bar2",
-            },
+      "foo":
+      "Foo1",
+      "nested":
+      {
+        "bar":
+        "Bar1",
+        "recursiveMember":
+        {
+          "foo":
+          "Foo2",
+          "nested":
+          {
+            "bar":
+            "Bar2",
           },
         },
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1417,19 +1520,21 @@ it("RpcV2CborMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborDenseMapsCommand({
-    denseStructMap: {
-      foo: {
-        hi: "there",
+  const command = new RpcV2CborDenseMapsCommand(
+  {
+    "denseStructMap": {
+      "foo": {
+        "hi": "there",
       } as any,
-      baz: {
-        hi: "bye",
+      "baz": {
+        "hi": "bye",
       } as any,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1440,8 +1545,8 @@ it("RpcV2CborMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborDenseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1464,17 +1569,19 @@ it("RpcV2CborSerializesZeroValuesInMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborDenseMapsCommand({
-    denseNumberMap: {
-      x: 0,
+  const command = new RpcV2CborDenseMapsCommand(
+  {
+    "denseNumberMap": {
+      "x": 0,
     } as any,
-    denseBooleanMap: {
-      x: false,
+    "denseBooleanMap": {
+      "x": false,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1485,8 +1592,8 @@ it("RpcV2CborSerializesZeroValuesInMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborDenseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1509,15 +1616,21 @@ it("RpcV2CborSerializesDenseSetMap:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborDenseMapsCommand({
-    denseSetMap: {
-      x: [],
-      y: ["a", "b"],
+  const command = new RpcV2CborDenseMapsCommand(
+  {
+    "denseSetMap": {
+      "x": [
+      ],
+      "y": [
+        "a",
+        "b",
+      ],
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1528,8 +1641,8 @@ it("RpcV2CborSerializesDenseSetMap:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborDenseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1553,11 +1666,11 @@ it("RpcV2CborMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ==`
-    ),
+      `oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ==`,
+    )
   });
 
   const params: any = {};
@@ -1570,23 +1683,28 @@ it("RpcV2CborMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseStructMap":
     {
-      denseStructMap: {
-        foo: {
-          hi: "there",
-        },
-        baz: {
-          hi: "bye",
-        },
+      "foo":
+      {
+        "hi":
+        "there",
+      },
+      "baz":
+      {
+        "hi":
+        "bye",
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1602,11 +1720,11 @@ it("RpcV2CborDeserializesZeroValuesInMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A==`
-    ),
+      `om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A==`,
+    )
   });
 
   const params: any = {};
@@ -1619,21 +1737,25 @@ it("RpcV2CborDeserializesZeroValuesInMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseNumberMap":
     {
-      denseNumberMap: {
-        x: 0,
-      },
-      denseBooleanMap: {
-        x: false,
-      },
+      "x":
+      0,
     },
+    "denseBooleanMap":
+    {
+      "x":
+      false,
+    },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1649,11 +1771,11 @@ it("RpcV2CborDeserializesDenseSetMap:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWtkZW5zZVNldE1hcKJheIBheYJhYWFi`
-    ),
+      `oWtkZW5zZVNldE1hcKJheIBheYJhYWFi`,
+    )
   });
 
   const params: any = {};
@@ -1666,19 +1788,26 @@ it("RpcV2CborDeserializesDenseSetMap:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseSetMap":
     {
-      denseSetMap: {
-        x: [],
-        y: ["a", "b"],
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1688,18 +1817,18 @@ it("RpcV2CborDeserializesDenseSetMap:Response", async () => {
  * Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD
  * drop the null key-value pair.
  */
-it.skip("RpcV2CborDeserializesDenseSetMapAndSkipsNull:Response", async () => {
+it.skip("RpcV2CborDeserializesDenseSetMapAndSkipsNull:Response", async() => {
   const client = new RpcV2ProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWtkZW5zZVNldE1hcKNheIBheYJhYWFiYXr2`
-    ),
+      `oWtkZW5zZVNldE1hcKNheIBheYJhYWFiYXr2`,
+    )
   });
 
   const params: any = {};
@@ -1712,19 +1841,26 @@ it.skip("RpcV2CborDeserializesDenseSetMapAndSkipsNull:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "denseSetMap":
     {
-      denseSetMap: {
-        x: [],
-        y: ["a", "b"],
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1739,33 +1875,65 @@ it("RpcV2CborLists:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborListsCommand({
-    stringList: ["foo", "bar"],
-    stringSet: ["foo", "bar"],
-    integerList: [1, 2],
-    booleanList: [true, false],
-    timestampList: [new Date(1398796238000), new Date(1398796238000)],
-    enumList: ["Foo", "0"],
-    intEnumList: [1, 2],
-    nestedStringList: [
-      ["foo", "bar"],
-      ["baz", "qux"],
+  const command = new RpcV2CborListsCommand(
+  {
+    "stringList": [
+      "foo",
+      "bar",
     ],
-    structureList: [
+    "stringSet": [
+      "foo",
+      "bar",
+    ],
+    "integerList": [
+      1,
+      2,
+    ],
+    "booleanList": [
+      true,
+      false,
+    ],
+    "timestampList": [
+      new Date(1398796238000),
+      new Date(1398796238000),
+    ],
+    "enumList": [
+      "Foo",
+      "0",
+    ],
+    "intEnumList": [
+      1,
+      2,
+    ],
+    "nestedStringList": [
+      [
+        "foo",
+        "bar",
+      ],
+      [
+        "baz",
+        "qux",
+      ],
+    ],
+    "structureList": [
       {
-        a: "1",
-        b: "2",
+        "a": "1",
+        "b": "2",
       } as any,
       {
-        a: "3",
-        b: "4",
+        "a": "3",
+        "b": "4",
       } as any,
     ],
-    blobList: [Uint8Array.from("foo", (c) => c.charCodeAt(0)), Uint8Array.from("bar", (c) => c.charCodeAt(0))],
-  } as any);
+    "blobList": [
+      Uint8Array.from("foo", c => c.charCodeAt(0)),
+      Uint8Array.from("bar", c => c.charCodeAt(0)),
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1776,8 +1944,8 @@ it("RpcV2CborLists:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborLists");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1800,12 +1968,15 @@ it("RpcV2CborListsEmpty:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborListsCommand({
-    stringList: [],
-  } as any);
+  const command = new RpcV2CborListsCommand(
+  {
+    "stringList": [
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1816,8 +1987,8 @@ it("RpcV2CborListsEmpty:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborLists");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1840,12 +2011,15 @@ it("RpcV2CborListsEmptyUsingDefiniteLength:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborListsCommand({
-    stringList: [],
-  } as any);
+  const command = new RpcV2CborListsCommand(
+  {
+    "stringList": [
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -1856,8 +2030,8 @@ it("RpcV2CborListsEmptyUsingDefiniteLength:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborLists");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -1881,11 +2055,11 @@ it("RpcV2CborLists:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2pzdHJpbmdMaXN0n2Nmb29jYmFy/2lzdHJpbmdTZXSfY2Zvb2NiYXL/a2ludGVnZXJMaXN0nwEC/2tib29sZWFuTGlzdJ/19P9tdGltZXN0YW1wTGlzdJ/B+0HU1/vzgAAAwftB1Nf784AAAP9oZW51bUxpc3SfY0Zvb2Ew/2tpbnRFbnVtTGlzdJ8BAv9wbmVzdGVkU3RyaW5nTGlzdJ+fY2Zvb2NiYXL/n2NiYXpjcXV4//9tc3RydWN0dXJlTGlzdJ+/YWFhMWFiYTL/v2FhYTNhYmE0//9oYmxvYkxpc3SfQ2Zvb0NiYXL//w==`
-    ),
+      `v2pzdHJpbmdMaXN0n2Nmb29jYmFy/2lzdHJpbmdTZXSfY2Zvb2NiYXL/a2ludGVnZXJMaXN0nwEC/2tib29sZWFuTGlzdJ/19P9tdGltZXN0YW1wTGlzdJ/B+0HU1/vzgAAAwftB1Nf784AAAP9oZW51bUxpc3SfY0Zvb2Ew/2tpbnRFbnVtTGlzdJ8BAv9wbmVzdGVkU3RyaW5nTGlzdJ+fY2Zvb2NiYXL/n2NiYXpjcXV4//9tc3RydWN0dXJlTGlzdJ+/YWFhMWFiYTL/v2FhYTNhYmE0//9oYmxvYkxpc3SfQ2Zvb0NiYXL//w==`,
+    )
   });
 
   const params: any = {};
@@ -1898,37 +2072,81 @@ it("RpcV2CborLists:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: ["foo", "bar"],
-      stringSet: ["foo", "bar"],
-      integerList: [1, 2],
-      booleanList: [true, false],
-      timestampList: [new Date(1398796238 * 1000), new Date(1398796238 * 1000)],
-      enumList: ["Foo", "0"],
-      intEnumList: [1, 2],
-      nestedStringList: [
-        ["foo", "bar"],
-        ["baz", "qux"],
+  {
+    "stringList":
+    [
+      "foo",
+      "bar",
+    ],
+    "stringSet":
+    [
+      "foo",
+      "bar",
+    ],
+    "integerList":
+    [
+      1,
+      2,
+    ],
+    "booleanList":
+    [
+      true,
+      false,
+    ],
+    "timestampList":
+    [
+      new Date(1398796238 * 1000),
+      new Date(1398796238 * 1000),
+    ],
+    "enumList":
+    [
+      "Foo",
+      "0",
+    ],
+    "intEnumList":
+    [
+      1,
+      2,
+    ],
+    "nestedStringList":
+    [
+      [
+        "foo",
+        "bar",
       ],
-      structureList: [
-        {
-          a: "1",
-          b: "2",
-        },
-        {
-          a: "3",
-          b: "4",
-        },
+      [
+        "baz",
+        "qux",
       ],
-      blobList: [Uint8Array.from("foo", (c) => c.charCodeAt(0)), Uint8Array.from("bar", (c) => c.charCodeAt(0))],
-    },
+    ],
+    "structureList":
+    [
+      {
+        "a":
+        "1",
+        "b":
+        "2",
+      },
+      {
+        "a":
+        "3",
+        "b":
+        "4",
+      },
+    ],
+    "blobList":
+    [
+      Uint8Array.from("foo", c => c.charCodeAt(0)),
+      Uint8Array.from("bar", c => c.charCodeAt(0)),
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1944,11 +2162,11 @@ it("RpcV2CborListsEmpty:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2pzdHJpbmdMaXN0n///`
-    ),
+      `v2pzdHJpbmdMaXN0n///`,
+    )
   });
 
   const params: any = {};
@@ -1961,16 +2179,18 @@ it("RpcV2CborListsEmpty:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: [],
-    },
+  {
+    "stringList":
+    [
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -1986,11 +2206,11 @@ it("RpcV2CborIndefiniteStringInsideIndefiniteListCanDeserialize:Response", async
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2pzdHJpbmdMaXN0n394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n//8=`
-    ),
+      `v2pzdHJpbmdMaXN0n394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n//8=`,
+    )
   });
 
   const params: any = {};
@@ -2003,20 +2223,21 @@ it("RpcV2CborIndefiniteStringInsideIndefiniteListCanDeserialize:Response", async
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: [
-        "An example indefinite string, which will be chunked, on each comma",
-        "Another example indefinite string with only one chunk",
-        "This is a plain string",
-      ],
-    },
+  {
+    "stringList":
+    [
+      "An example indefinite string, which will be chunked, on each comma",
+      "Another example indefinite string with only one chunk",
+      "This is a plain string",
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2032,11 +2253,11 @@ it("RpcV2CborIndefiniteStringInsideDefiniteListCanDeserialize:Response", async (
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `oWpzdHJpbmdMaXN0g394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n`
-    ),
+      `oWpzdHJpbmdMaXN0g394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n`,
+    )
   });
 
   const params: any = {};
@@ -2049,20 +2270,21 @@ it("RpcV2CborIndefiniteStringInsideDefiniteListCanDeserialize:Response", async (
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      stringList: [
-        "An example indefinite string, which will be chunked, on each comma",
-        "Another example indefinite string with only one chunk",
-        "This is a plain string",
-      ],
-    },
+  {
+    "stringList":
+    [
+      "An example indefinite string, which will be chunked, on each comma",
+      "Another example indefinite string with only one chunk",
+      "This is a plain string",
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2077,19 +2299,21 @@ it("RpcV2CborSparseMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseStructMap: {
-      foo: {
-        hi: "there",
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseStructMap": {
+      "foo": {
+        "hi": "there",
       } as any,
-      baz: {
-        hi: "bye",
+      "baz": {
+        "hi": "bye",
       } as any,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2100,8 +2324,8 @@ it("RpcV2CborSparseMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2124,23 +2348,25 @@ it("RpcV2CborSerializesNullMapValues:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseBooleanMap: {
-      x: null,
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseBooleanMap": {
+      "x": null,
     } as any,
-    sparseNumberMap: {
-      x: null,
+    "sparseNumberMap": {
+      "x": null,
     } as any,
-    sparseStringMap: {
-      x: null,
+    "sparseStringMap": {
+      "x": null,
     } as any,
-    sparseStructMap: {
-      x: null,
+    "sparseStructMap": {
+      "x": null,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2151,8 +2377,8 @@ it("RpcV2CborSerializesNullMapValues:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2175,15 +2401,21 @@ it("RpcV2CborSerializesSparseSetMap:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseSetMap: {
-      x: [],
-      y: ["a", "b"],
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseSetMap": {
+      "x": [
+      ],
+      "y": [
+        "a",
+        "b",
+      ],
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2194,8 +2426,8 @@ it("RpcV2CborSerializesSparseSetMap:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2218,16 +2450,22 @@ it("RpcV2CborSerializesSparseSetMapAndRetainsNull:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseSetMap: {
-      x: [],
-      y: ["a", "b"],
-      z: null,
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseSetMap": {
+      "x": [
+      ],
+      "y": [
+        "a",
+        "b",
+      ],
+      "z": null,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2238,8 +2476,8 @@ it("RpcV2CborSerializesSparseSetMapAndRetainsNull:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2262,17 +2500,19 @@ it("RpcV2CborSerializesZeroValuesInSparseMaps:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new RpcV2CborSparseMapsCommand({
-    sparseNumberMap: {
-      x: 0,
+  const command = new RpcV2CborSparseMapsCommand(
+  {
+    "sparseNumberMap": {
+      "x": 0,
     } as any,
-    sparseBooleanMap: {
-      x: false,
+    "sparseBooleanMap": {
+      "x": false,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2283,8 +2523,8 @@ it("RpcV2CborSerializesZeroValuesInSparseMaps:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/RpcV2CborSparseMaps");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2308,11 +2548,11 @@ it("RpcV2CborSparseJsonMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v29zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb79iaGlldGhlcmX/Y2Jher9iaGljYnll////`
-    ),
+      `v29zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb79iaGlldGhlcmX/Y2Jher9iaGljYnll////`,
+    )
   });
 
   const params: any = {};
@@ -2325,23 +2565,28 @@ it("RpcV2CborSparseJsonMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseStructMap":
     {
-      sparseStructMap: {
-        foo: {
-          hi: "there",
-        },
-        baz: {
-          hi: "bye",
-        },
+      "foo":
+      {
+        "hi":
+        "there",
+      },
+      "baz":
+      {
+        "hi":
+        "bye",
       },
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2357,11 +2602,11 @@ it("RpcV2CborDeserializesNullMapValues:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//`
-    ),
+      `v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//`,
+    )
   });
 
   const params: any = {};
@@ -2374,27 +2619,35 @@ it("RpcV2CborDeserializesNullMapValues:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseBooleanMap":
     {
-      sparseBooleanMap: {
-        x: null,
-      },
-      sparseNumberMap: {
-        x: null,
-      },
-      sparseStringMap: {
-        x: null,
-      },
-      sparseStructMap: {
-        x: null,
-      },
+      "x":
+      null,
     },
+    "sparseNumberMap":
+    {
+      "x":
+      null,
+    },
+    "sparseStringMap":
+    {
+      "x":
+      null,
+    },
+    "sparseStructMap":
+    {
+      "x":
+      null,
+    },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2410,11 +2663,11 @@ it("RpcV2CborDeserializesSparseSetMap:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8=`
-    ),
+      `v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8=`,
+    )
   });
 
   const params: any = {};
@@ -2427,19 +2680,26 @@ it("RpcV2CborDeserializesSparseSetMap:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseSetMap":
     {
-      sparseSetMap: {
-        x: [],
-        y: ["a", "b"],
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2455,11 +2715,11 @@ it("RpcV2CborDeserializesSparseSetMapAndRetainsNull:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL/YXr2//8=`
-    ),
+      `v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL/YXr2//8=`,
+    )
   });
 
   const params: any = {};
@@ -2472,20 +2732,28 @@ it("RpcV2CborDeserializesSparseSetMapAndRetainsNull:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseSetMap":
     {
-      sparseSetMap: {
-        x: [],
-        y: ["a", "b"],
-        z: null,
-      },
+      "x":
+      [
+      ],
+      "y":
+      [
+        "a",
+        "b",
+      ],
+      "z":
+      null,
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2501,11 +2769,11 @@ it("RpcV2CborDeserializesZeroValuesInSparseMaps:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v29zcGFyc2VOdW1iZXJNYXC/YXgA/3BzcGFyc2VCb29sZWFuTWFwv2F49P//`
-    ),
+      `v29zcGFyc2VOdW1iZXJNYXC/YXgA/3BzcGFyc2VCb29sZWFuTWFwv2F49P//`,
+    )
   });
 
   const params: any = {};
@@ -2518,21 +2786,25 @@ it("RpcV2CborDeserializesZeroValuesInSparseMaps:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseNumberMap":
     {
-      sparseNumberMap: {
-        x: 0,
-      },
-      sparseBooleanMap: {
-        x: false,
-      },
+      "x":
+      0,
     },
+    "sparseBooleanMap":
+    {
+      "x":
+      false,
+    },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2547,21 +2819,23 @@ it("RpcV2CborSimpleScalarProperties:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    byteValue: 5,
-    doubleValue: 1.889,
-    falseBooleanValue: false,
-    floatValue: 7.625,
-    integerValue: 256,
-    longValue: 9873,
-    shortValue: 9898,
-    stringValue: "simple",
-    trueBooleanValue: true,
-    blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "byteValue": 5,
+    "doubleValue": 1.889,
+    "falseBooleanValue": false,
+    "floatValue": 7.625,
+    "integerValue": 256,
+    "longValue": 9873,
+    "shortValue": 9898,
+    "stringValue": "simple",
+    "trueBooleanValue": true,
+    "blobValue": Uint8Array.from("foo", c => c.charCodeAt(0)),
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2572,8 +2846,8 @@ it("RpcV2CborSimpleScalarProperties:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2596,12 +2870,14 @@ it("RpcV2CborClientDoesntSerializeNullStructureValues:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    stringValue: null,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "stringValue": null,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2612,8 +2888,8 @@ it("RpcV2CborClientDoesntSerializeNullStructureValues:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2636,13 +2912,15 @@ it("RpcV2CborSupportsNaNFloatInputs:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    doubleValue: NaN,
-    floatValue: NaN,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "doubleValue": NaN,
+    "floatValue": NaN,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2653,8 +2931,8 @@ it("RpcV2CborSupportsNaNFloatInputs:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2677,13 +2955,15 @@ it("RpcV2CborSupportsInfinityFloatInputs:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    doubleValue: Infinity,
-    floatValue: Infinity,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "doubleValue": Infinity,
+    "floatValue": Infinity,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2694,8 +2974,8 @@ it("RpcV2CborSupportsInfinityFloatInputs:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2718,13 +2998,15 @@ it("RpcV2CborSupportsNegativeInfinityFloatInputs:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SimpleScalarPropertiesCommand({
-    doubleValue: -Infinity,
-    floatValue: -Infinity,
-  } as any);
+  const command = new SimpleScalarPropertiesCommand(
+  {
+    "doubleValue": -Infinity,
+    "floatValue": -Infinity,
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -2735,8 +3017,8 @@ it("RpcV2CborSupportsNegativeInfinityFloatInputs:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SimpleScalarProperties");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -2760,11 +3042,11 @@ it("RpcV2CborSimpleScalarProperties:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v3B0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb2//`
-    ),
+      `v3B0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb2//`,
+    )
   });
 
   const params: any = {};
@@ -2777,24 +3059,33 @@ it("RpcV2CborSimpleScalarProperties:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      trueBooleanValue: true,
-      falseBooleanValue: false,
-      byteValue: 5,
-      doubleValue: 1.889,
-      floatValue: 7.625,
-      integerValue: 256,
-      shortValue: 9898,
-      stringValue: "simple",
-      blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-    },
+  {
+    "trueBooleanValue":
+    true,
+    "falseBooleanValue":
+    false,
+    "byteValue":
+    5,
+    "doubleValue":
+    1.889,
+    "floatValue":
+    7.625,
+    "integerValue":
+    256,
+    "shortValue":
+    9898,
+    "stringValue":
+    "simple",
+    "blobValue":
+    Uint8Array.from("foo", c => c.charCodeAt(0)),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2810,11 +3101,11 @@ it("RpcV2CborSimpleScalarPropertiesUsingDefiniteLength:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `qXB0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb28=`
-    ),
+      `qXB0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb28=`,
+    )
   });
 
   const params: any = {};
@@ -2827,24 +3118,33 @@ it("RpcV2CborSimpleScalarPropertiesUsingDefiniteLength:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      trueBooleanValue: true,
-      falseBooleanValue: false,
-      byteValue: 5,
-      doubleValue: 1.889,
-      floatValue: 7.625,
-      integerValue: 256,
-      shortValue: 9898,
-      stringValue: "simple",
-      blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-    },
+  {
+    "trueBooleanValue":
+    true,
+    "falseBooleanValue":
+    false,
+    "byteValue":
+    5,
+    "doubleValue":
+    1.889,
+    "floatValue":
+    7.625,
+    "integerValue":
+    256,
+    "shortValue":
+    9898,
+    "stringValue":
+    "simple",
+    "blobValue":
+    Uint8Array.from("foo", c => c.charCodeAt(0)),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2860,11 +3160,11 @@ it("RpcV2CborClientDoesntDeserializeNullStructureValues:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tzdHJpbmdWYWx1Zfb/`
-    ),
+      `v2tzdHJpbmdWYWx1Zfb/`,
+    )
   });
 
   const params: any = {};
@@ -2877,7 +3177,7 @@ it("RpcV2CborClientDoesntDeserializeNullStructureValues:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
 });
 
 /**
@@ -2890,11 +3190,11 @@ it("RpcV2CborSupportsNaNFloatOutputs:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/`
-    ),
+      `v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/`,
+    )
   });
 
   const params: any = {};
@@ -2907,17 +3207,19 @@ it("RpcV2CborSupportsNaNFloatOutputs:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: NaN,
-      floatValue: NaN,
-    },
+  {
+    "doubleValue":
+    NaN,
+    "floatValue":
+    NaN,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2933,11 +3235,11 @@ it("RpcV2CborSupportsInfinityFloatOutputs:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/`
-    ),
+      `v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/`,
+    )
   });
 
   const params: any = {};
@@ -2950,17 +3252,19 @@ it("RpcV2CborSupportsInfinityFloatOutputs:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: Infinity,
-      floatValue: Infinity,
-    },
+  {
+    "doubleValue":
+    Infinity,
+    "floatValue":
+    Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -2976,11 +3280,11 @@ it("RpcV2CborSupportsNegativeInfinityFloatOutputs:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/`
-    ),
+      `v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/`,
+    )
   });
 
   const params: any = {};
@@ -2993,17 +3297,19 @@ it("RpcV2CborSupportsNegativeInfinityFloatOutputs:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: -Infinity,
-      floatValue: -Infinity,
-    },
+  {
+    "doubleValue":
+    -Infinity,
+    "floatValue":
+    -Infinity,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3019,11 +3325,11 @@ it("RpcV2CborSupportsUpcastingDataOnDeserialize:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2tkb3VibGVWYWx1Zfk+AGpmbG9hdFZhbHVl+UegbGludGVnZXJWYWx1ZRg4aWxvbmdWYWx1ZRkBAGpzaG9ydFZhbHVlCv8=`
-    ),
+      `v2tkb3VibGVWYWx1Zfk+AGpmbG9hdFZhbHVl+UegbGludGVnZXJWYWx1ZRg4aWxvbmdWYWx1ZRkBAGpzaG9ydFZhbHVlCv8=`,
+    )
   });
 
   const params: any = {};
@@ -3036,20 +3342,25 @@ it("RpcV2CborSupportsUpcastingDataOnDeserialize:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      doubleValue: 1.5,
-      floatValue: 7.625,
-      integerValue: 56,
-      longValue: 256,
-      shortValue: 10,
-    },
+  {
+    "doubleValue":
+    1.5,
+    "floatValue":
+    7.625,
+    "integerValue":
+    56,
+    "longValue":
+    256,
+    "shortValue":
+    10,
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3067,11 +3378,11 @@ it("RpcV2CborExtraFieldsInTheBodyShouldBeSkippedByClients:Response", async () =>
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABrZXh0cmFPYmplY3S/c2luZGVmaW5pdGVMZW5ndGhNYXC/a3dpdGhBbkFycmF5nwECA///cWRlZmluaXRlTGVuZ3RoTWFwo3J3aXRoQURlZmluaXRlQXJyYXmDAQIDeB1hbmRTb21lSW5kZWZpbml0ZUxlbmd0aFN0cmluZ3gfdGhhdCBoYXMsIGJlZW4gY2h1bmtlZCBvbiBjb21tYWxub3JtYWxTdHJpbmdjZm9vanNob3J0VmFsdWUZJw9uc29tZU90aGVyRmllbGR2dGhpcyBzaG91bGQgYmUgc2tpcHBlZP9saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w==`
-    ),
+      `v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABrZXh0cmFPYmplY3S/c2luZGVmaW5pdGVMZW5ndGhNYXC/a3dpdGhBbkFycmF5nwECA///cWRlZmluaXRlTGVuZ3RoTWFwo3J3aXRoQURlZmluaXRlQXJyYXmDAQIDeB1hbmRTb21lSW5kZWZpbml0ZUxlbmd0aFN0cmluZ3gfdGhhdCBoYXMsIGJlZW4gY2h1bmtlZCBvbiBjb21tYWxub3JtYWxTdHJpbmdjZm9vanNob3J0VmFsdWUZJw9uc29tZU90aGVyRmllbGR2dGhpcyBzaG91bGQgYmUgc2tpcHBlZP9saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w==`,
+    )
   });
 
   const params: any = {};
@@ -3084,25 +3395,35 @@ it("RpcV2CborExtraFieldsInTheBodyShouldBeSkippedByClients:Response", async () =>
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      byteValue: 5,
-      doubleValue: 1.889,
-      falseBooleanValue: false,
-      floatValue: 7.625,
-      integerValue: 256,
-      longValue: 9873,
-      shortValue: 9898,
-      stringValue: "simple",
-      trueBooleanValue: true,
-      blobValue: Uint8Array.from("foo", (c) => c.charCodeAt(0)),
-    },
+  {
+    "byteValue":
+    5,
+    "doubleValue":
+    1.889,
+    "falseBooleanValue":
+    false,
+    "floatValue":
+    7.625,
+    "integerValue":
+    256,
+    "longValue":
+    9873,
+    "shortValue":
+    9898,
+    "stringValue":
+    "simple",
+    "trueBooleanValue":
+    true,
+    "blobValue":
+    Uint8Array.from("foo", c => c.charCodeAt(0)),
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3117,14 +3438,16 @@ it("RpcV2CborSparseMapsSerializeNullValues:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SparseNullsOperationCommand({
-    sparseStringMap: {
-      foo: null,
+  const command = new SparseNullsOperationCommand(
+  {
+    "sparseStringMap": {
+      "foo": null,
     } as any,
-  } as any);
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -3135,8 +3458,8 @@ it("RpcV2CborSparseMapsSerializeNullValues:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SparseNullsOperation");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -3159,12 +3482,16 @@ it("RpcV2CborSparseListsSerializeNull:Request", async () => {
     requestHandler: new RequestSerializationTestHandler(),
   });
 
-  const command = new SparseNullsOperationCommand({
-    sparseStringList: [null],
-  } as any);
+  const command = new SparseNullsOperationCommand(
+  {
+    "sparseStringList": [
+      null,
+    ],
+  } as any,
+  );
   try {
     await client.send(command);
-    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    fail('Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown');
     return;
   } catch (err) {
     if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
@@ -3175,8 +3502,8 @@ it("RpcV2CborSparseListsSerializeNull:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/service/RpcV2Protocol/operation/SparseNullsOperation");
     expect(
-      r.headers["content-length"],
-      `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
+        r.headers["content-length"],
+        `Header key "content-length" should have been defined in ${JSON.stringify(r.headers)}`
     ).toBeDefined();
 
     expect(r.headers["accept"]).toBe("application/cbor");
@@ -3200,11 +3527,11 @@ it("RpcV2CborSparseMapsDeserializeNullValues:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v29zcGFyc2VTdHJpbmdNYXC/Y2Zvb/b//w==`
-    ),
+      `v29zcGFyc2VTdHJpbmdNYXC/Y2Zvb/b//w==`,
+    )
   });
 
   const params: any = {};
@@ -3217,18 +3544,20 @@ it("RpcV2CborSparseMapsDeserializeNullValues:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
+  {
+    "sparseStringMap":
     {
-      sparseStringMap: {
-        foo: null,
-      },
+      "foo":
+      null,
     },
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });
@@ -3244,11 +3573,11 @@ it("RpcV2CborSparseListsDeserializeNull:Response", async () => {
       true,
       200,
       {
-        "smithy-protocol": "rpc-v2-cbor",
-        "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          "content-type": "application/cbor"
       },
-      `v3BzcGFyc2VTdHJpbmdMaXN0n/b//w==`
-    ),
+      `v3BzcGFyc2VTdHJpbmdMaXN0n/b//w==`,
+    )
   });
 
   const params: any = {};
@@ -3261,16 +3590,19 @@ it("RpcV2CborSparseListsDeserializeNull:Response", async () => {
     fail("Expected a valid response to be returned, got " + err);
     return;
   }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
+  expect(r['$metadata'].httpStatusCode).toBe(200);
   const paramsToValidate: any = [
-    {
-      sparseStringList: [null],
-    },
+  {
+    "sparseStringList":
+    [
+      null,
+    ],
+  },
   ][0];
-  Object.keys(paramsToValidate).forEach((param) => {
+  Object.keys(paramsToValidate).forEach(param => {
     expect(
-      r[param],
-      `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
+        r[param],
+        `The output field ${param} should have been defined in ${JSON.stringify(r, null, 2)}`
     ).toBeDefined();
     expect(equivalentContents(paramsToValidate[param], r[param])).toBe(true);
   });


### PR DESCRIPTION
This removes formatting from generated clients in the private folder.

This is because we will soon have better formatted code generation, and to improve our level of awareness of the visual formatting of the code that we generate.

https://github.com/smithy-lang/smithy-typescript/pull/1780 will follow up with improved default formatting