### PR TITLE
feat(util-waiter): add type information to waiter result

### DIFF
--- a/.changeset/spicy-geese-arrive.md
+++ b/.changeset/spicy-geese-arrive.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-waiter": minor
+---
+
+add type information to WaiterResult reason

--- a/packages/util-waiter/src/poller.spec.ts
+++ b/packages/util-waiter/src/poller.spec.ts
@@ -27,6 +27,9 @@ describe(runPolling.name, () => {
     reason: {
       mockedReason: "some-failure-value",
     },
+    final: {
+      mockedReason: "some-failure-value",
+    },
     observedResponses: {
       [JSON.stringify({
         mockedReason: "some-failure-value",
@@ -36,6 +39,9 @@ describe(runPolling.name, () => {
   const successState = {
     state: WaiterState.SUCCESS,
     reason: {
+      mockedReason: "some-success-value",
+    },
+    final: {
       mockedReason: "some-success-value",
     },
     observedResponses: {
@@ -150,5 +156,48 @@ describe(runPolling.name, () => {
     abortController.abort();
     await expect(runPolling(localConfig, input, mockAcceptorChecks)).resolves.toStrictEqual(abortedState);
     expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("should populate 'final' alongside 'reason' on non-retry results", async () => {
+    const reason = { code: "ResourceReady" };
+    mockAcceptorChecks = vi.fn().mockResolvedValueOnce({ state: WaiterState.SUCCESS, reason });
+    const result = await runPolling(config, input, mockAcceptorChecks);
+    expect(result.final).toStrictEqual(reason);
+    expect(result.reason).toStrictEqual(reason);
+  });
+
+  it("should populate 'final' after retries resolve to a terminal state", async () => {
+    const reason = { code: "InstanceRunning" };
+    mockAcceptorChecks = vi
+      .fn()
+      .mockResolvedValueOnce(retryState)
+      .mockResolvedValueOnce({ state: WaiterState.SUCCESS, reason });
+    const result = await runPolling(config, input, mockAcceptorChecks);
+    expect(result.final).toStrictEqual(reason);
+    expect(result.reason).toStrictEqual(reason);
+  });
+
+  it("should not populate 'final' on timeout", async () => {
+    let now = Date.now();
+    const delay = 2;
+    const nowMock = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(now)
+      .mockImplementation(() => {
+        const rtn = now;
+        now += delay * 1000;
+        return rtn;
+      });
+    const localConfig = {
+      ...config,
+      minDelay: delay,
+      maxDelay: delay,
+      maxWaitTime: 5,
+    };
+    mockAcceptorChecks = vi.fn().mockResolvedValue(retryState);
+    const result = await runPolling(localConfig, input, mockAcceptorChecks);
+    expect(result.state).toBe(WaiterState.TIMEOUT);
+    expect(result.final).toBeUndefined();
+    nowMock.mockReset();
   });
 });

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -4,9 +4,8 @@ import type { WaiterOptions, WaiterResult } from "./waiter";
 import { WaiterState } from "./waiter";
 
 /**
- * @internal
- *
  * Reference: https://smithy.io/2.0/additional-specs/waiters.html#waiter-retries
+ * @internal
  */
 const exponentialBackoffWithJitter = (minDelay: number, maxDelay: number, attemptCeiling: number, attempt: number) => {
   if (attempt > attemptCeiling) return maxDelay;
@@ -24,11 +23,11 @@ const randomInRange = (min: number, max: number) => min + Math.random() * (max -
  * @param input - client input
  * @param acceptorChecks - function that checks the acceptor states on each poll.
  */
-export const runPolling = async <Client, Input>(
+export const runPolling = async <Client, Input, Reason = any>(
   { minDelay, maxDelay, maxWaitTime, abortController, client, abortSignal }: WaiterOptions<Client>,
   input: Input,
-  acceptorChecks: (client: Client, input: Input) => Promise<WaiterResult>
-): Promise<WaiterResult> => {
+  acceptorChecks: (client: Client, input: Input) => Promise<WaiterResult<Reason>>
+): Promise<WaiterResult<Reason>> => {
   const observedResponses: Record<string, number> = {};
 
   const { state, reason } = await acceptorChecks(client, input);
@@ -39,7 +38,7 @@ export const runPolling = async <Client, Input>(
   }
 
   if (state !== WaiterState.RETRY) {
-    return { state, reason, observedResponses };
+    return { state, reason, final: reason, observedResponses };
   }
 
   let currentAttempt = 1;
@@ -70,7 +69,7 @@ export const runPolling = async <Client, Input>(
     }
 
     if (state !== WaiterState.RETRY) {
-      return { state, reason, observedResponses };
+      return { state, reason, final: reason, observedResponses };
     }
 
     currentAttempt += 1;
@@ -78,9 +77,10 @@ export const runPolling = async <Client, Input>(
 };
 
 /**
- * @internal
- * convert the result of an SDK operation, either an error or response object, to a
+ * Convert the result of an SDK operation, either an error or response object, to a
  * readable string.
+ *
+ * @internal
  */
 const createMessageFromResponse = (reason: any): string => {
   if (reason?.$responseBodyText) {

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -1,11 +1,8 @@
-import type { WaiterConfiguration as WaiterConfiguration__ } from "@smithy/types";
+import type { WaiterConfiguration } from "@smithy/types";
 
 import { getCircularReplacer } from "./circularReplacer";
 
-/**
- * @internal
- */
-export interface WaiterConfiguration<T> extends WaiterConfiguration__<T> {}
+export { WaiterConfiguration };
 
 /**
  * @internal
@@ -22,7 +19,7 @@ export type WaiterOptions<Client> = WaiterConfiguration<Client> &
   Required<Pick<WaiterConfiguration<Client>, "minDelay" | "maxDelay">>;
 
 /**
- * @internal
+ * @public
  */
 export enum WaiterState {
   ABORTED = "ABORTED",
@@ -33,15 +30,21 @@ export enum WaiterState {
 }
 
 /**
- * @internal
+ * @public
  */
-export type WaiterResult = {
+export type WaiterResult<R = any> = {
   state: WaiterState;
+
+  /**
+   * @deprecated because this was untyped as `any`, new code should use the field 'final',
+   * which is the same value, but typed.
+   */
+  reason?: any;
 
   /**
    * (optional) Indicates a reason for why a waiter has reached its state.
    */
-  reason?: any;
+  final?: R;
 
   /**
    * Responses observed by the waiter during its polling, where the value
@@ -51,12 +54,11 @@ export type WaiterResult = {
 };
 
 /**
- * @internal
- *
  * Handles and throws exceptions resulting from the waiterResult
+ * @internal
  * @param result - WaiterResult
  */
-export const checkExceptions = (result: WaiterResult): WaiterResult => {
+export const checkExceptions = <R>(result: WaiterResult<R>): WaiterResult<R> => {
   if (result.state === WaiterState.ABORTED) {
     const abortError = new Error(
       `${JSON.stringify(

--- a/private/my-local-model-schema/src/waiters/waitForNumbersAligned.ts
+++ b/private/my-local-model-schema/src/waiters/waitForNumbersAligned.ts
@@ -7,21 +7,26 @@ import {
   WaiterState,
 } from "@smithy/util-waiter";
 
-import { type GetNumbersCommandInput, GetNumbersCommand } from "../commands/GetNumbersCommand";
+import {
+  type GetNumbersCommandInput,
+  type GetNumbersCommandOutput,
+  GetNumbersCommand,
+} from "../commands/GetNumbersCommand";
+import type { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 import type { XYZServiceClient } from "../XYZServiceClient";
 
-const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInput): Promise<WaiterResult> => {
+const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInput): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
   let reason;
   try {
-    let result: any = await client.send(new GetNumbersCommand(input));
+    let result: GetNumbersCommandOutput & any = await client.send(new GetNumbersCommand(input));
     reason = result;
     return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
     reason = exception;
-    if (exception.name && exception.name == "MysteryThrottlingError") {
+    if (exception.name === "MysteryThrottlingError") {
       return { state: WaiterState.RETRY, reason };
     }
-    if (exception.name && exception.name == "HaltError") {
+    if (exception.name === "HaltError") {
       return { state: WaiterState.FAILURE, reason };
     }
   }
@@ -34,7 +39,7 @@ const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInpu
 export const waitForNumbersAligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult> => {
+): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
 };
@@ -46,7 +51,7 @@ export const waitForNumbersAligned = async (
 export const waitUntilNumbersAligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult> => {
+): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
   return checkExceptions(result);

--- a/private/my-local-model/package.json
+++ b/private/my-local-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xyz",
   "description": "xyz client",
-  "version": "3.23.16",
+  "version": "3.23.17",
   "scripts": {
     "build": "concurrently 'npm:build:cjs' 'npm:build:es' 'npm:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/private/my-local-model/src/waiters/waitForNumbersAligned.ts
+++ b/private/my-local-model/src/waiters/waitForNumbersAligned.ts
@@ -7,21 +7,26 @@ import {
   WaiterState,
 } from "@smithy/util-waiter";
 
-import { type GetNumbersCommandInput, GetNumbersCommand } from "../commands/GetNumbersCommand";
+import {
+  type GetNumbersCommandInput,
+  type GetNumbersCommandOutput,
+  GetNumbersCommand,
+} from "../commands/GetNumbersCommand";
+import type { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 import type { XYZServiceClient } from "../XYZServiceClient";
 
-const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInput): Promise<WaiterResult> => {
+const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInput): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
   let reason;
   try {
-    let result: any = await client.send(new GetNumbersCommand(input));
+    let result: GetNumbersCommandOutput & any = await client.send(new GetNumbersCommand(input));
     reason = result;
     return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
     reason = exception;
-    if (exception.name && exception.name == "MysteryThrottlingError") {
+    if (exception.name === "MysteryThrottlingError") {
       return { state: WaiterState.RETRY, reason };
     }
-    if (exception.name && exception.name == "HaltError") {
+    if (exception.name === "HaltError") {
       return { state: WaiterState.FAILURE, reason };
     }
   }
@@ -34,7 +39,7 @@ const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInpu
 export const waitForNumbersAligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult> => {
+): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
 };
@@ -46,7 +51,7 @@ export const waitForNumbersAligned = async (
 export const waitUntilNumbersAligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult> => {
+): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
   return checkExceptions(result);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -609,7 +609,9 @@ final class DirectedTypeScriptCodegen
                                 service,
                                 operation,
                                 waiterWriter,
-                                symbolProvider
+                                symbolProvider,
+                                settings,
+                                model
                             ).run()
                         );
                     });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.typescript.codegen;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.TreeSet;
@@ -37,6 +38,8 @@ class WaiterGenerator implements Runnable {
     private final Symbol serviceSymbol;
     private final Symbol operationSymbol;
     private final Symbol inputSymbol;
+    private final Symbol outputSymbol;
+    private final String waiterResultType;
 
     WaiterGenerator(
         String waiterName,
@@ -44,7 +47,9 @@ class WaiterGenerator implements Runnable {
         ServiceShape service,
         OperationShape operation,
         TypeScriptWriter writer,
-        SymbolProvider symbolProvider
+        SymbolProvider symbolProvider,
+        TypeScriptSettings settings,
+        Model model
     ) {
         this.waiterName = waiterName;
         this.waiter = waiter;
@@ -56,6 +61,16 @@ class WaiterGenerator implements Runnable {
             .putProperty("typeOnly", true)
             .build();
         this.inputSymbol = operationSymbol.expectProperty("inputType", Symbol.class);
+        this.outputSymbol = operationSymbol.expectProperty("outputType", Symbol.class);
+
+        String serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
+        String syntheticBaseExceptionName = CodegenUtils.getSyntheticBaseExceptionName(serviceName, model);
+        writer.addRelativeTypeImport(
+            syntheticBaseExceptionName,
+            null,
+            Path.of(".", "src", "models", syntheticBaseExceptionName)
+        );
+        waiterResultType = outputSymbol.getName() + " | " + syntheticBaseExceptionName;
     }
 
     @Override
@@ -92,11 +107,12 @@ class WaiterGenerator implements Runnable {
             export const waitFor$L = async (
               params: WaiterConfiguration<$T>,
               input: $T
-            ): Promise<WaiterResult> => {""",
+            ): Promise<WaiterResult<$L>> => {""",
             "};",
             waiterName,
             serviceSymbol,
             inputSymbol,
+            waiterResultType,
             () -> {
                 writer.write(
                     "const serviceDefaults = { minDelay: $L, maxDelay: $L };",
@@ -121,11 +137,12 @@ class WaiterGenerator implements Runnable {
             export const waitUntil$L = async (
               params: WaiterConfiguration<$T>,
               input: $T
-            ): Promise<WaiterResult> => {""",
+            ): Promise<WaiterResult<$L>> => {""",
             "};",
             waiterName,
             serviceSymbol,
             inputSymbol,
+            waiterResultType,
             () -> {
                 writer.write(
                     "const serviceDefaults = { minDelay: $L, maxDelay: $L };",
@@ -142,16 +159,21 @@ class WaiterGenerator implements Runnable {
 
     private void generateAcceptors() {
         writer.openBlock(
-            "const checkState = async (client: $T, input: $T): Promise<WaiterResult> => {",
+            "const checkState = async (client: $T, input: $T): Promise<WaiterResult<$L>> => {",
             "};",
             serviceSymbol,
             inputSymbol,
+            waiterResultType,
             () -> {
                 writer.write("let reason;");
 
                 writer.write("try {").indent();
                 {
-                    writer.write("let result: any = await client.send(new $T(input));", operationSymbol);
+                    writer.write(
+                        "let result: $T & any = await client.send(new $T(input));",
+                        outputSymbol,
+                        operationSymbol
+                    );
                     writer.write("reason = result;");
                     writeAcceptors("result", false);
                 }
@@ -208,7 +230,7 @@ class WaiterGenerator implements Runnable {
     }
 
     private void generateErrorMatcher(String accessor, Matcher.ErrorTypeMember member, AcceptorState state) {
-        writer.openBlock("if ($L.name && $L.name == $S) {", "}", accessor, accessor, member.getValue(), () -> {
+        writer.openBlock("if ($L.name === $S) {", "}", accessor, member.getValue(), () -> {
             writer.write("return $L;", makeWaiterResult(state));
         });
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/smithy-lang/smithy-typescript/issues/1793

*Description of changes:*

Adds a type parameter to WaiterResult to allow generated clients to describe the waiter result reason of their individual waiter functions.


### old
```ts
export type WaiterResult = {
  state: WaiterState;

  reason?: any;

  observedResponses?: Record<string, number>;
};
```

### new
```ts
export type WaiterResult<R = any> = {
  state: WaiterState;

  /** @deprecated `final` contains the same value, and is typed. */
  reason?: any;

  final?: R;

  observedResponses?: Record<string, number>;
};
```

For e.g. Amazon S3, `R` is `HeadBucketCommandOutput | S3ServiceException` for waiters like waitUntilBucketExists