### PR TITLE
fix(codegen): handle enum traits in file bucketing

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -481,7 +481,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             }
 
             String path;
-            if (shape.isEnumShape() || shape.isIntEnumShape()) {
+            if (shape.isEnumShape() || shape.isIntEnumShape() || shape.hasTrait(EnumTrait.class)) {
                 path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "enums");
             } else if (shape.isStructureShape() && shape.hasTrait(ErrorTrait.class)) {
                 path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "errors");


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/7517

Enum and IntEnum shapes are being bucketed into a file called 'enums.ts' but this failed to catch legacy enum trait annotated shapes that do not have the new enum/intEnum shape types. 