### PR TITLE
chore: use Node.js 20 minimum in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
           cache: "yarn"
 
       - name: Set up JDK ${{ matrix.java }}
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
           cache: "yarn"
       - name: Install dependencies
         run: yarn
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v5
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
           cache: "yarn"
       - name: Install dependencies
         run: |
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
           cache: "yarn"
       - name: Install dependencies
         run: yarn
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
           cache: "yarn"
       - name: Install
         run: yarn


### PR DESCRIPTION
removes Node.js 18 from CI