### PR TITLE
fix(core/cbor): handle __type in structural input/outputs

### DIFF
--- a/.changeset/mean-cows-live.md
+++ b/.changeset/mean-cows-live.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+custom handling for \_\_type in structures


### PR DESCRIPTION
This commit adds custom handling when encountering `__type` in a structural input or output. Under this condition, unrecognized members are serialized using the Document schema. 
