### PR TITLE
feat(smithy-client): add pagination/waiters to aggregate clients

### DIFF
--- a/.changeset/nervous-taxis-prove.md
+++ b/.changeset/nervous-taxis-prove.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": minor
+---
+
+add paginators/waiters to aggregate clients

--- a/packages/core/src/core.integ.spec.ts
+++ b/packages/core/src/core.integ.spec.ts
@@ -1,7 +1,13 @@
-import { SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
+import { cbor, SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
 import type { HttpProtocol } from "@smithy/core/protocols";
+import { HttpResponse } from "@smithy/protocol-http";
 import { RpcV2ProtocolClient } from "@smithy/smithy-rpcv2-cbor-schema";
+import { requireRequestsFrom } from "@smithy/util-test/src";
 import { describe, expect, test as it } from "vitest";
+import type { GetNumbersCommandOutput } from "xyz-schema";
+import { XYZService } from "xyz-schema";
+
+import { NumericValue } from "./submodules/serde";
 
 describe("@smithy/core", () => {
   it("should normalize the config.protocol field", () => {
@@ -38,3 +44,113 @@ describe("@smithy/core", () => {
     expect((withSettings.config.protocol as HttpProtocol).options.defaultNamespace).toEqual("ns");
   });
 });
+
+describe("aggregated clients", () => {
+  it("should contain paginator and waiter methods", async () => {
+    const xyz = new XYZService({ endpoint: `https://localhost`, apiKey: async () => ({ apiKey: "test-key" }) });
+
+    expect(xyz.paginateGetNumbers).toBeInstanceOf(Function);
+    expect(xyz.waitUntilNumbersAligned).toBeInstanceOf(Function);
+
+    const testHandler = requireRequestsFrom(xyz).toMatch({
+      hostname: /^localhost$/,
+    });
+    for (const i of [0, 1, 2, 3, 4, 5, 6]) {
+      testHandler.respondWith(
+        new HttpResponse({
+          headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+          },
+          statusCode: 200,
+          body: cbor.serialize({
+            bigInteger: BigInt("123"),
+            bigDecimal: new NumericValue("123.456", "bigDecimal"),
+            numbers: [1, 2, 3],
+            nextToken: "nextToken" + i,
+          } as GetNumbersCommandOutput),
+        })
+      );
+    }
+    testHandler.respondWith(
+      new HttpResponse({
+        headers: {
+          "smithy-protocol": "rpc-v2-cbor",
+        },
+        statusCode: 200,
+        body: cbor.serialize({} as GetNumbersCommandOutput),
+      }),
+      new HttpResponse({
+        headers: {
+          "smithy-protocol": "rpc-v2-cbor",
+        },
+        statusCode: 400,
+        body: cbor.serialize({
+          __type: "firstError",
+        }),
+      }),
+      new HttpResponse({
+        headers: {
+          "smithy-protocol": "rpc-v2-cbor",
+        },
+        statusCode: 400,
+        body: cbor.serialize({
+          __type: "secondError",
+        }),
+      }),
+      new HttpResponse({
+        headers: {
+          "smithy-protocol": "rpc-v2-cbor",
+        },
+        statusCode: 200,
+        body: cbor.serialize({
+          __type: "finalAwaited",
+        }),
+      })
+    );
+
+    // all args optional
+    for await (const page of xyz.paginateGetNumbers()) {
+      if (page.nextToken === "nextToken3") {
+        break;
+      }
+    }
+
+    for await (const page of xyz.paginateGetNumbers(
+      {
+        startToken: "token",
+        maxResults: 10,
+        bigDecimal: new NumericValue("0.0", "bigDecimal"),
+        bigInteger: BigInt(100),
+      },
+      {
+        stopOnSameToken: true,
+        withCommand(command: any) {
+          return command;
+        },
+      }
+    )) {
+      expect(page.$metadata).toBeDefined();
+      expect(page.bigInteger).toBeDefined();
+      expect(page.bigDecimal).toBeDefined();
+      expect(page.numbers?.[0]).toBeDefined();
+      expect(page.nextToken).toBeDefined();
+      if (page.nextToken === "nextToken6") {
+        break;
+      }
+    }
+
+    await xyz.waitUntilNumbersAligned(
+      {
+        bigInteger: BigInt(1),
+      },
+      120
+    );
+
+    const result = await xyz.waitUntilNumbersAligned({}, { maxWaitTime: 8, minDelay: 0.001, maxDelay: 0.01 });
+    expect(result.reason).toMatchObject({
+      __type: "finalAwaited",
+    });
+
+    expect.assertions(29);
+  });
+}, 30_000);

--- a/packages/smithy-client/src/create-aggregated-client.ts
+++ b/packages/smithy-client/src/create-aggregated-client.ts
@@ -1,19 +1,44 @@
+import type { PaginationConfiguration, WaiterConfiguration } from "@smithy/types";
+
 import type { Client } from "./client";
+
+/**
+ * @internal
+ */
+type AggregatedClientPaginationConfiguration = Omit<PaginationConfiguration, "client">;
+
+/**
+ * @internal
+ */
+type AggregatedClientWaiterConfiguration<C> = Omit<WaiterConfiguration<C>, "client">;
 
 /**
  * @internal
  *
  * @param commands - command lookup container.
- * @param client - client instance on which to add aggregated methods.
+ * @param Client - client instance on which to add aggregated methods.
+ * @param options
+ * @param options.paginators - paginator functions.
+ * @param options.waiters - waiter functions.
+ *
  * @returns an aggregated client with dynamically created methods.
  */
 export const createAggregatedClient = (
   commands: Record<string, any>,
-  Client: { new (...args: any): Client<any, any, any, any> }
+  Client: { new (...args: any): Client<any, any, any, any> },
+  options?: {
+    paginators?: Record<string, any>;
+    waiters?: Record<string, any>;
+  }
 ): void => {
-  for (const command of Object.keys(commands)) {
-    const CommandCtor = commands[command];
-    const methodImpl = async function (this: InstanceType<typeof Client>, args: any, optionsOrCb: any, cb: any) {
+  type CommandInput = any;
+  for (const [command, CommandCtor] of Object.entries(commands)) {
+    const methodImpl = async function (
+      this: InstanceType<typeof Client>,
+      args: CommandInput,
+      optionsOrCb: any,
+      cb: any
+    ) {
       const command: any = new CommandCtor(args);
       if (typeof optionsOrCb === "function") {
         this.send(command, optionsOrCb);
@@ -26,5 +51,50 @@ export const createAggregatedClient = (
     };
     const methodName = (command[0].toLowerCase() + command.slice(1)).replace(/Command$/, "");
     Client.prototype[methodName] = methodImpl;
+  }
+  const { paginators = {}, waiters = {} } = options ?? {};
+  for (const [paginatorName, paginatorFn] of Object.entries(paginators)) {
+    if (Client.prototype[paginatorName] === void 0) {
+      Client.prototype[paginatorName] = function (
+        this: InstanceType<typeof Client>,
+        commandInput: CommandInput = {},
+        paginationConfiguration: AggregatedClientPaginationConfiguration,
+        ...rest: any[]
+      ) {
+        return paginatorFn(
+          {
+            ...paginationConfiguration,
+            client: this,
+          },
+          commandInput,
+          ...rest
+        );
+      };
+    }
+  }
+  for (const [waiterName, waiterFn] of Object.entries(waiters)) {
+    if (Client.prototype[waiterName] === void 0) {
+      Client.prototype[waiterName] = async function (
+        this: InstanceType<typeof Client>,
+        commandInput: CommandInput = {},
+        waiterConfiguration: AggregatedClientWaiterConfiguration<typeof Client> | number,
+        ...rest: any[]
+      ) {
+        let config = waiterConfiguration as AggregatedClientWaiterConfiguration<typeof Client>;
+        if (typeof waiterConfiguration === "number") {
+          config = {
+            maxWaitTime: waiterConfiguration,
+          };
+        }
+        return waiterFn(
+          {
+            ...config,
+            client: this,
+          },
+          commandInput,
+          ...rest
+        );
+      };
+    }
   }
 };

--- a/private/my-local-model-schema/package.json
+++ b/private/my-local-model-schema/package.json
@@ -49,6 +49,7 @@
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-retry": "workspace:^",
     "@smithy/util-utf8": "workspace:^",
+    "@smithy/util-waiter": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/my-local-model-schema/src/XYZService.ts
+++ b/private/my-local-model-schema/src/XYZService.ts
@@ -1,6 +1,12 @@
 // smithy-typescript generated code
 import { createAggregatedClient } from "@smithy/smithy-client";
-import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
+import type {
+  HttpHandlerOptions as __HttpHandlerOptions,
+  PaginationConfiguration,
+  Paginator,
+  WaiterConfiguration,
+} from "@smithy/types";
+import type { WaiterResult } from "@smithy/util-waiter";
 
 import {
   type GetNumbersCommandInput,
@@ -12,11 +18,19 @@ import {
   type TradeEventStreamCommandOutput,
   TradeEventStreamCommand,
 } from "./commands/TradeEventStreamCommand";
+import { paginateGetNumbers } from "./pagination/GetNumbersPaginator";
+import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
   GetNumbersCommand,
   TradeEventStreamCommand,
+};
+const paginators = {
+  paginateGetNumbers,
+};
+const waiters = {
+  waitUntilNumbersAligned,
 };
 
 export interface XYZService {
@@ -55,6 +69,27 @@ export interface XYZService {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: TradeEventStreamCommandOutput) => void
   ): void;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param paginationConfig - optional pagination config.
+   * @returns AsyncIterable of {@link GetNumbersCommandOutput}.
+   */
+  paginateGetNumbers(
+    args?: GetNumbersCommandInput,
+    paginationConfig?: Omit<PaginationConfiguration, "client">
+  ): Paginator<GetNumbersCommandOutput>;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param waiterConfig - `maxWaitTime` in seconds or waiter config object.
+   */
+  waitUntilNumbersAligned(
+    args: GetNumbersCommandInput,
+    waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
+  ): Promise<WaiterResult>;
 }
 
 /**
@@ -62,4 +97,4 @@ export interface XYZService {
  * @public
  */
 export class XYZService extends XYZServiceClient implements XYZService {}
-createAggregatedClient(commands, XYZService);
+createAggregatedClient(commands, XYZService, { paginators, waiters });

--- a/private/my-local-model-schema/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model-schema/src/commands/GetNumbersCommand.ts
@@ -42,12 +42,18 @@ export interface GetNumbersCommandOutput extends GetNumbersResponse, __MetadataB
  *   bigInteger: Number("bigint"),
  *   fieldWithoutMessage: "STRING_VALUE",
  *   fieldWithMessage: "STRING_VALUE",
+ *   startToken: "STRING_VALUE",
+ *   maxResults: Number("int"),
  * };
  * const command = new GetNumbersCommand(input);
  * const response = await client.send(command);
  * // { // GetNumbersResponse
  * //   bigDecimal: Number("bigdecimal"),
  * //   bigInteger: Number("bigint"),
+ * //   numbers: [ // IntegerList
+ * //     Number("int"),
+ * //   ],
+ * //   nextToken: "STRING_VALUE",
  * // };
  *
  * ```

--- a/private/my-local-model-schema/src/index.ts
+++ b/private/my-local-model-schema/src/index.ts
@@ -12,6 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./schemas/schemas_0";
+export * from "./pagination";
+export * from "./waiters";
 
 export * from "./models/errors";
 export * from "./models/models_0";

--- a/private/my-local-model-schema/src/models/models_0.ts
+++ b/private/my-local-model-schema/src/models/models_0.ts
@@ -30,6 +30,9 @@ export interface GetNumbersRequest {
    * @public
    */
   fieldWithMessage?: string | undefined;
+
+  startToken?: string | undefined;
+  maxResults?: number | undefined;
 }
 
 /**
@@ -38,6 +41,8 @@ export interface GetNumbersRequest {
 export interface GetNumbersResponse {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;
+  numbers?: number[] | undefined;
+  nextToken?: string | undefined;
 }
 
 /**

--- a/private/my-local-model-schema/src/pagination/GetNumbersPaginator.ts
+++ b/private/my-local-model-schema/src/pagination/GetNumbersPaginator.ts
@@ -1,0 +1,20 @@
+// smithy-typescript generated code
+import { createPaginator } from "@smithy/core";
+import type { Paginator } from "@smithy/types";
+
+import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
+import { XYZServiceClient } from "../XYZServiceClient";
+import { XYZServicePaginationConfiguration } from "./Interfaces";
+
+/**
+ * @public
+ */
+export const paginateGetNumbers: (
+  config: XYZServicePaginationConfiguration,
+  input: GetNumbersCommandInput,
+  ...rest: any[]
+) => Paginator<GetNumbersCommandOutput> = createPaginator<
+  XYZServicePaginationConfiguration,
+  GetNumbersCommandInput,
+  GetNumbersCommandOutput
+>(XYZServiceClient, GetNumbersCommand, "startToken", "nextToken", "maxResults");

--- a/private/my-local-model-schema/src/pagination/Interfaces.ts
+++ b/private/my-local-model-schema/src/pagination/Interfaces.ts
@@ -1,0 +1,11 @@
+// smithy-typescript generated code
+import type { PaginationConfiguration } from "@smithy/types";
+
+import { XYZServiceClient } from "../XYZServiceClient";
+
+/**
+ * @public
+ */
+export interface XYZServicePaginationConfiguration extends PaginationConfiguration {
+  client: XYZServiceClient;
+}

--- a/private/my-local-model-schema/src/pagination/index.ts
+++ b/private/my-local-model-schema/src/pagination/index.ts
@@ -1,0 +1,3 @@
+// smithy-typescript generated code
+export * from "./Interfaces";
+export * from "./GetNumbersPaginator";

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -24,14 +24,24 @@ const _fWMi = "fieldWithMessage";
 const _g = "gamma";
 const _hE = "httpError";
 const _i = "id";
+const _mR = "maxResults";
+const _n = "numbers";
+const _nT = "nextToken";
 const _s = "smithy.ts.sdk.synthetic.org.xyz.v1";
+const _sT = "startToken";
 const _st = "streaming";
 const _t = "timestamp";
 const n0 = "org.xyz.v1";
 
 // smithy-typescript generated code
 import { TypeRegistry } from "@smithy/core/schema";
-import type { StaticErrorSchema, StaticOperationSchema, StaticStructureSchema, StaticUnionSchema } from "@smithy/types";
+import type {
+  StaticErrorSchema,
+  StaticListSchema,
+  StaticOperationSchema,
+  StaticStructureSchema,
+  StaticUnionSchema,
+} from "@smithy/types";
 
 import {
   CodedThrottlingError,
@@ -57,13 +67,13 @@ export var CodedThrottlingError$: StaticErrorSchema = [-3, n0, _CTE,
 TypeRegistry.for(n0).registerError(CodedThrottlingError$, CodedThrottlingError);
 export var GetNumbersRequest$: StaticStructureSchema = [3, n0, _GNR,
   0,
-  [_bD, _bI, _fWM, _fWMi],
-  [19, 17, 0, 0]
+  [_bD, _bI, _fWM, _fWMi, _sT, _mR],
+  [19, 17, 0, 0, 0, 1]
 ];
 export var GetNumbersResponse$: StaticStructureSchema = [3, n0, _GNRe,
   0,
-  [_bD, _bI],
-  [19, 17]
+  [_bD, _bI, _n, _nT],
+  [19, 17, 64 | 1, 0]
 ];
 export var HaltError$: StaticErrorSchema = [-3, n0, _HE,
   { [_e]: _c },
@@ -108,6 +118,7 @@ TypeRegistry.for(n0).registerError(XYZServiceServiceException$, XYZServiceServic
 var __Unit = "unit" as const;
 export var XYZServiceSyntheticServiceException$: StaticErrorSchema = [-3, _s, "XYZServiceSyntheticServiceException", 0, [], []];
 TypeRegistry.for(_s).registerError(XYZServiceSyntheticServiceException$, XYZServiceSyntheticServiceException);
+var IntegerList = 64 | 1;
 export var TradeEvents$: StaticUnionSchema = [4, n0, _TE,
   { [_st]: 1 },
   [_a, _b, _g],

--- a/private/my-local-model-schema/src/waiters/index.ts
+++ b/private/my-local-model-schema/src/waiters/index.ts
@@ -1,0 +1,2 @@
+// smithy-typescript generated code
+export * from "./waitForNumbersAligned";

--- a/private/my-local-model-schema/src/waiters/waitForNumbersAligned.ts
+++ b/private/my-local-model-schema/src/waiters/waitForNumbersAligned.ts
@@ -1,0 +1,47 @@
+// smithy-typescript generated code
+import { checkExceptions, createWaiter, WaiterConfiguration, WaiterResult, WaiterState } from "@smithy/util-waiter";
+
+import { type GetNumbersCommandInput, GetNumbersCommand } from "../commands/GetNumbersCommand";
+import { XYZServiceClient } from "../XYZServiceClient";
+
+const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInput): Promise<WaiterResult> => {
+  let reason;
+  try {
+    let result: any = await client.send(new GetNumbersCommand(input));
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
+  } catch (exception) {
+    reason = exception;
+    if (exception.name && exception.name == "MysteryThrottlingError") {
+      return { state: WaiterState.RETRY, reason };
+    }
+    if (exception.name && exception.name == "HaltError") {
+      return { state: WaiterState.FAILURE, reason };
+    }
+  }
+  return { state: WaiterState.RETRY, reason };
+};
+/**
+ * wait until the numbers align
+ *  @deprecated Use waitUntilNumbersAligned instead. waitForNumbersAligned does not throw error in non-success cases.
+ */
+export const waitForNumbersAligned = async (
+  params: WaiterConfiguration<XYZServiceClient>,
+  input: GetNumbersCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 2, maxDelay: 120 };
+  return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * wait until the numbers align
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetNumbersCommand for polling.
+ */
+export const waitUntilNumbersAligned = async (
+  params: WaiterConfiguration<XYZServiceClient>,
+  input: GetNumbersCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 2, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
+};

--- a/private/my-local-model-schema/test/index-objects.spec.mjs
+++ b/private/my-local-model-schema/test/index-objects.spec.mjs
@@ -12,6 +12,7 @@ import {
   MainServiceLinkedError$,
   MysteryThrottlingError,
   MysteryThrottlingError$,
+  paginateGetNumbers,
   RetryableError,
   RetryableError$,
   TradeEvents$,
@@ -19,6 +20,8 @@ import {
   TradeEventStreamCommand,
   TradeEventStreamRequest$,
   TradeEventStreamResponse$,
+  waitForNumbersAligned,
+  waitUntilNumbersAligned,
   XYZService,
   XYZServiceClient,
   XYZServiceServiceException,
@@ -55,4 +58,9 @@ assert(typeof RetryableError$ === "object");
 assert(XYZServiceServiceException.prototype instanceof XYZServiceSyntheticServiceException);
 assert(typeof XYZServiceServiceException$ === "object");
 assert(XYZServiceSyntheticServiceException.prototype instanceof Error);
+// waiters
+assert(typeof waitForNumbersAligned === "function");
+assert(typeof waitUntilNumbersAligned === "function");
+// paginators
+assert(typeof paginateGetNumbers === "function");
 console.log(`XYZService index test passed.`);

--- a/private/my-local-model-schema/test/index-types.ts
+++ b/private/my-local-model-schema/test/index-types.ts
@@ -21,4 +21,7 @@ export type {
   RetryableError,
   XYZServiceServiceException,
   XYZServiceSyntheticServiceException,
+  waitForNumbersAligned,
+  waitUntilNumbersAligned,
+  paginateGetNumbers,
 } from "../dist-types/index.d";

--- a/private/my-local-model/package.json
+++ b/private/my-local-model/package.json
@@ -48,6 +48,7 @@
     "@smithy/util-middleware": "workspace:^",
     "@smithy/util-retry": "workspace:^",
     "@smithy/util-utf8": "workspace:^",
+    "@smithy/util-waiter": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/my-local-model/src/XYZService.ts
+++ b/private/my-local-model/src/XYZService.ts
@@ -1,6 +1,12 @@
 // smithy-typescript generated code
 import { createAggregatedClient } from "@smithy/smithy-client";
-import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
+import type {
+  HttpHandlerOptions as __HttpHandlerOptions,
+  PaginationConfiguration,
+  Paginator,
+  WaiterConfiguration,
+} from "@smithy/types";
+import type { WaiterResult } from "@smithy/util-waiter";
 
 import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
 import {
@@ -8,11 +14,19 @@ import {
   TradeEventStreamCommandInput,
   TradeEventStreamCommandOutput,
 } from "./commands/TradeEventStreamCommand";
+import { paginateGetNumbers } from "./pagination/GetNumbersPaginator";
+import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
   GetNumbersCommand,
   TradeEventStreamCommand,
+};
+const paginators = {
+  paginateGetNumbers,
+};
+const waiters = {
+  waitUntilNumbersAligned,
 };
 
 export interface XYZService {
@@ -51,6 +65,27 @@ export interface XYZService {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: TradeEventStreamCommandOutput) => void
   ): void;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param paginationConfig - optional pagination config.
+   * @returns AsyncIterable of {@link GetNumbersCommandOutput}.
+   */
+  paginateGetNumbers(
+    args?: GetNumbersCommandInput,
+    paginationConfig?: Omit<PaginationConfiguration, "client">
+  ): Paginator<GetNumbersCommandOutput>;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param waiterConfig - `maxWaitTime` in seconds or waiter config object.
+   */
+  waitUntilNumbersAligned(
+    args: GetNumbersCommandInput,
+    waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
+  ): Promise<WaiterResult>;
 }
 
 /**
@@ -58,4 +93,4 @@ export interface XYZService {
  * @public
  */
 export class XYZService extends XYZServiceClient implements XYZService {}
-createAggregatedClient(commands, XYZService);
+createAggregatedClient(commands, XYZService, { paginators, waiters });

--- a/private/my-local-model/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model/src/commands/GetNumbersCommand.ts
@@ -43,12 +43,18 @@ export interface GetNumbersCommandOutput extends GetNumbersResponse, __MetadataB
  *   bigInteger: Number("bigint"),
  *   fieldWithoutMessage: "STRING_VALUE",
  *   fieldWithMessage: "STRING_VALUE",
+ *   startToken: "STRING_VALUE",
+ *   maxResults: Number("int"),
  * };
  * const command = new GetNumbersCommand(input);
  * const response = await client.send(command);
  * // { // GetNumbersResponse
  * //   bigDecimal: Number("bigdecimal"),
  * //   bigInteger: Number("bigint"),
+ * //   numbers: [ // IntegerList
+ * //     Number("int"),
+ * //   ],
+ * //   nextToken: "STRING_VALUE",
  * // };
  *
  * ```

--- a/private/my-local-model/src/index.ts
+++ b/private/my-local-model/src/index.ts
@@ -11,6 +11,8 @@ export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
+export * from "./pagination";
+export * from "./waiters";
 
 export * from "./models/errors";
 export * from "./models/models_0";

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -30,6 +30,9 @@ export interface GetNumbersRequest {
    * @public
    */
   fieldWithMessage?: string | undefined;
+
+  startToken?: string | undefined;
+  maxResults?: number | undefined;
 }
 
 /**
@@ -38,6 +41,8 @@ export interface GetNumbersRequest {
 export interface GetNumbersResponse {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;
+  numbers?: number[] | undefined;
+  nextToken?: string | undefined;
 }
 
 /**

--- a/private/my-local-model/src/pagination/GetNumbersPaginator.ts
+++ b/private/my-local-model/src/pagination/GetNumbersPaginator.ts
@@ -1,0 +1,20 @@
+// smithy-typescript generated code
+import { createPaginator } from "@smithy/core";
+import type { Paginator } from "@smithy/types";
+
+import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
+import { XYZServiceClient } from "../XYZServiceClient";
+import { XYZServicePaginationConfiguration } from "./Interfaces";
+
+/**
+ * @public
+ */
+export const paginateGetNumbers: (
+  config: XYZServicePaginationConfiguration,
+  input: GetNumbersCommandInput,
+  ...rest: any[]
+) => Paginator<GetNumbersCommandOutput> = createPaginator<
+  XYZServicePaginationConfiguration,
+  GetNumbersCommandInput,
+  GetNumbersCommandOutput
+>(XYZServiceClient, GetNumbersCommand, "startToken", "nextToken", "maxResults");

--- a/private/my-local-model/src/pagination/Interfaces.ts
+++ b/private/my-local-model/src/pagination/Interfaces.ts
@@ -1,0 +1,11 @@
+// smithy-typescript generated code
+import type { PaginationConfiguration } from "@smithy/types";
+
+import { XYZServiceClient } from "../XYZServiceClient";
+
+/**
+ * @public
+ */
+export interface XYZServicePaginationConfiguration extends PaginationConfiguration {
+  client: XYZServiceClient;
+}

--- a/private/my-local-model/src/pagination/index.ts
+++ b/private/my-local-model/src/pagination/index.ts
@@ -1,0 +1,3 @@
+// smithy-typescript generated code
+export * from "./Interfaces";
+export * from "./GetNumbersPaginator";

--- a/private/my-local-model/src/protocols/Rpcv2cbor.ts
+++ b/private/my-local-model/src/protocols/Rpcv2cbor.ts
@@ -367,6 +367,8 @@ const se_Alpha_event = (
         'bigInteger': [],
         'fieldWithMessage': [],
         'fieldWithoutMessage': [],
+        'maxResults': [],
+        'startToken': [],
       });
     }
 
@@ -397,10 +399,14 @@ const se_Alpha_event = (
       return take(output, {
         'bigDecimal': [],
         'bigInteger': [],
+        'nextToken': __expectString,
+        'numbers': _json,
       }) as any;
     }
 
     // de_HaltError omitted.
+
+    // de_IntegerList omitted.
 
     // de_MainServiceLinkedError omitted.
 

--- a/private/my-local-model/src/waiters/index.ts
+++ b/private/my-local-model/src/waiters/index.ts
@@ -1,0 +1,2 @@
+// smithy-typescript generated code
+export * from "./waitForNumbersAligned";

--- a/private/my-local-model/src/waiters/waitForNumbersAligned.ts
+++ b/private/my-local-model/src/waiters/waitForNumbersAligned.ts
@@ -1,0 +1,47 @@
+// smithy-typescript generated code
+import { checkExceptions, createWaiter, WaiterConfiguration, WaiterResult, WaiterState } from "@smithy/util-waiter";
+
+import { GetNumbersCommand, GetNumbersCommandInput } from "../commands/GetNumbersCommand";
+import { XYZServiceClient } from "../XYZServiceClient";
+
+const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInput): Promise<WaiterResult> => {
+  let reason;
+  try {
+    let result: any = await client.send(new GetNumbersCommand(input));
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
+  } catch (exception) {
+    reason = exception;
+    if (exception.name && exception.name == "MysteryThrottlingError") {
+      return { state: WaiterState.RETRY, reason };
+    }
+    if (exception.name && exception.name == "HaltError") {
+      return { state: WaiterState.FAILURE, reason };
+    }
+  }
+  return { state: WaiterState.RETRY, reason };
+};
+/**
+ * wait until the numbers align
+ *  @deprecated Use waitUntilNumbersAligned instead. waitForNumbersAligned does not throw error in non-success cases.
+ */
+export const waitForNumbersAligned = async (
+  params: WaiterConfiguration<XYZServiceClient>,
+  input: GetNumbersCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 2, maxDelay: 120 };
+  return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * wait until the numbers align
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetNumbersCommand for polling.
+ */
+export const waitUntilNumbersAligned = async (
+  params: WaiterConfiguration<XYZServiceClient>,
+  input: GetNumbersCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 2, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
+};

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -127,9 +127,10 @@ final class CommandGenerator implements Runnable {
         String configType = ServiceBareBonesClientGenerator.getResolvedConfigTypeName(serviceSymbol);
 
         // Add required imports.
-        writer.addRelativeTypeImport(configType, null, Paths.get(".", serviceSymbol.getNamespace()));
-        writer.addRelativeTypeImport("ServiceInputTypes", null, Paths.get(".", serviceSymbol.getNamespace()));
-        writer.addRelativeTypeImport("ServiceOutputTypes", null, Paths.get(".", serviceSymbol.getNamespace()));
+        Path servicePath = Paths.get(".", serviceSymbol.getNamespace());
+        writer.addRelativeTypeImport(configType, null, servicePath);
+        writer.addRelativeTypeImport("ServiceInputTypes", null, servicePath);
+        writer.addRelativeTypeImport("ServiceOutputTypes", null, servicePath);
         writer.addImport("Command", "$Command", TypeScriptDependency.AWS_SMITHY_CLIENT);
 
         String name = symbol.getName();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -310,7 +310,7 @@ final class DirectedTypeScriptCodegen
         Set<OperationShape> containedOperations = directive.operations();
         for (OperationShape operation : containedOperations) {
             if (operation.hasTrait(PaginatedTrait.ID)) {
-                String outputFilename = PaginationGenerator.getOutputFilelocation(operation);
+                String outputFilename = PaginationGenerator.getOutputFileLocation(operation);
                 delegator.useFileWriter(
                     outputFilename,
                     paginationWriter -> new PaginationGenerator(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -106,7 +106,7 @@ final class PaginationGenerator implements Runnable {
         writePager();
     }
 
-    static String getOutputFilelocation(OperationShape operation) {
+    static String getOutputFileLocation(OperationShape operation) {
         return Paths.get(
             CodegenUtils.SOURCE_FOLDER,
             PAGINATION_FOLDER,
@@ -145,7 +145,7 @@ final class PaginationGenerator implements Runnable {
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
         for (OperationShape operation : containedOperations) {
             if (operation.hasTrait(PaginatedTrait.ID)) {
-                String outputFilepath = PaginationGenerator.getOutputFilelocation(operation);
+                String outputFilepath = PaginationGenerator.getOutputFileLocation(operation);
                 writer.write("export * from \"./$L\";", getModulePath(outputFilepath));
             }
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.typescript.codegen;
 
+import java.nio.file.Paths;
 import java.util.Set;
 import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -13,8 +14,12 @@ import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.PaginatedTrait;
+import software.amazon.smithy.typescript.codegen.knowledge.ServiceClosure;
 import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
+import software.amazon.smithy.waiters.WaitableTrait;
+import software.amazon.smithy.waiters.Waiter;
 
 /**
  * Generates aggregated client for service.
@@ -35,6 +40,7 @@ final class ServiceAggregatedClientGenerator implements Runnable {
     private final String aggregateClientName;
     private final Symbol serviceSymbol;
     private final ApplicationProtocol applicationProtocol;
+    private final ServiceClosure closure;
 
     ServiceAggregatedClientGenerator(
         TypeScriptSettings settings,
@@ -52,22 +58,76 @@ final class ServiceAggregatedClientGenerator implements Runnable {
         this.aggregateClientName = aggregateClientName;
         this.applicationProtocol = applicationProtocol;
         serviceSymbol = symbolProvider.toSymbol(service).toBuilder().putProperty("typeOnly", false).build();
+        closure = ServiceClosure.of(model, settings.getService(model));
     }
 
     @Override
     public void run() {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         final Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
-        writer.openBlock("const commands = {", "};", () -> {
-            for (OperationShape operation : containedOperations) {
-                Symbol operationSymbol = symbolProvider
-                    .toSymbol(operation)
-                    .toBuilder()
-                    .putProperty("typeOnly", false)
-                    .build();
-                writer.write("$T,", operationSymbol);
+
+        boolean hasPaginators = !closure.getPaginatedOperationShapes().isEmpty();
+        boolean hasWaiters = !closure.getWaitableOperationShapes().isEmpty();
+
+        writer.openBlock("const commands = {");
+        for (OperationShape operation : containedOperations) {
+            Symbol operationSymbol = symbolProvider
+                .toSymbol(operation)
+                .toBuilder()
+                .putProperty("typeOnly", false)
+                .build();
+            writer.write("$T,", operationSymbol);
+            if (operation.hasTrait(PaginatedTrait.ID)) {
+                hasPaginators = true;
             }
-        });
+            if (operation.hasTrait(WaitableTrait.ID)) {
+                hasWaiters = true;
+            }
+        }
+        writer.closeBlock("};");
+
+        if (hasPaginators) {
+            writer.openBlock("const paginators = {");
+            for (OperationShape operation : closure.getPaginatedOperationShapes()) {
+                String paginatorFnName = "paginate" + StringUtils.capitalize(operation.getId().getName());
+                writer.addRelativeImport(
+                    paginatorFnName,
+                    null,
+                    Paths.get(
+                        ".",
+                        CodegenUtils.SOURCE_FOLDER,
+                        PaginationGenerator.getOutputFileLocation(operation)
+                            .replaceFirst("(.*?)pagination(.*?)\\.ts$", "pagination$2")
+                    )
+                );
+                writer.write("$L,", paginatorFnName);
+            }
+            writer.closeBlock("};");
+        }
+
+        if (hasWaiters) {
+            writer.openBlock("const waiters = {");
+            for (OperationShape operation : closure.getWaitableOperationShapes()) {
+                WaitableTrait waitableTrait = operation.expectTrait(WaitableTrait.class);
+                waitableTrait
+                    .getWaiters()
+                    .forEach((String waiterName, Waiter waiter) -> {
+                        String waiterFnName = "waitUntil" + StringUtils.capitalize(waiterName);
+                        writer.addRelativeImport(
+                            waiterFnName,
+                            null,
+                            Paths.get(
+                                ".",
+                                CodegenUtils.SOURCE_FOLDER,
+                                WaiterGenerator.getOutputFileLocation(waiterName)
+                                    .replaceFirst("(.*?)waiters(.*?)\\.ts$", "waiters$2")
+                            )
+                        );
+                        writer.write("$L,", waiterFnName);
+                    });
+            }
+            writer.closeBlock("};");
+        }
 
         writer.write("");
 
@@ -111,6 +171,88 @@ final class ServiceAggregatedClientGenerator implements Runnable {
                 );
                 writer.write("");
             }
+
+            for (OperationShape operation : closure.getPaginatedOperationShapes()) {
+                if (operation.hasTrait(PaginatedTrait.ID)) {
+                    String paginatorFnName = "paginate" + StringUtils.capitalize(operation.getId().getName());
+
+                    Symbol operationSymbol = symbolProvider.toSymbol(operation);
+                    Symbol input = operationSymbol.expectProperty("inputType", Symbol.class);
+                    Symbol output = operationSymbol.expectProperty("outputType", Symbol.class);
+
+                    writer.addTypeImport("Paginator", null, TypeScriptDependency.SMITHY_TYPES);
+                    writer.addTypeImport("PaginationConfiguration", null, TypeScriptDependency.SMITHY_TYPES);
+
+                    boolean inputOptional = model
+                        .getShape(operation.getInputShape())
+                        .map(shape -> shape.getAllMembers().values().stream().noneMatch(MemberShape::isRequired))
+                        .orElse(true);
+
+                    String inputOptionality = inputOptional ? "?" : "";
+
+                    writer.writeDocs(
+                        """
+                        @see {@link %s}
+                        @param args - command input.
+                        @param paginationConfig - optional pagination config.
+                        @returns AsyncIterable of {@link %s}.""".formatted(operationSymbol.getName(), output.getName())
+                    );
+                    writer.write(
+                        """
+                        $1L(
+                          args$5L: $2T,
+                          paginationConfig?: Omit<$3L, "client">
+                        ): Paginator<$4T>;
+                        """,
+                        paginatorFnName,
+                        input,
+                        "PaginationConfiguration",
+                        output,
+                        inputOptionality
+                    );
+                }
+            }
+
+            for (OperationShape operation : closure.getWaitableOperationShapes()) {
+                if (operation.hasTrait(WaitableTrait.ID)) {
+                    WaitableTrait waitableTrait = operation.expectTrait(WaitableTrait.class);
+
+                    Symbol operationSymbol = symbolProvider.toSymbol(operation);
+                    Symbol input = operationSymbol.expectProperty("inputType", Symbol.class);
+
+                    // TODO: use this to change WaiterResult to WaiterResult<OutputType>.
+                    Symbol output = operationSymbol.expectProperty("outputType", Symbol.class);
+
+                    waitableTrait
+                        .getWaiters()
+                        .forEach((String waiterName, Waiter waiter) -> {
+                            String waiterFnName = "waitUntil" + StringUtils.capitalize(waiterName);
+
+                            writer.addTypeImport("WaiterConfiguration", null, TypeScriptDependency.SMITHY_TYPES);
+                            writer.addTypeImport("WaiterResult", null, TypeScriptDependency.AWS_SDK_UTIL_WAITERS);
+
+                            writer.writeDocs(
+                                """
+                                @see {@link %s}
+                                @param args - command input.
+                                @param waiterConfig - `maxWaitTime` in seconds or waiter config object."""
+                                    .formatted(operationSymbol.getName())
+                            );
+                            writer.write(
+                                """
+                                $1L(
+                                  args: $2T,
+                                  waiterConfig: number | Omit<$3L, "client">
+                                ): Promise<WaiterResult>;
+                                """,
+                                waiterFnName,
+                                input,
+                                "WaiterConfiguration<" + aggregateClientName + ">"
+                            );
+                        });
+                }
+            }
+
             writer.unwrite("\n");
         });
 
@@ -126,6 +268,15 @@ final class ServiceAggregatedClientGenerator implements Runnable {
         );
 
         writer.addImport("createAggregatedClient", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
-        writer.write("createAggregatedClient(commands, $L);", aggregateClientName);
+
+        if (hasPaginators && hasWaiters) {
+            writer.write("createAggregatedClient(commands, $L, { paginators, waiters });", aggregateClientName);
+        } else if (hasPaginators) {
+            writer.write("createAggregatedClient(commands, $L, { paginators });", aggregateClientName);
+        } else if (hasWaiters) {
+            writer.write("createAggregatedClient(commands, $L, { waiters });", aggregateClientName);
+        } else {
+            writer.write("createAggregatedClient(commands, $L);", aggregateClientName);
+        }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3677,7 +3677,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@smithy/util-waiter@workspace:packages/util-waiter":
+"@smithy/util-waiter@workspace:^, @smithy/util-waiter@workspace:packages/util-waiter":
   version: 0.0.0-use.local
   resolution: "@smithy/util-waiter@workspace:packages/util-waiter"
   dependencies:
@@ -12234,6 +12234,7 @@ __metadata:
     "@smithy/util-middleware": "workspace:^"
     "@smithy/util-retry": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
+    "@smithy/util-waiter": "workspace:^"
     "@tsconfig/node20": "npm:20.1.8"
     "@types/node": "npm:^20.14.8"
     concurrently: "npm:7.0.0"
@@ -12280,6 +12281,7 @@ __metadata:
     "@smithy/util-middleware": "workspace:^"
     "@smithy/util-retry": "workspace:^"
     "@smithy/util-utf8": "workspace:^"
+    "@smithy/util-waiter": "workspace:^"
     "@tsconfig/node20": "npm:20.1.8"
     "@types/node": "npm:^20.14.8"
     concurrently: "npm:7.0.0"


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

Adds paginators and waiters as methods on aggregated clients.

## "bare-bones" modular client
```ts
// modular syntax
import {
  XYZClient,
  GetNumbersCommand,
  paginateGetNumbers,
  waitUntilNumbersAligned,
} from "@namespace/client-xyz";

const client = new XYZClient();

await client.send(new GetNumbersCommand({ bigInteger: 1n }));

for await (const page of paginateGetNumbers({ client }, { bigInteger: 1n })) {
  // page
}

await waitUntilNumbersAligned({ client }, { bigInteger: 1n });
```

## aggregated client
```ts
// aggregated syntax (calls modular syntax internally)

import { XYZ } from "@namespace/client-xyz";

const xyz = new XYZ();

await xyz.getNumbers({ bigInteger: 1n });

for await (const page of xyz.paginateGetNumbers(
  { bigInteger: 1n },
  {
    /* optional paginator config */
  },
)) {
  // page
}

await xyz.waitUntilNumbersAligned(
  { bigInteger: 1n },
  {
    /* optional waiter config */
  },
);

```