### PR TITLE
feat(core/schema): improved structIterator performance

### DIFF
--- a/.changeset/wild-dragons-carry.md
+++ b/.changeset/wild-dragons-carry.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+improve schema struct iterator performance

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
@@ -20,7 +20,7 @@ import type {
   TimestampDefaultSchema,
   TimestampEpochSecondsSchema,
 } from "@smithy/types";
-import { parseUrl } from "@smithy/url-parser/src";
+import { parseUrl } from "@smithy/url-parser";
 import { Readable } from "node:stream";
 import { describe, expect, test as it } from "vitest";
 


### PR DESCRIPTION
*Issue #, if available:*
JS-6449

*Description of changes:*

improves performance of reading schema information. 
- faster implementation of `isIdempotencyToken()`
- caching for structure member iteration

significantly reduces the time spent in the iterator function itself (500ms -> ~100ms) and the overall serialization time (2000ms -> 1000ms).

### test script, small objects in JSON RPC x 150_000
```js
import { DynamoDB, GetItem$, PutItem$ } from "@aws-sdk/client-dynamodb";
import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
import { DynamoDBJsonCodec } from "@aws-sdk/dynamodb-codec";
import { HttpResponse } from "@smithy/protocol-http";
import { parseUrl } from "@smithy/url-parser";
import { Readable } from "node:stream";

const client = new DynamoDB();

const input = {
  TableName: "test",
  Item: {
    id: {
      S: "1",
    },
    data: {
      M: {
        a: {
          S: "a",
        },
        b: {
          B: new Uint8Array([0, 1, 2, 3]),
        },
      },
    },
  },
};

const output = {
  Item: {
    id: {
      S: "1",
    },
    data: {
      M: {
        a: {
          S: "a",
        },
        b: {
          B: new Uint8Array([0, 1, 2, 3]),
        },
      },
    },
  },
};

const iterations = 150000;

const protocol = new AwsJson1_0Protocol({
  defaultNamespace: "com.amazonaws.dynamodb",
  xmlNamespace: "http://dynamodb.amazonaws.com/doc/2012-08-10/",
  version: "2012-08-10",
  serviceTarget: "DynamoDB_20120810",
  // codec: new DynamoDBJsonCodec(),
});
const codec = protocol.getPayloadCodec();
const serializer = codec.createSerializer();
const context = {
  ...client.config,
  endpoint: async () => parseUrl("https://localhost"),
};

const httpResponse = () => {
  serializer.write(GetItem$[5], output);
  return new HttpResponse({
    headers: {
      statusCode: 200,
    },
    body: Readable.from(Buffer.from(serializer.flush())),
  });
};

function operation(op$) {
  const [, namespace, name, traits, input, output] = op$;
  return {
    namespace,
    name,
    traits,
    input,
    output,
  };
}

{
  const A = performance.now();
  for (let i = 0; i < iterations; ++i) {
    const request = await protocol.serializeRequest(operation(PutItem$), input, context);
  }
  const B = performance.now();

  console.log("serialization", iterations.toFixed(0), (B - A).toFixed(2));
}

{
  const A = performance.now();
  for (let i = 0; i < iterations; ++i) {
    const result = await protocol.deserializeResponse(operation(GetItem$), context, httpResponse());
  }
  const B = performance.now();

  console.log("deserialization", iterations.toFixed(0), (B - A).toFixed(2));
}

```