### PR TITLE
retag 0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Smithy Typescript Codegen Changelog
 
-## 0.41.0 (2025-12-31)
+## 0.41.0 (2026-01-02)
 
 ### Features
 
-- generate schema-based serialization/deserialization for clients ([#1600](https://github.com/smithy-lang/smithy-typescript/issues/1600))
+- Changed default serialization/deserialization for clients to schema-based ([#1600](https://github.com/smithy-lang/smithy-typescript/issues/1600))
+
+### Bug Fixes
+
+- Fixed const/let generation in waiters ([#1826](https://github.com/smithy-lang/smithy-typescript/pull/1826))
 
 ## 0.40.0 (2025-12-22)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 allprojects {
     group = "software.amazon.smithy.typescript"
     version = "0.41.0"
+    // no-op change line to include latest commit(s) in 0.41.0
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
Since 0.41.0 hasn't been released, I am retagging latest main as 0.41.0. 
