### PR TITLE
fix(core/protocols): drain Unit response streams in HttpBindingProtocol

### DIFF
--- a/.changeset/nervous-lies-film.md
+++ b/.changeset/nervous-lies-film.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+drain stream in httpBindingProtocol with unit output


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/7510

*Description of changes:*

Fixes HttpBindingProtocol (REST handler) to drain/discard response streams when the output model is `Unit`, i.e. empty.