### PR TITLE
chore(codegen): adjust logging levels to reduce output

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -92,19 +92,19 @@ final class DirectedTypeScriptCodegen
 
         List<RuntimeClientPlugin> runtimePlugins = new ArrayList<>();
         directive.integrations().forEach(integration -> {
-            LOGGER.info(() -> "Adding TypeScriptIntegration: " + integration.getClass().getName());
+            LOGGER.fine(() -> "Adding TypeScriptIntegration: " + integration.getClass().getName());
             integration.getClientPlugins().forEach(runtimePlugin -> {
                 if (runtimePlugin.matchesSettings(directive.model(), directive.service(), directive.settings())) {
-                    LOGGER.info(() -> "Adding TypeScript runtime plugin: " + runtimePlugin);
+                    LOGGER.fine(() -> "Adding TypeScript runtime plugin: " + runtimePlugin);
                     runtimePlugins.add(runtimePlugin);
                 } else {
-                    LOGGER.info(() -> "Skipping TypeScript runtime plugin based on settings: " + runtimePlugin);
+                    LOGGER.fine(() -> "Skipping TypeScript runtime plugin based on settings: " + runtimePlugin);
                 }
             });
         });
 
         directive.integrations().forEach(integration -> {
-            LOGGER.info(() -> "Mutating plugins from TypeScriptIntegration: " + integration.name());
+            LOGGER.fine(() -> "Mutating plugins from TypeScriptIntegration: " + integration.name());
             integration.mutateClientPlugins(runtimePlugins);
         });
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptClientCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptClientCodegenPlugin.java
@@ -55,7 +55,7 @@ public class TypeScriptClientCodegenPlugin implements SmithyBuildPlugin {
                 .filter(integration -> {
                     boolean matchesSettings = integration.matchesSettings(settings);
                     if (!matchesSettings) {
-                        LOGGER.info(() -> "Skipping TypeScript integration based on settings: " + integration.name());
+                        LOGGER.fine(() -> "Skipping TypeScript integration based on settings: " + integration.name());
                     }
                     return matchesSettings;
                 })

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
@@ -65,7 +65,7 @@ public class TypeScriptServerCodegenPlugin implements SmithyBuildPlugin {
                 .filter(integration -> {
                     boolean matchesSettings = integration.matchesSettings(settings);
                     if (!matchesSettings) {
-                        LOGGER.info(() -> "Skipping TypeScript integration based on settings: " + integration.name());
+                        LOGGER.fine(() -> "Skipping TypeScript integration based on settings: " + integration.name());
                     }
                     return matchesSettings;
                 })

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -70,6 +70,8 @@ public final class TypeScriptSettings {
     private static final String GENERATE_INDEX_TESTS = "generateIndexTests";
     private static final String SERVICE_PROTOCOL_PRIORITY = "serviceProtocolPriority";
     private static final String DEFAULT_PROTOCOL_PRIORITY = "defaultProtocolPriority";
+    private static final String BIG_NUMBER_MODE = "bigNumberMode";
+    private static final String GENERATE_SCHEMAS = "generateSchemas";
 
     private String packageName;
     private String packageDescription = "";
@@ -190,7 +192,7 @@ public final class TypeScriptSettings {
             throw new CodegenException("Cannot infer a service to generate because the model contains "
                                        + "multiple service shapes: " + services);
         } else {
-            LOGGER.info("Inferring service to generate as " + services.get(0));
+            LOGGER.fine("Inferring service to generate as " + services.get(0));
             return services.get(0);
         }
     }
@@ -576,14 +578,14 @@ public final class TypeScriptSettings {
                     PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
                     SERVICE, PROTOCOL, PRIVATE, REQUIRED_MEMBER_MODE,
                     CREATE_DEFAULT_README, USE_LEGACY_AUTH, GENERATE_TYPEDOC,
-                    GENERATE_INDEX_TESTS
+                    GENERATE_INDEX_TESTS, BIG_NUMBER_MODE, GENERATE_SCHEMAS
                 )),
         SSDK((m, s) -> new ServerSymbolVisitor(m, new SymbolVisitor(m, s)),
                 Arrays.asList(
                     PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
                     SERVICE, PROTOCOL, PRIVATE, REQUIRED_MEMBER_MODE,
                     DISABLE_DEFAULT_VALIDATION, CREATE_DEFAULT_README, GENERATE_TYPEDOC,
-                    GENERATE_INDEX_TESTS
+                    GENERATE_INDEX_TESTS, BIG_NUMBER_MODE, GENERATE_SCHEMAS
                 ));
 
         private final BiFunction<Model, TypeScriptSettings, SymbolProvider> symbolProviderFactory;


### PR DESCRIPTION
Adjust logging levels to reduce log output and make additional fields known to the TypeScriptSettings class (also to avoid warnings). 