### PR TITLE
feat(codegen): encode required member count in schemas

### DIFF
--- a/.changeset/shy-houses-listen.md
+++ b/.changeset/shy-houses-listen.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": minor
+---
+
+encode required member count in structure schemas

--- a/packages/types/src/schema/static-schemas.ts
+++ b/packages/types/src/schema/static-schemas.ts
@@ -85,8 +85,9 @@ export type StaticStructureSchema = [
   ShapeNamespace,
   ShapeName,
   SchemaTraits,
-  string[], // member name list
-  $SchemaRef[], // member schema list
+  string[], // member name list.
+  $SchemaRef[], // member schema list.
+  number?, // required member count, front-loaded in the lists.
 ];
 
 /**
@@ -97,8 +98,8 @@ export type StaticUnionSchema = [
   ShapeNamespace,
   ShapeName,
   SchemaTraits,
-  string[], // member name list
-  $SchemaRef[], // member schema list
+  string[], // member name list.
+  $SchemaRef[], // member schema list.
 ];
 
 /**
@@ -109,8 +110,9 @@ export type StaticErrorSchema = [
   ShapeNamespace,
   ShapeName,
   SchemaTraits,
-  string[], // member name list
-  $SchemaRef[], // member schema list
+  string[], // member name list.
+  $SchemaRef[], // member schema list.
+  number?, // required member count, front-loaded in the lists.
 ];
 
 /**

--- a/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
@@ -148,13 +148,13 @@ var __Unit = "unit" as const;
 export var ValidationException$: StaticErrorSchema = [-3, n0, _VE,
   { [_e]: _c },
   [_m, _fL],
-  [0, () => ValidationExceptionFieldList]
+  [0, () => ValidationExceptionFieldList], 1
 ];
 TypeRegistry.for(n0).registerError(ValidationException$, ValidationException);
 export var ValidationExceptionField$: StaticStructureSchema = [3, n0, _VEF,
   0,
   [_p, _m],
-  [0, 0]
+  [0, 0], 2
 ];
 export var ClientOptionalDefaults$: StaticStructureSchema = [3, n1, _COD,
   0,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -447,6 +447,7 @@ final class DirectedTypeScriptCodegen
             .useShapeWriter(directive.shape(), writer -> {
                 StructureGenerator generator = new StructureGenerator(
                     directive.model(),
+                    directive.settings(),
                     directive.symbolProvider(),
                     writer,
                     directive.shape(),
@@ -466,6 +467,7 @@ final class DirectedTypeScriptCodegen
             .useShapeWriter(directive.shape(), writer -> {
                 StructureGenerator generator = new StructureGenerator(
                     directive.model(),
+                    directive.settings(),
                     directive.symbolProvider(),
                     writer,
                     directive.shape(),
@@ -485,6 +487,7 @@ final class DirectedTypeScriptCodegen
             .useShapeWriter(directive.shape(), writer -> {
                 UnionGenerator generator = new UnionGenerator(
                     directive.model(),
+                    directive.settings(),
                     directive.symbolProvider(),
                     writer,
                     directive.shape(),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -18,6 +18,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings.RequiredMemberMode;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
+import software.amazon.smithy.typescript.codegen.knowledge.ServiceClosure;
 import software.amazon.smithy.typescript.codegen.validation.SensitiveDataFinder;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -64,17 +65,25 @@ final class StructureGenerator implements Runnable {
     private final RequiredMemberMode requiredMemberMode;
     private final SensitiveDataFinder sensitiveDataFinder;
     private final boolean schemaMode;
+    private final ServiceClosure closure;
 
     /**
      * sets 'includeValidation' to 'false' and requiredMemberMode
      * to {@link RequiredMemberMode#NULLABLE}.
      */
-    StructureGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, StructureShape shape) {
-        this(model, symbolProvider, writer, shape, false, RequiredMemberMode.NULLABLE, false);
+    StructureGenerator(
+        Model model,
+        TypeScriptSettings settings,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer,
+        StructureShape shape
+    ) {
+        this(model, settings, symbolProvider, writer, shape, false, RequiredMemberMode.NULLABLE, false);
     }
 
     StructureGenerator(
         Model model,
+        TypeScriptSettings settings,
         SymbolProvider symbolProvider,
         TypeScriptWriter writer,
         StructureShape shape,
@@ -90,6 +99,7 @@ final class StructureGenerator implements Runnable {
         this.requiredMemberMode = requiredMemberMode;
         sensitiveDataFinder = new SensitiveDataFinder(model);
         this.schemaMode = schemaMode;
+        closure = ServiceClosure.of(model, settings.getService(model));
     }
 
     @Override
@@ -165,6 +175,7 @@ final class StructureGenerator implements Runnable {
 
         StructuredMemberWriter config = new StructuredMemberWriter(
             model,
+            closure,
             symbolProvider,
             shape.getAllMembers().values(),
             this.requiredMemberMode,
@@ -287,6 +298,7 @@ final class StructureGenerator implements Runnable {
         }
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
             model,
+            closure,
             symbolProvider,
             shape.getAllMembers().values(),
             this.requiredMemberMode,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/knowledge/ServiceClosure.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/knowledge/ServiceClosure.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.schema.SchemaReferenceIndex;
@@ -221,6 +222,20 @@ public final class ServiceClosure implements KnowledgeIndex {
             suffix = "$";
         }
         return symbolName + suffix;
+    }
+
+    /**
+     * This is the existing definition migrated from StructuredMemberWriter, which
+     * writes e.g. `member?: Type | undefined` vs. `member: Type | undefined`, the canonical
+     * client-side modeled optionality.
+     * This differs from the structure member optionality specification in
+     * <a href="https://smithy.io/2.0/spec/aggregate-types.html#structure-member-optionality">spec point 3.3.3</a>
+     */
+    public boolean isMemberRequiredInClient(MemberShape member) {
+        // Currently the client only generates a default for idempotency tokens.
+        // No default is generated for values with a default value trait.
+        boolean clientGeneratesValue = member.hasTrait(IdempotencyTokenTrait.class);
+        return member.isRequired() && !clientGeneratesValue;
     }
 
     /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -278,7 +278,7 @@ public class StructureGeneratorTest {
         );
 
         TypeScriptWriter writer = new TypeScriptWriter("./foo");
-        new StructureGenerator(model, new SymbolVisitor(model, settings), writer, struct).run();
+        new StructureGenerator(model, settings, new SymbolVisitor(model, settings), writer, struct).run();
         String output = writer.toString();
 
         assertThat(output, containsString("export interface Bar {"));
@@ -311,7 +311,7 @@ public class StructureGeneratorTest {
         );
 
         TypeScriptWriter writer = new TypeScriptWriter("./foo");
-        new StructureGenerator(model, new SymbolVisitor(model, settings), writer, struct).run();
+        new StructureGenerator(model, settings, new SymbolVisitor(model, settings), writer, struct).run();
         String output = writer.toString();
 
         assertThat(output, containsString("export interface Bar {"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
@@ -40,7 +40,7 @@ public class UnionGeneratorTest {
         );
         SymbolProvider symbolProvider = new SymbolVisitor(model, settings);
         TypeScriptWriter writer = new TypeScriptWriter("./Example");
-        new UnionGenerator(model, symbolProvider, writer, unionShape).run();
+        new UnionGenerator(model, settings, symbolProvider, writer, unionShape).run();
         String output = writer.toString();
 
         assertEquals(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/7610

*Description of changes:*

This is a preparatory commit where required member count is encoded into structure schemas. 

Required member count is very lightweight and important for validation, so I'm adding this information into the schemas. Although there are more specific constraint traits https://smithy.io/2.0/spec/constraint-traits.html, we don't validate them so I won't be adding them into the default schema at this time.

They could be an option in the future if there is strong demand for RTTC. 