### PR TITLE
fix(core/protocols): support for $unknown union members in schema-serde

### DIFF
--- a/.changeset/chatty-dogs-rule.md
+++ b/.changeset/chatty-dogs-rule.md
@@ -1,0 +1,6 @@
+---
+"@smithy/types": minor
+"@smithy/core": minor
+---
+
+add static union schema as a new type

--- a/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
+++ b/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
@@ -22,6 +22,7 @@ import type {
   StaticSchemaIdList,
   StaticSchemaIdMap,
   StaticSchemaIdStruct,
+  StaticSchemaIdUnion,
   StaticSimpleSchema,
   StaticStructureSchema,
   StreamingBlobSchema,
@@ -194,12 +195,24 @@ export class NormalizedSchema implements INormalizedSchema {
       : (sc as StaticSchema)[0] === (2 satisfies StaticSchemaIdMap);
   }
 
+  /**
+   * To simplify serialization logic, static union schemas are considered a specialization
+   * of structs in the TypeScript typings and JS runtime, as well as static error schemas
+   * which have a different identifier.
+   */
   public isStructSchema(): boolean {
     const sc = this.getSchema();
+    const id = (sc as StaticSchema)[0];
     return (
-      (sc as StaticSchema)[0] === (3 satisfies StaticSchemaIdStruct) ||
-      (sc as StaticSchema)[0] === (-3 satisfies StaticSchemaIdError)
+      id === (3 satisfies StaticSchemaIdStruct) ||
+      id === (-3 satisfies StaticSchemaIdError) ||
+      id === (4 satisfies StaticSchemaIdUnion)
     );
+  }
+
+  public isUnionSchema(): boolean {
+    const sc = this.getSchema();
+    return (sc as StaticSchema)[0] === (4 satisfies StaticSchemaIdUnion);
   }
 
   public isBlobSchema(): boolean {

--- a/packages/types/src/schema/static-schemas.ts
+++ b/packages/types/src/schema/static-schemas.ts
@@ -28,6 +28,11 @@ export type StaticSchemaIdStruct = 3;
 /**
  * @public
  */
+export type StaticSchemaIdUnion = 4;
+
+/**
+ * @public
+ */
 export type StaticSchemaIdError = -3;
 
 /**
@@ -43,6 +48,7 @@ export type StaticSchema =
   | StaticListSchema
   | StaticMapSchema
   | StaticStructureSchema
+  | StaticUnionSchema
   | StaticErrorSchema
   | StaticOperationSchema;
 
@@ -76,6 +82,18 @@ export type StaticMapSchema = [StaticSchemaIdMap, ShapeNamespace, ShapeName, Sch
  */
 export type StaticStructureSchema = [
   StaticSchemaIdStruct,
+  ShapeNamespace,
+  ShapeName,
+  SchemaTraits,
+  string[], // member name list
+  $SchemaRef[], // member schema list
+];
+
+/**
+ * @public
+ */
+export type StaticUnionSchema = [
+  StaticSchemaIdUnion,
   ShapeNamespace,
   ShapeName,
   SchemaTraits,


### PR DESCRIPTION
#1600

In Smithy, unions and structures are different types of shapes, but they behave nearly identically in the runtime.

This PR reintroduces handling for `$unknown` union members in schema-serde mode.