### PR TITLE
set default of generateSchemas to true

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -80,7 +80,7 @@ public final class TypeScriptSettings {
     private boolean generateTypeDoc = false;
     private ProtocolPriorityConfig protocolPriorityConfig = new ProtocolPriorityConfig(null, null);
     private String bigNumberMode = "native";
-    private boolean generateSchemas = false;
+    private boolean generateSchemas = true;
     private boolean generateIndexTests = false;
 
     @Deprecated
@@ -145,7 +145,7 @@ public final class TypeScriptSettings {
 
         // Internal undocumented configuration used to control rollout of schemas.
         // `true` will eventually be the only available option, and this should not be set by users.
-        settings.setGenerateSchemas(config.getBooleanMemberOrDefault("generateSchemas", false));
+        settings.setGenerateSchemas(config.getBooleanMemberOrDefault("generateSchemas", true));
 
         settings.setGenerateIndexTests(config.getBooleanMemberOrDefault("generateIndexTests", false));
 

--- a/smithy-typescript-protocol-test-codegen/smithy-build.json
+++ b/smithy-typescript-protocol-test-codegen/smithy-build.json
@@ -25,6 +25,7 @@
             "license": "Apache-2.0"
           },
           "private": true,
+          "generateSchemas": false,
           "generateIndexTests": true
         }
       }
@@ -47,8 +48,7 @@
               "name": "Smithy team",
               "url": "https://smithy.io/"
             },
-            "scripts": {
-            },
+            "scripts": {},
             "license": "Apache-2.0"
           },
           "private": true,
@@ -74,7 +74,8 @@
           "packageJson": {
             "private": true
           },
-          "bigNumberMode": "native"
+          "bigNumberMode": "native",
+          "generateSchemas": false
         }
       }
     },


### PR DESCRIPTION
set default of generateSchemas to `true`.

The option to set this value at all will be removed in a future version.