### PR TITLE
chore(codegen): generate config iterations with const

### DIFF
--- a/private/my-local-model-schema/src/XYZServiceClient.ts
+++ b/private/my-local-model-schema/src/XYZServiceClient.ts
@@ -245,15 +245,15 @@ export class XYZServiceClient extends __Client<
   readonly config: XYZServiceClientResolvedConfig;
 
   constructor(...[configuration]: __CheckOptionalClientConfig<XYZServiceClientConfig>) {
-    let _config_0 = __getRuntimeConfig(configuration || {});
+    const _config_0 = __getRuntimeConfig(configuration || {});
     super(_config_0 as any);
     this.initConfig = _config_0;
-    let _config_1 = resolveClientEndpointParameters(_config_0);
-    let _config_2 = resolveRetryConfig(_config_1);
-    let _config_3 = resolveEndpointConfig(_config_2);
-    let _config_4 = resolveEndpointRequiredConfig(_config_3);
-    let _config_5 = resolveEventStreamSerdeConfig(_config_4);
-    let _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_1 = resolveClientEndpointParameters(_config_0);
+    const _config_2 = resolveRetryConfig(_config_1);
+    const _config_3 = resolveEndpointConfig(_config_2);
+    const _config_4 = resolveEndpointRequiredConfig(_config_3);
+    const _config_5 = resolveEventStreamSerdeConfig(_config_4);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
     let _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     this.config = _config_7;
     this.middlewareStack.use(getSchemaSerdePlugin(this.config));

--- a/private/my-local-model-schema/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/my-local-model-schema/src/auth/httpAuthExtensionConfiguration.ts
@@ -27,7 +27,7 @@ export type HttpAuthRuntimeConfig = Partial<{
 export const getHttpAuthExtensionConfiguration = (
   runtimeConfig: HttpAuthRuntimeConfig
 ): HttpAuthExtensionConfiguration => {
-  let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
+  const _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {

--- a/private/my-local-model/src/XYZServiceClient.ts
+++ b/private/my-local-model/src/XYZServiceClient.ts
@@ -231,15 +231,15 @@ export class XYZServiceClient extends __Client<
   readonly config: XYZServiceClientResolvedConfig;
 
   constructor(...[configuration]: __CheckOptionalClientConfig<XYZServiceClientConfig>) {
-    let _config_0 = __getRuntimeConfig(configuration || {});
+    const _config_0 = __getRuntimeConfig(configuration || {});
     super(_config_0 as any);
     this.initConfig = _config_0;
-    let _config_1 = resolveClientEndpointParameters(_config_0);
-    let _config_2 = resolveRetryConfig(_config_1);
-    let _config_3 = resolveEndpointConfig(_config_2);
-    let _config_4 = resolveEndpointRequiredConfig(_config_3);
-    let _config_5 = resolveEventStreamSerdeConfig(_config_4);
-    let _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_1 = resolveClientEndpointParameters(_config_0);
+    const _config_2 = resolveRetryConfig(_config_1);
+    const _config_3 = resolveEndpointConfig(_config_2);
+    const _config_4 = resolveEndpointRequiredConfig(_config_3);
+    const _config_5 = resolveEventStreamSerdeConfig(_config_4);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
     let _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/private/my-local-model/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/my-local-model/src/auth/httpAuthExtensionConfiguration.ts
@@ -27,7 +27,7 @@ export type HttpAuthRuntimeConfig = Partial<{
 export const getHttpAuthExtensionConfiguration = (
   runtimeConfig: HttpAuthRuntimeConfig
 ): HttpAuthExtensionConfiguration => {
-  let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
+  const _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {

--- a/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
@@ -292,14 +292,14 @@ export class RpcV2ProtocolClient extends __Client<
   readonly config: RpcV2ProtocolClientResolvedConfig;
 
   constructor(...[configuration]: __CheckOptionalClientConfig<RpcV2ProtocolClientConfig>) {
-    let _config_0 = __getRuntimeConfig(configuration || {});
+    const _config_0 = __getRuntimeConfig(configuration || {});
     super(_config_0 as any);
     this.initConfig = _config_0;
-    let _config_1 = resolveClientEndpointParameters(_config_0);
-    let _config_2 = resolveRetryConfig(_config_1);
-    let _config_3 = resolveEndpointConfig(_config_2);
-    let _config_4 = resolveEndpointRequiredConfig(_config_3);
-    let _config_5 = resolveHttpAuthSchemeConfig(_config_4);
+    const _config_1 = resolveClientEndpointParameters(_config_0);
+    const _config_2 = resolveRetryConfig(_config_1);
+    const _config_3 = resolveEndpointConfig(_config_2);
+    const _config_4 = resolveEndpointRequiredConfig(_config_3);
+    const _config_5 = resolveHttpAuthSchemeConfig(_config_4);
     let _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
     this.config = _config_6;
     this.middlewareStack.use(getSchemaSerdePlugin(this.config));

--- a/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/auth/httpAuthExtensionConfiguration.ts
@@ -27,7 +27,7 @@ export type HttpAuthRuntimeConfig = Partial<{
 export const getHttpAuthExtensionConfiguration = (
   runtimeConfig: HttpAuthRuntimeConfig
 ): HttpAuthExtensionConfiguration => {
-  let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
+  const _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {

--- a/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
@@ -269,14 +269,14 @@ export class RpcV2ProtocolClient extends __Client<
   readonly config: RpcV2ProtocolClientResolvedConfig;
 
   constructor(...[configuration]: __CheckOptionalClientConfig<RpcV2ProtocolClientConfig>) {
-    let _config_0 = __getRuntimeConfig(configuration || {});
+    const _config_0 = __getRuntimeConfig(configuration || {});
     super(_config_0 as any);
     this.initConfig = _config_0;
-    let _config_1 = resolveClientEndpointParameters(_config_0);
-    let _config_2 = resolveRetryConfig(_config_1);
-    let _config_3 = resolveEndpointConfig(_config_2);
-    let _config_4 = resolveEndpointRequiredConfig(_config_3);
-    let _config_5 = resolveHttpAuthSchemeConfig(_config_4);
+    const _config_1 = resolveClientEndpointParameters(_config_0);
+    const _config_2 = resolveRetryConfig(_config_1);
+    const _config_3 = resolveEndpointConfig(_config_2);
+    const _config_4 = resolveEndpointRequiredConfig(_config_3);
+    const _config_5 = resolveHttpAuthSchemeConfig(_config_4);
     let _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
     this.config = _config_6;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/private/smithy-rpcv2-cbor/src/auth/httpAuthExtensionConfiguration.ts
+++ b/private/smithy-rpcv2-cbor/src/auth/httpAuthExtensionConfiguration.ts
@@ -27,7 +27,7 @@ export type HttpAuthRuntimeConfig = Partial<{
 export const getHttpAuthExtensionConfiguration = (
   runtimeConfig: HttpAuthRuntimeConfig
 ): HttpAuthExtensionConfiguration => {
-  let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
+  const _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
   let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -379,7 +379,7 @@ public final class ServiceBareBonesClientGenerator implements Runnable {
 
             int configVariable = 0;
             String initialConfigVar = generateConfigVariable(configVariable);
-            writer.write("let $L = __getRuntimeConfig(configuration || {});",
+            writer.write("const $L = __getRuntimeConfig(configuration || {});",
                 initialConfigVar);
             writer.write("super($L as any);", initialConfigVar);
             writer.write("this.initConfig = $L;", initialConfigVar);
@@ -387,7 +387,7 @@ public final class ServiceBareBonesClientGenerator implements Runnable {
             configVariable++;
             writer.addImport("resolveClientEndpointParameters", null,
                 EndpointsV2Generator.ENDPOINT_PARAMETERS_DEPENDENCY);
-            writer.write("let $L = $L($L);",
+            writer.write("const $L = $L($L);",
                 generateConfigVariable(configVariable),
                 "resolveClientEndpointParameters",
                 generateConfigVariable(configVariable - 1));
@@ -420,7 +420,7 @@ public final class ServiceBareBonesClientGenerator implements Runnable {
                     }
                     writer.pushState();
                     writer.putContext(symbolMap);
-                    writer.write("let $newConfig:L = $resolveFn:T($oldConfig:L" + additionalParamsString + ");");
+                    writer.write("const $newConfig:L = $resolveFn:T($oldConfig:L" + additionalParamsString + ");");
                     writer.popState();
                 }
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
@@ -287,7 +287,7 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                 ): HttpAuthExtensionConfiguration => {""", "};",
                 () -> {
                 w.addTypeImport("HttpAuthScheme", null, TypeScriptDependency.SMITHY_TYPES);
-                w.write("let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;");
+                w.write("const _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;");
                 w.addTypeImport(serviceName + "HttpAuthSchemeProvider", null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
                 w.write("let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;");
                 List<ConfigField> mainConfigFields = configFields.values().stream()


### PR DESCRIPTION
Generate variables that are not reassigned with `const` in auth scheme and client constructors.