### PR TITLE
chore(codegen): use type symbol when writing structure member

### DIFF
--- a/private/smithy-rpcv2-cbor/src/models/errors.ts
+++ b/private/smithy-rpcv2-cbor/src/models/errors.ts
@@ -1,7 +1,7 @@
 // smithy-typescript generated code
 import type { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
 
-import { ComplexNestedErrorData, ValidationExceptionField } from "./models_0";
+import { type ComplexNestedErrorData, ValidationExceptionField } from "./models_0";
 import { RpcV2ProtocolServiceException as __BaseException } from "./RpcV2ProtocolServiceException";
 
 /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -109,8 +109,15 @@ final class StructuredMemberWriter {
             if (optionalSuffix.equals("?")) {
                 typeSuffix = " | undefined"; // support exactOptionalPropertyTypes.
             }
-            writer.write("${L}${L}${L}: ${T}${L};", memberPrefix, memberName, optionalSuffix,
-                    symbolProvider.toSymbol(member), typeSuffix);
+            writer.write(
+                "${L}${L}${L}: ${T}${L};",
+                memberPrefix, memberName, optionalSuffix,
+                symbolProvider.toSymbol(member)
+                    .toBuilder()
+                    .putProperty("typeOnly", true)
+                    .build(),
+                typeSuffix
+            );
 
             if (wroteDocs && position < members.size() - 1) {
                 writer.write("");


### PR DESCRIPTION
This follows up with https://github.com/smithy-lang/smithy-typescript/pull/1786 by changing the symbol used in writing structure interface members to typeOnly. 

Because this code is writing a type, the member symbol does not need to be imported as a runtime value, even if it has one (such as errors and enums). 