### PR TITLE
fix(core/protocols): validate httpLabel arguments

### DIFF
--- a/.changeset/giant-meals-punch.md
+++ b/.changeset/giant-meals-punch.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+client side httpLabel validation

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
@@ -284,4 +284,25 @@ describe(HttpBindingProtocol.name, () => {
 
     expect(streamProgress).toBe(100);
   });
+
+  it("should throw an error if an httpLabel is missing", async () => {
+    const protocol = new StringRestProtocol();
+    await expect(
+      protocol.serializeRequest(
+        op(
+          "ns",
+          "operation",
+          {
+            http: ["GET", "/path/{labelGoesHere}/operation?arg=1", 200],
+          },
+          [3, "ns", "Struct", 0, ["labelGoesHere"], [[0, { httpLabel: 1 }]]] satisfies StaticStructureSchema,
+          "unit"
+        ),
+        {},
+        {
+          endpoint: async () => parseUrl("https://localhost"),
+        } as any
+      )
+    ).rejects.toThrow("No value provided for input HTTP label: labelGoesHere.");
+  });
 });

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
@@ -79,6 +79,9 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
       const inputMemberValue = input[memberName];
 
       if (inputMemberValue == null && !memberNs.isIdempotencyToken()) {
+        if (memberTraits.httpLabel) {
+          throw new Error(`No value provided for input HTTP label: ${memberName}.`);
+        }
         continue;
       }
 


### PR DESCRIPTION
*Issue #, if available:*
V2073227955

*Description of changes:*

Adds client-side validation of httpLabel inputs. Unlike other inputs which should be validated server-side by default, a missing http label makes construction of the target URL impossible.
