### PR TITLE
fix(core/cbor): bigDecimal serialization in ShapeSerializer

### DIFF
--- a/.changeset/silent-news-beam.md
+++ b/.changeset/silent-news-beam.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix cbor bigDecimal serialization

--- a/packages/core/src/submodules/cbor/CborCodec.spec.ts
+++ b/packages/core/src/submodules/cbor/CborCodec.spec.ts
@@ -128,6 +128,25 @@ describe(CborShapeSerializer.name, () => {
         },
       });
     });
+
+    it("should pass through NumericValue types if the schema is BigDecimal", async () => {
+      const schema = [
+        3,
+        "ns",
+        "Currency",
+        0,
+        ["price"],
+        [19 satisfies BigDecimalSchema],
+      ] satisfies StaticStructureSchema;
+      const data = {
+        price: nv("0.99"),
+      };
+      serializer.write(NormalizedSchema.of(schema), data);
+      const serialized = serializer.flush();
+      expect(cbor.deserialize(serialized)).toEqual({
+        price: nv("0.99"),
+      });
+    });
   });
 
   describe("deserialization", () => {

--- a/packages/core/src/submodules/cbor/CborCodec.ts
+++ b/packages/core/src/submodules/cbor/CborCodec.ts
@@ -106,6 +106,8 @@ export class CborShapeSerializer extends SerdeContext implements ShapeSerializer
         for (const key of Object.keys(sourceObject)) {
           newObject[key] = this.serialize(ns.getValueSchema(), sourceObject[key]);
         }
+      } else if (ns.isBigDecimalSchema()) {
+        return sourceObject;
       }
       return newObject;
     }


### PR DESCRIPTION
*Issue #, if available:*
Similar to https://github.com/smithy-lang/smithy-typescript/pull/1830.

*Description of changes:*

In a regression, the CborShapeSerializer did not account for NumericValue objects (bigDecimal containers), and converted them to untyped empty objects. 

This PR allows them to pass through to the untyped CBOR serializer. 