### PR TITLE
Bump jreleaser to 1.21.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     checkstyle
     jacoco
     id("com.github.spotbugs") version "6.3.0"
-    id("org.jreleaser") version "1.20.0"
+    id("org.jreleaser") version "1.21.0"
     id("com.diffplug.spotless") version "8.1.0"
 }
 


### PR DESCRIPTION
*Issue #, if available:*
* Internal JS-6423
* Refs: https://github.com/jreleaser/jreleaser/releases/tag/v1.21.0

*Description of changes:*
Bumps jreleaser to 1.21.0

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
