### PR TITLE
fix(smithy-client): make new field optional on resolved type

### DIFF
--- a/.changeset/chilled-eyes-perform.md
+++ b/.changeset/chilled-eyes-perform.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+set protocol to optional on resolved config type

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -83,7 +83,7 @@ export interface SmithyConfiguration<HandlerOptions> {
 export type SmithyResolvedConfiguration<HandlerOptions> = {
   requestHandler: RequestHandler<any, any, HandlerOptions>;
   cacheMiddleware?: boolean;
-  protocol: ClientProtocol<any, any> | $ClientProtocol<any, any>;
+  protocol?: ClientProtocol<any, any> | $ClientProtocol<any, any>;
   protocolSettings?: {
     defaultNamespace?: string;
     [setting: string]: unknown;


### PR DESCRIPTION
the resolved type of smithyClient must still allow protocol to be undefined, due to supporting older clients