### PR TITLE
fix(util-stream): chunked encoding for 0-length Node.js streams

### DIFF
--- a/.changeset/small-cows-dress.md
+++ b/.changeset/small-cows-dress.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-stream": patch
+---
+
+correct chunked encoding output for 0-length streams

--- a/packages/util-stream/src/checksum/ChecksumStream.ts
+++ b/packages/util-stream/src/checksum/ChecksumStream.ts
@@ -31,11 +31,10 @@ export interface ChecksumStreamInit<T extends Readable | ReadableStream> {
 }
 
 /**
- * @internal
- *
  * Wrapper for throwing checksum errors for streams without
  * buffering the stream.
  *
+ * @internal
  */
 export class ChecksumStream extends Duplex {
   private expectedChecksum: string;
@@ -70,7 +69,8 @@ export class ChecksumStream extends Duplex {
   }
 
   /**
-   * @internal do not call this directly.
+   * Do not call this directly.
+   * @internal
    */
   public _read(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -78,10 +78,10 @@ export class ChecksumStream extends Duplex {
   ): void {}
 
   /**
-   * @internal do not call this directly.
-   *
    * When the upstream source flows data to this stream,
    * calculate a step update of the checksum.
+   * Do not call this directly.
+   * @internal
    */
   public _write(chunk: Buffer, encoding: string, callback: (err?: Error) => void): void {
     try {
@@ -94,9 +94,9 @@ export class ChecksumStream extends Duplex {
   }
 
   /**
-   * @internal do not call this directly.
-   *
    * When the upstream source finishes, perform the checksum comparison.
+   * Do not call this directly.
+   * @internal
    */
   public async _final(callback: (err?: Error) => void): Promise<void> {
     try {

--- a/packages/util-stream/src/checksum/createChecksumStream.browser.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.browser.ts
@@ -5,10 +5,10 @@ import type { ChecksumStreamInit } from "./ChecksumStream.browser";
 import { ChecksumStream } from "./ChecksumStream.browser";
 
 /**
- * @internal
  * Alias prevents compiler from turning
  * ReadableStream into ReadableStream<any>, which is incompatible
  * with the NodeJS.ReadableStream global type.
+ * @internal
  */
 export type ReadableStreamType = ReadableStream;
 
@@ -24,10 +24,9 @@ interface TransformStreamDefaultController {
 }
 
 /**
- * @internal
- *
  * Creates a stream adapter for throwing checksum errors for streams without
  * buffering the stream.
+ * @internal
  */
 export const createChecksumStream = ({
   expectedChecksum,

--- a/packages/util-stream/src/checksum/createChecksumStream.ts
+++ b/packages/util-stream/src/checksum/createChecksumStream.ts
@@ -7,13 +7,18 @@ import type { ReadableStreamType } from "./createChecksumStream.browser";
 import { createChecksumStream as createChecksumStreamWeb } from "./createChecksumStream.browser";
 
 /**
- * @internal
- *
  * Creates a stream mirroring the input stream's interface, but
  * performs checksumming when reading to the end of the stream.
+ * @internal
  */
 export function createChecksumStream(init: ChecksumStreamInit<ReadableStreamType>): ReadableStreamType;
+/**
+ * @internal
+ */
 export function createChecksumStream(init: ChecksumStreamInit<Readable>): Readable;
+/**
+ * @internal
+ */
 export function createChecksumStream(
   init: ChecksumStreamInit<Readable | ReadableStreamType>
 ): Readable | ReadableStreamType {

--- a/packages/util-stream/src/createBufferedReadable.ts
+++ b/packages/util-stream/src/createBufferedReadable.ts
@@ -10,12 +10,18 @@ import { isReadableStream } from "./stream-type-check";
  * @internal
  * @param upstream - any Readable or ReadableStream.
  * @param size - byte or character length minimum. Buffering occurs when a chunk fails to meet this value.
- * @param onBuffer - for emitting warnings when buffering occurs.
+ * @param logger - for emitting warnings when buffering occurs.
  * @returns another stream of the same data and stream class, but buffers chunks until
  * the minimum size is met, except for the last chunk.
  */
 export function createBufferedReadable(upstream: Readable, size: number, logger?: Logger): Readable;
+/**
+ * @internal
+ */
 export function createBufferedReadable(upstream: ReadableStream, size: number, logger?: Logger): ReadableStream;
+/**
+ * @internal
+ */
 export function createBufferedReadable(
   upstream: Readable | ReadableStream,
   size: number,

--- a/packages/util-stream/src/getAwsChunkedEncodingStream.browser.spec.ts
+++ b/packages/util-stream/src/getAwsChunkedEncodingStream.browser.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test as it } from "vitest";
 
+import { getAwsChunkedEncodingStream as getAwsChunkedEncodingStreamRs } from "./getAwsChunkedEncodingStream";
 import { getAwsChunkedEncodingStream } from "./getAwsChunkedEncodingStream.browser";
 
 describe(getAwsChunkedEncodingStream.name, () => {
@@ -78,6 +79,20 @@ World\r
   it("computes checksum and adds it to the end event", async () => {
     const readableStream = getMockReadableStream();
     const awsChunkedBody = getAwsChunkedEncodingStream(readableStream, mockOptions);
+    const expectedBuffer = `5\r
+Hello\r
+5\r
+World\r
+0\r
+${mockChecksumLocationName}:${mockChecksum}\r
+\r
+`;
+    await validateStream(awsChunkedBody, expectedBuffer);
+  });
+
+  it("redirects from Readable to ReadableStream implementation", async () => {
+    const readableStream = getMockReadableStream();
+    const awsChunkedBody = getAwsChunkedEncodingStreamRs(readableStream, mockOptions);
     const expectedBuffer = `5\r
 Hello\r
 5\r

--- a/packages/util-stream/src/getAwsChunkedEncodingStream.browser.ts
+++ b/packages/util-stream/src/getAwsChunkedEncodingStream.browser.ts
@@ -17,7 +17,7 @@ export const getAwsChunkedEncodingStream: GetAwsChunkedEncodingStream<ReadableSt
     streamHasher !== undefined;
   const digest = checksumRequired ? streamHasher!(checksumAlgorithmFn!, readableStream) : undefined;
 
-  // ToDo: Validate the ReadableStream and getReader() is accessable before calling.
+  // ToDo: Validate the ReadableStream and getReader() is accessible before calling.
   // ReactNative doesn't support ReadableStream. They might not be available in older browsers, or some polyfills.
   const reader = readableStream.getReader();
   return new ReadableStream({

--- a/packages/util-stream/src/headStream.browser.ts
+++ b/packages/util-stream/src/headStream.browser.ts
@@ -1,9 +1,8 @@
 /**
+ * Caution: the input stream must be destroyed separately, this function does not do so.
  * @internal
  * @param stream
  * @param bytes - read head bytes from the stream and discard the rest of it.
- *
- * Caution: the input stream must be destroyed separately, this function does not do so.
  */
 export async function headStream(stream: ReadableStream, bytes: number): Promise<Uint8Array> {
   let byteLengthCounter = 0;

--- a/packages/util-stream/src/headStream.ts
+++ b/packages/util-stream/src/headStream.ts
@@ -5,11 +5,11 @@ import { headStream as headWebStream } from "./headStream.browser";
 import { isReadableStream } from "./stream-type-check";
 
 /**
+ * Caution: the input stream must be destroyed separately, this function does not do so.
+ *
  * @internal
  * @param stream - to be read.
  * @param bytes - read head bytes from the stream and discard the rest of it.
- *
- * Caution: the input stream must be destroyed separately, this function does not do so.
  */
 export const headStream = (stream: Readable | ReadableStream, bytes: number): Promise<Uint8Array> => {
   if (isReadableStream(stream)) {

--- a/packages/util-stream/src/index.ts
+++ b/packages/util-stream/src/index.ts
@@ -6,4 +6,8 @@ export * from "./getAwsChunkedEncodingStream";
 export * from "./headStream";
 export * from "./sdk-stream-mixin";
 export * from "./splitStream";
-export * from "./stream-type-check";
+
+/**
+ * @internal
+ */
+export { isReadableStream, isBlob } from "./stream-type-check";

--- a/packages/util-stream/src/splitStream.ts
+++ b/packages/util-stream/src/splitStream.ts
@@ -10,7 +10,13 @@ import { isBlob, isReadableStream } from "./stream-type-check";
  * @returns stream split into two identical streams.
  */
 export async function splitStream(stream: Readable): Promise<[Readable, Readable]>;
+/**
+ * @internal
+ */
 export async function splitStream(stream: ReadableStream): Promise<[ReadableStream, ReadableStream]>;
+/**
+ * @internal
+ */
 export async function splitStream(
   stream: Readable | ReadableStream
 ): Promise<[Readable | ReadableStream, Readable | ReadableStream]> {

--- a/packages/util-stream/src/stream-type-check.ts
+++ b/packages/util-stream/src/stream-type-check.ts
@@ -1,8 +1,9 @@
 /**
- * @internal
  * Alias prevents compiler from turning
  * ReadableStream into ReadableStream<any>, which is incompatible
  * with the NodeJS.ReadableStream global type.
+ *
+ * @internal
  */
 type ReadableStreamType = ReadableStream;
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/7636

*Description of changes:*

When an empty chunk is handled by the Readable data event handler, ignore it rather than encoding a zero chunk in the chunked encoding stream.