### PR TITLE
feat(core/protocols): make protocol selection easier

### DIFF
--- a/.changeset/eighty-peas-think.md
+++ b/.changeset/eighty-peas-think.md
@@ -1,0 +1,7 @@
+---
+"@smithy/smithy-client": minor
+"@smithy/types": minor
+"@smithy/core": minor
+---
+
+make protocol selection easier

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,9 @@
     "extract:docs": "api-extractor run --local",
     "test:cbor:perf": "node ./scripts/cbor-perf.mjs",
     "test": "yarn g:vitest run",
-    "test:watch": "yarn g:vitest watch"
+    "test:watch": "yarn g:vitest watch",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts",
+    "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.mts"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/core/src/core.integ.spec.ts
+++ b/packages/core/src/core.integ.spec.ts
@@ -1,0 +1,40 @@
+import { SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
+import type { HttpProtocol } from "@smithy/core/protocols";
+import { RpcV2ProtocolClient } from "@smithy/smithy-rpcv2-cbor-schema";
+import { describe, expect, test as it } from "vitest";
+
+describe("@smithy/core", () => {
+  it("should normalize the config.protocol field", () => {
+    const withInstance = new RpcV2ProtocolClient({
+      endpoint: "https://localhost",
+      protocol: new SmithyRpcV2CborProtocol({
+        defaultNamespace: "smithy.protocoltests.rpcv2Cbor",
+      }),
+    });
+
+    expect(withInstance.config.protocol).toBeInstanceOf(SmithyRpcV2CborProtocol);
+    expect((withInstance.config.protocol as HttpProtocol).options.defaultNamespace).toEqual(
+      "smithy.protocoltests.rpcv2Cbor"
+    );
+
+    const withCtor = new RpcV2ProtocolClient({
+      endpoint: "https://localhost",
+      protocol: SmithyRpcV2CborProtocol,
+    });
+
+    expect(withCtor.config.protocol).toBeInstanceOf(SmithyRpcV2CborProtocol);
+    expect((withCtor.config.protocol as HttpProtocol).options.defaultNamespace).toEqual(
+      "smithy.protocoltests.rpcv2Cbor"
+    );
+
+    const withSettings = new RpcV2ProtocolClient({
+      endpoint: "https://localhost",
+      protocolSettings: {
+        defaultNamespace: "ns",
+      },
+    });
+
+    expect(withCtor.config.protocol).toBeInstanceOf(SmithyRpcV2CborProtocol);
+    expect((withSettings.config.protocol as HttpProtocol).options.defaultNamespace).toEqual("ns");
+  });
+});

--- a/packages/core/vitest.config.integ.mts
+++ b/packages/core/vitest.config.integ.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["**/*.{e2e,browser}.spec.ts"],
+    include: ["**/*.integ.spec.ts"],
+    environment: "node",
+    hideSkippedTests: true,
+  },
+});

--- a/packages/types/src/schema/schema-deprecated.ts
+++ b/packages/types/src/schema/schema-deprecated.ts
@@ -167,3 +167,11 @@ export interface ClientProtocol<Request, Response> extends ConfigurableSerdeCont
     response: Response
   ): Promise<Output>;
 }
+
+/**
+ * @public
+ * @deprecated use $ClientProtocolCtor.
+ */
+export interface ClientProtocolCtor<Request, Response> {
+  new (args: any): ClientProtocol<Request, Response>;
+}

--- a/packages/types/src/schema/schema.ts
+++ b/packages/types/src/schema/schema.ts
@@ -278,6 +278,13 @@ export interface $ClientProtocol<Request, Response> extends ConfigurableSerdeCon
 }
 
 /**
+ * @public
+ */
+export interface $ClientProtocolCtor<Request, Response> {
+  new (args: any): $ClientProtocol<Request, Response>;
+}
+
+/**
  * Allows a protocol, codec, or serde utility to accept the serdeContext
  * from a client configuration or request/response handlerExecutionContext.
  *

--- a/private/my-local-model-schema/src/XYZServiceClient.ts
+++ b/private/my-local-model-schema/src/XYZServiceClient.ts
@@ -36,14 +36,11 @@ import type {
   BodyLengthCalculator as __BodyLengthCalculator,
   CheckOptionalClientConfig as __CheckOptionalClientConfig,
   ChecksumConstructor as __ChecksumConstructor,
-  ClientProtocol,
   Decoder as __Decoder,
   Encoder as __Encoder,
   EventStreamSerdeProvider as __EventStreamSerdeProvider,
   HashConstructor as __HashConstructor,
   HttpHandlerOptions as __HttpHandlerOptions,
-  HttpRequest,
-  HttpResponse,
   Logger as __Logger,
   Provider as __Provider,
   StreamCollector as __StreamCollector,
@@ -174,16 +171,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * Optional extensions
    */
   extensions?: RuntimeExtension[];
-
-  /**
-   * The protocol controlling the message type (e.g. HTTP) and format (e.g. JSON)
-   * may be overridden. A default will always be set by the client.
-   * Available options depend on the service's supported protocols and will not be validated by
-   * the client.
-   * @alpha
-   *
-   */
-  protocol?: ClientProtocol<HttpRequest, HttpResponse>;
 
   /**
    * The function that provides necessary utilities for generating and parsing event stream

--- a/private/my-local-model-schema/src/runtimeConfig.shared.ts
+++ b/private/my-local-model-schema/src/runtimeConfig.shared.ts
@@ -32,7 +32,10 @@ export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
       },
     ],
     logger: config?.logger ?? new NoOpLogger(),
-    protocol: config?.protocol ?? new SmithyRpcV2CborProtocol({ defaultNamespace: "org.xyz.v1" }),
+    protocol: config?.protocol ?? SmithyRpcV2CborProtocol,
+    protocolSettings: config?.protocolSettings ?? {
+      defaultNamespace: "org.xyz.v1",
+    },
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,
     utf8Encoder: config?.utf8Encoder ?? toUtf8,

--- a/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/RpcV2ProtocolClient.ts
@@ -31,13 +31,10 @@ import type {
   BodyLengthCalculator as __BodyLengthCalculator,
   CheckOptionalClientConfig as __CheckOptionalClientConfig,
   ChecksumConstructor as __ChecksumConstructor,
-  ClientProtocol,
   Decoder as __Decoder,
   Encoder as __Encoder,
   HashConstructor as __HashConstructor,
   HttpHandlerOptions as __HttpHandlerOptions,
-  HttpRequest,
-  HttpResponse,
   Logger as __Logger,
   Provider as __Provider,
   StreamCollector as __StreamCollector,
@@ -225,16 +222,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * Optional extensions
    */
   extensions?: RuntimeExtension[];
-
-  /**
-   * The protocol controlling the message type (e.g. HTTP) and format (e.g. JSON)
-   * may be overridden. A default will always be set by the client.
-   * Available options depend on the service's supported protocols and will not be validated by
-   * the client.
-   * @alpha
-   *
-   */
-  protocol?: ClientProtocol<HttpRequest, HttpResponse>;
 
   /**
    * The {@link @smithy/smithy-client#DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.

--- a/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.shared.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.shared.ts
@@ -32,7 +32,10 @@ export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
       },
     ],
     logger: config?.logger ?? new NoOpLogger(),
-    protocol: config?.protocol ?? new SmithyRpcV2CborProtocol({ defaultNamespace: "smithy.protocoltests.rpcv2Cbor" }),
+    protocol: config?.protocol ?? SmithyRpcV2CborProtocol,
+    protocolSettings: config?.protocolSettings ?? {
+      defaultNamespace: "smithy.protocoltests.rpcv2Cbor",
+    },
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,
     utf8Encoder: config?.utf8Encoder ?? toUtf8,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddProtocolConfig.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddProtocolConfig.java
@@ -27,36 +27,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class AddProtocolConfig implements TypeScriptIntegration {
 
-    @Override
-    public void addConfigInterfaceFields(
-        TypeScriptSettings settings,
-        Model model,
-        SymbolProvider symbolProvider,
-        TypeScriptWriter writer
-    ) {
-        // the {{ protocol?: Protocol }} type field is provided
-        // by the smithy client config interface.
-        if (!SchemaGenerationAllowlist.allows(settings.getService(), settings)) {
-            return;
-        }
-
-        writer
-            .addTypeImport("ClientProtocol", null, TypeScriptDependency.SMITHY_TYPES)
-            .addTypeImport("HttpRequest", null, TypeScriptDependency.SMITHY_TYPES)
-            .addTypeImport("HttpResponse", null, TypeScriptDependency.SMITHY_TYPES)
-            .writeDocs("""
-            The protocol controlling the message type (e.g. HTTP) and format (e.g. JSON)
-            may be overridden. A default will always be set by the client.
-            Available options depend on the service's supported protocols and will not be validated by
-            the client.
-            @alpha
-            """)
-            .write("""
-            protocol?: ClientProtocol<HttpRequest, HttpResponse>;
-            """);
-    }
-
-    @Override
+  @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
         TypeScriptSettings settings,
         Model model,
@@ -77,7 +48,15 @@ public final class AddProtocolConfig implements TypeScriptIntegration {
                             writer.addImportSubmodule(
                                 "SmithyRpcV2CborProtocol", null,
                                 TypeScriptDependency.SMITHY_CORE, "/cbor");
-                            writer.write("new SmithyRpcV2CborProtocol({ defaultNamespace: $S })", namespace);
+                            writer.write("SmithyRpcV2CborProtocol");
+                        },
+                       "protocolSettings", writer -> {
+                             writer.write("""
+                                 {
+                                   defaultNamespace: $S,
+                                 }""",
+                                 namespace
+                            );
                         }
                     );
                 }


### PR DESCRIPTION
Currently, all required constructor parameters of the chosen protocol must be 
provided by the caller. Customers would generally have no idea what these are, and what values to provide.

### current
```js
import { SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
import { RpcV2ProtocolClient } from "@smithy/smithy-rpcv2-cbor-schema";

const withInstance = new RpcV2ProtocolClient({
  endpoint: "https://localhost",
  protocol: new SmithyRpcV2CborProtocol({
    defaultNamespace: "smithy.protocoltests.rpcv2Cbor",
  }),
});
```


### new in PR

This PR adds a config generated field called "protocolSettings", which contain service-specific information used to construct the protocol class.

This allows the customer to use a shortened protocol selection syntax:

```js
import { SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
import { RpcV2ProtocolClient } from "@smithy/smithy-rpcv2-cbor-schema";

const withCtor = new RpcV2ProtocolClient({
  endpoint: "https://localhost",
  protocol: SmithyRpcV2CborProtocol,
});
```