### PR TITLE
fix(codegen): ssdk unsupported features in smithy 1.64.0

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -103,6 +103,7 @@ public enum TypeScriptDependency implements Dependency {
         false),
     AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@smithy/eventstream-serde-node", false),
     AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@smithy/eventstream-serde-browser", false),
+    AWS_SDK_EVENTSTREAM_CODEC("dependencies", "@smithy/eventstream-codec", false),
 
     // Conditionally added if a requestCompression shape is found on any model operation.
     MIDDLEWARE_COMPRESSION("dependencies", "@smithy/middleware-compression", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -334,8 +334,16 @@ public class EventStreamGenerator {
             String memberName = headerMember.getMemberName();
             Shape target = model.expectShape(headerMember.getTarget());
             writer.openBlock("if (input.$L != null) {", "}", memberName, () -> {
-                writer.write("headers[$1S] = { type: $2S, value: input.$1L }", memberName,
+                if (target.isLongShape()) {
+                    writer.addImport("Int64", "__Int64", TypeScriptDependency.AWS_SDK_EVENTSTREAM_CODEC);
+                    writer.write("headers[$1S] = { type: $2S, value: __Int64.fromNumber(input.$1L) }",
+                        memberName,
+                        getEventHeaderType(target)
+                    );
+                } else {
+                    writer.write("headers[$1S] = { type: $2S, value: input.$1L }", memberName,
                         getEventHeaderType(target));
+                }
             });
         }
     }


### PR DESCRIPTION
Add stubs for unsupported SSDK event stream features so AWS protocol tests can compile against the existing supported feature set.