### PR TITLE
fix(node-http-handler): use configured logger instead of hardcoded co…

### DIFF
--- a/.changeset/ninety-lizards-speak.md
+++ b/.changeset/ninety-lizards-speak.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Use configured logger when provided.

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -133,6 +133,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
       httpAgent,
       httpsAgent,
       throwOnRequestTimeout,
+      logger,
     } = options || {};
     const keepAlive = true;
     const maxSockets = 50;
@@ -157,7 +158,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         }
         return new hsAgent({ keepAlive, maxSockets, ...httpsAgent });
       })(),
-      logger: console,
+      logger,
     };
   }
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Previously, the NodeHttpHandler always used console for logging regardless of the logger option passed in configuration. This change ensures the configured logger is properly used when provided, falling back to undefined if not specified. This seemed like it was intended in the [original PR](https://github.com/smithy-lang/smithy-typescript/commit/c16e0148eaa753f845e0998314383624653ba61b) that added the configurable logger though it never actually passed the configured logger.

This allows consumers to provide custom loggers that integrate with their logging infrastructure rather than being forced to use console output.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
