### PR TITLE
fix(codegen): omit unnamed enums in runtime object test

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageApiValidationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageApiValidationGenerator.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.typescript.codegen.knowledge.ServiceClosure;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -134,7 +135,16 @@ public final class PackageApiValidationGenerator {
         }
 
         // enums
-        TreeSet<Shape> enumShapes = serviceClosure.getEnums();
+
+        // string shapes with enum trait do not generate anything if
+        // any enum value does not have a name.
+        TreeSet<Shape> enumShapes = serviceClosure.getEnums().stream()
+            .filter(shape -> shape
+                .getTrait(EnumTrait.class)
+                .map(EnumTrait::hasNames)
+                .orElse(true))
+            .collect(TreeSet::new, Set::add, Set::addAll);
+
         if (!enumShapes.isEmpty()) {
             writer.write("// enums");
         }


### PR DESCRIPTION
Omit unnamed enums from the runtime object index test (they do not generate runtime objects).