### PR TITLE
fix(codegen): handle paginators for operations with camelCase names

### DIFF
--- a/private/my-local-model-schema/src/XYZService.ts
+++ b/private/my-local-model-schema/src/XYZService.ts
@@ -9,6 +9,11 @@ import type {
 import type { WaiterResult } from "@smithy/util-waiter";
 
 import {
+  type CamelCaseOperationCommandInput,
+  type CamelCaseOperationCommandOutput,
+  CamelCaseOperationCommand,
+} from "./commands/CamelCaseOperationCommand";
+import {
   type GetNumbersCommandInput,
   type GetNumbersCommandOutput,
   GetNumbersCommand,
@@ -18,15 +23,18 @@ import {
   type TradeEventStreamCommandOutput,
   TradeEventStreamCommand,
 } from "./commands/TradeEventStreamCommand";
+import { paginatecamelCaseOperation as paginateCamelCaseOperation } from "./pagination/camelCaseOperationPaginator";
 import { paginateGetNumbers } from "./pagination/GetNumbersPaginator";
 import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
+  CamelCaseOperationCommand,
   GetNumbersCommand,
   TradeEventStreamCommand,
 };
 const paginators = {
+  paginateCamelCaseOperation,
   paginateGetNumbers,
 };
 const waiters = {
@@ -34,6 +42,24 @@ const waiters = {
 };
 
 export interface XYZService {
+  /**
+   * @see {@link CamelCaseOperationCommand}
+   */
+  camelCaseOperation(): Promise<CamelCaseOperationCommandOutput>;
+  camelCaseOperation(
+    args: CamelCaseOperationCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<CamelCaseOperationCommandOutput>;
+  camelCaseOperation(
+    args: CamelCaseOperationCommandInput,
+    cb: (err: any, data?: CamelCaseOperationCommandOutput) => void
+  ): void;
+  camelCaseOperation(
+    args: CamelCaseOperationCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: CamelCaseOperationCommandOutput) => void
+  ): void;
+
   /**
    * @see {@link GetNumbersCommand}
    */
@@ -69,6 +95,17 @@ export interface XYZService {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: TradeEventStreamCommandOutput) => void
   ): void;
+
+  /**
+   * @see {@link CamelCaseOperationCommand}
+   * @param args - command input.
+   * @param paginationConfig - optional pagination config.
+   * @returns AsyncIterable of {@link CamelCaseOperationCommandOutput}.
+   */
+  paginateCamelCaseOperation(
+    args?: CamelCaseOperationCommandInput,
+    paginationConfig?: Omit<PaginationConfiguration, "client">
+  ): Paginator<CamelCaseOperationCommandOutput>;
 
   /**
    * @see {@link GetNumbersCommand}

--- a/private/my-local-model-schema/src/XYZServiceClient.ts
+++ b/private/my-local-model-schema/src/XYZServiceClient.ts
@@ -50,6 +50,10 @@ import {
   defaultXYZServiceHttpAuthSchemeParametersProvider,
   resolveHttpAuthSchemeConfig,
 } from "./auth/httpAuthSchemeProvider";
+import type {
+  CamelCaseOperationCommandInput,
+  CamelCaseOperationCommandOutput,
+} from "./commands/CamelCaseOperationCommand";
 import type { GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
 import type { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "./commands/TradeEventStreamCommand";
 import {
@@ -67,6 +71,7 @@ export { __Client };
  * @public
  */
 export type ServiceInputTypes =
+  | CamelCaseOperationCommandInput
   | GetNumbersCommandInput
   | TradeEventStreamCommandInput;
 
@@ -74,6 +79,7 @@ export type ServiceInputTypes =
  * @public
  */
 export type ServiceOutputTypes =
+  | CamelCaseOperationCommandOutput
   | GetNumbersCommandOutput
   | TradeEventStreamCommandOutput;
 

--- a/private/my-local-model-schema/src/commands/CamelCaseOperationCommand.ts
+++ b/private/my-local-model-schema/src/commands/CamelCaseOperationCommand.ts
@@ -1,0 +1,94 @@
+// smithy-typescript generated code
+import { getEndpointPlugin } from "@smithy/middleware-endpoint";
+import { Command as $Command } from "@smithy/smithy-client";
+import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
+
+import { commonParams } from "../endpoint/EndpointParameters";
+import type { CamelCaseOperationInput, CamelCaseOperationOutput } from "../models/models_0";
+import { camelCaseOperation$ } from "../schemas/schemas_0";
+import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+
+/**
+ * @public
+ */
+export type { __MetadataBearer };
+export { $Command };
+/**
+ * @public
+ *
+ * The input for {@link CamelCaseOperationCommand}.
+ */
+export interface CamelCaseOperationCommandInput extends CamelCaseOperationInput {}
+/**
+ * @public
+ *
+ * The output of {@link CamelCaseOperationCommand}.
+ */
+export interface CamelCaseOperationCommandOutput extends CamelCaseOperationOutput, __MetadataBearer {}
+
+/**
+ * @public
+ *
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { XYZServiceClient, CamelCaseOperationCommand } from "xyz-schema"; // ES Modules import
+ * // const { XYZServiceClient, CamelCaseOperationCommand } = require("xyz-schema"); // CommonJS import
+ * // import type { XYZServiceClientConfig } from "xyz-schema";
+ * const config = {}; // type is XYZServiceClientConfig
+ * const client = new XYZServiceClient(config);
+ * const input = { // camelCaseOperationInput
+ *   token: "STRING_VALUE",
+ * };
+ * const command = new CamelCaseOperationCommand(input);
+ * const response = await client.send(command);
+ * // { // camelCaseOperationOutput
+ * //   token: "STRING_VALUE",
+ * //   results: [ // Blobs
+ * //     new Uint8Array(),
+ * //   ],
+ * // };
+ *
+ * ```
+ *
+ * @param CamelCaseOperationCommandInput - {@link CamelCaseOperationCommandInput}
+ * @returns {@link CamelCaseOperationCommandOutput}
+ * @see {@link CamelCaseOperationCommandInput} for command's `input` shape.
+ * @see {@link CamelCaseOperationCommandOutput} for command's `response` shape.
+ * @see {@link XYZServiceClientResolvedConfig | config} for XYZServiceClient's `config` shape.
+ *
+ * @throws {@link MainServiceLinkedError} (client fault)
+ *
+ * @throws {@link XYZServiceSyntheticServiceException}
+ * <p>Base exception class for all service exceptions from XYZService service.</p>
+ *
+ *
+ */
+export class CamelCaseOperationCommand extends $Command
+  .classBuilder<
+    CamelCaseOperationCommandInput,
+    CamelCaseOperationCommandOutput,
+    XYZServiceClientResolvedConfig,
+    ServiceInputTypes,
+    ServiceOutputTypes
+  >()
+  .ep(commonParams)
+  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+  })
+  .s("XYZService", "camelCaseOperation", {})
+  .n("XYZServiceClient", "CamelCaseOperationCommand")
+  .sc(camelCaseOperation$)
+  .build() {
+  /** @internal type navigation helper, not in runtime. */
+  protected declare static __types: {
+    api: {
+      input: CamelCaseOperationInput;
+      output: CamelCaseOperationOutput;
+    };
+    sdk: {
+      input: CamelCaseOperationCommandInput;
+      output: CamelCaseOperationCommandOutput;
+    };
+  };
+}

--- a/private/my-local-model-schema/src/commands/index.ts
+++ b/private/my-local-model-schema/src/commands/index.ts
@@ -1,3 +1,4 @@
 // smithy-typescript generated code
+export * from "./CamelCaseOperationCommand";
 export * from "./GetNumbersCommand";
 export * from "./TradeEventStreamCommand";

--- a/private/my-local-model-schema/src/models/errors.ts
+++ b/private/my-local-model-schema/src/models/errors.ts
@@ -6,6 +6,25 @@ import { XYZServiceSyntheticServiceException as __BaseException } from "./XYZSer
 /**
  * @public
  */
+export class MainServiceLinkedError extends __BaseException {
+  readonly name = "MainServiceLinkedError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<MainServiceLinkedError, __BaseException>) {
+    super({
+      name: "MainServiceLinkedError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, MainServiceLinkedError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
 export class CodedThrottlingError extends __BaseException {
   readonly name = "CodedThrottlingError" as const;
   readonly $fault = "client" as const;
@@ -41,25 +60,6 @@ export class HaltError extends __BaseException {
       ...opts,
     });
     Object.setPrototypeOf(this, HaltError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class MainServiceLinkedError extends __BaseException {
-  readonly name = "MainServiceLinkedError" as const;
-  readonly $fault = "client" as const;
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<MainServiceLinkedError, __BaseException>) {
-    super({
-      name: "MainServiceLinkedError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, MainServiceLinkedError.prototype);
   }
 }
 

--- a/private/my-local-model-schema/src/models/models_0.ts
+++ b/private/my-local-model-schema/src/models/models_0.ts
@@ -12,6 +12,21 @@ export interface Alpha {
 /**
  * @public
  */
+export interface CamelCaseOperationInput {
+  token?: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CamelCaseOperationOutput {
+  token?: string | undefined;
+  results?: Uint8Array[] | undefined;
+}
+
+/**
+ * @public
+ */
 export interface GetNumbersRequest {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;

--- a/private/my-local-model-schema/src/pagination/camelCaseOperationPaginator.ts
+++ b/private/my-local-model-schema/src/pagination/camelCaseOperationPaginator.ts
@@ -1,0 +1,24 @@
+// smithy-typescript generated code
+import { createPaginator } from "@smithy/core";
+import type { Paginator } from "@smithy/types";
+
+import {
+  CamelCaseOperationCommand,
+  CamelCaseOperationCommandInput,
+  CamelCaseOperationCommandOutput,
+} from "../commands/CamelCaseOperationCommand";
+import { XYZServiceClient } from "../XYZServiceClient";
+import { XYZServicePaginationConfiguration } from "./Interfaces";
+
+/**
+ * @public
+ */
+export const paginatecamelCaseOperation: (
+  config: XYZServicePaginationConfiguration,
+  input: CamelCaseOperationCommandInput,
+  ...rest: any[]
+) => Paginator<CamelCaseOperationCommandOutput> = createPaginator<
+  XYZServicePaginationConfiguration,
+  CamelCaseOperationCommandInput,
+  CamelCaseOperationCommandOutput
+>(XYZServiceClient, CamelCaseOperationCommand, "token", "token", "");

--- a/private/my-local-model-schema/src/pagination/index.ts
+++ b/private/my-local-model-schema/src/pagination/index.ts
@@ -1,3 +1,4 @@
 // smithy-typescript generated code
 export * from "./Interfaces";
+export * from "./camelCaseOperationPaginator";
 export * from "./GetNumbersPaginator";

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -17,6 +17,9 @@ const _b = "beta";
 const _bD = "bigDecimal";
 const _bI = "bigInteger";
 const _c = "client";
+const _cCO = "camelCaseOperation";
+const _cCOI = "camelCaseOperationInput";
+const _cCOO = "camelCaseOperationOutput";
 const _e = "error";
 const _eS = "eventStream";
 const _fWM = "fieldWithoutMessage";
@@ -27,10 +30,12 @@ const _i = "id";
 const _mR = "maxResults";
 const _n = "numbers";
 const _nT = "nextToken";
+const _r = "results";
 const _s = "smithy.ts.sdk.synthetic.org.xyz.v1";
 const _sT = "startToken";
 const _st = "streaming";
 const _t = "timestamp";
+const _to = "token";
 const n0 = "org.xyz.v1";
 
 // smithy-typescript generated code
@@ -58,6 +63,16 @@ export var Alpha$: StaticStructureSchema = [3, n0, _A,
   0,
   [_i, _t],
   [0, 4]
+];
+export var camelCaseOperationInput$: StaticStructureSchema = [3, n0, _cCOI,
+  0,
+  [_to],
+  [0]
+];
+export var camelCaseOperationOutput$: StaticStructureSchema = [3, n0, _cCOO,
+  0,
+  [_to, _r],
+  [0, 64 | 21]
 ];
 export var CodedThrottlingError$: StaticErrorSchema = [-3, n0, _CTE,
   { [_e]: _c, [_hE]: 429 },
@@ -118,11 +133,15 @@ TypeRegistry.for(n0).registerError(XYZServiceServiceException$, XYZServiceServic
 var __Unit = "unit" as const;
 export var XYZServiceSyntheticServiceException$: StaticErrorSchema = [-3, _s, "XYZServiceSyntheticServiceException", 0, [], []];
 TypeRegistry.for(_s).registerError(XYZServiceSyntheticServiceException$, XYZServiceSyntheticServiceException);
+var Blobs = 64 | 21;
 var IntegerList = 64 | 1;
 export var TradeEvents$: StaticUnionSchema = [4, n0, _TE,
   { [_st]: 1 },
   [_a, _b, _g],
   [() => Alpha$, () => __Unit, () => __Unit]
+];
+export var camelCaseOperation$: StaticOperationSchema = [9, n0, _cCO,
+  0, () => camelCaseOperationInput$, () => camelCaseOperationOutput$
 ];
 export var GetNumbers$: StaticOperationSchema = [9, n0, _GN,
   0, () => GetNumbersRequest$, () => GetNumbersResponse$

--- a/private/my-local-model-schema/test/index-objects.spec.mjs
+++ b/private/my-local-model-schema/test/index-objects.spec.mjs
@@ -1,5 +1,9 @@
 import {
   Alpha$,
+  camelCaseOperation$,
+  CamelCaseOperationCommand,
+  camelCaseOperationInput$,
+  camelCaseOperationOutput$,
   CodedThrottlingError,
   CodedThrottlingError$,
   GetNumbers$,
@@ -12,6 +16,7 @@ import {
   MainServiceLinkedError$,
   MysteryThrottlingError,
   MysteryThrottlingError$,
+  paginatecamelCaseOperation,
   paginateGetNumbers,
   RetryableError,
   RetryableError$,
@@ -33,12 +38,16 @@ import assert from "node:assert";
 assert(typeof XYZServiceClient === "function");
 assert(typeof XYZService === "function");
 // commands
+assert(typeof CamelCaseOperationCommand === "function");
+assert(typeof camelCaseOperation$ === "object");
 assert(typeof GetNumbersCommand === "function");
 assert(typeof GetNumbers$ === "object");
 assert(typeof TradeEventStreamCommand === "function");
 assert(typeof TradeEventStream$ === "object");
 // structural schemas
 assert(typeof Alpha$ === "object");
+assert(typeof camelCaseOperationInput$ === "object");
+assert(typeof camelCaseOperationOutput$ === "object");
 assert(typeof GetNumbersRequest$ === "object");
 assert(typeof GetNumbersResponse$ === "object");
 assert(typeof TradeEvents$ === "object");
@@ -63,4 +72,5 @@ assert(typeof waitForNumbersAligned === "function");
 assert(typeof waitUntilNumbersAligned === "function");
 // paginators
 assert(typeof paginateGetNumbers === "function");
+assert(typeof paginatecamelCaseOperation === "function");
 console.log(`XYZService index test passed.`);

--- a/private/my-local-model-schema/test/index-types.ts
+++ b/private/my-local-model-schema/test/index-types.ts
@@ -2,6 +2,9 @@
 export type {
   XYZServiceClient,
   XYZService,
+  CamelCaseOperationCommand,
+  CamelCaseOperationCommandInput,
+  CamelCaseOperationCommandOutput,
   GetNumbersCommand,
   GetNumbersCommandInput,
   GetNumbersCommandOutput,
@@ -9,6 +12,8 @@ export type {
   TradeEventStreamCommandInput,
   TradeEventStreamCommandOutput,
   Alpha,
+  CamelCaseOperationInput,
+  CamelCaseOperationOutput,
   GetNumbersRequest,
   GetNumbersResponse,
   TradeEvents,
@@ -24,4 +29,5 @@ export type {
   waitForNumbersAligned,
   waitUntilNumbersAligned,
   paginateGetNumbers,
+  paginatecamelCaseOperation,
 } from "../dist-types/index.d";

--- a/private/my-local-model/src/XYZService.ts
+++ b/private/my-local-model/src/XYZService.ts
@@ -8,21 +8,29 @@ import type {
 } from "@smithy/types";
 import type { WaiterResult } from "@smithy/util-waiter";
 
+import {
+  CamelCaseOperationCommand,
+  CamelCaseOperationCommandInput,
+  CamelCaseOperationCommandOutput,
+} from "./commands/CamelCaseOperationCommand";
 import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
 import {
   TradeEventStreamCommand,
   TradeEventStreamCommandInput,
   TradeEventStreamCommandOutput,
 } from "./commands/TradeEventStreamCommand";
+import { paginatecamelCaseOperation as paginateCamelCaseOperation } from "./pagination/camelCaseOperationPaginator";
 import { paginateGetNumbers } from "./pagination/GetNumbersPaginator";
 import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
+  CamelCaseOperationCommand,
   GetNumbersCommand,
   TradeEventStreamCommand,
 };
 const paginators = {
+  paginateCamelCaseOperation,
   paginateGetNumbers,
 };
 const waiters = {
@@ -30,6 +38,24 @@ const waiters = {
 };
 
 export interface XYZService {
+  /**
+   * @see {@link CamelCaseOperationCommand}
+   */
+  camelCaseOperation(): Promise<CamelCaseOperationCommandOutput>;
+  camelCaseOperation(
+    args: CamelCaseOperationCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<CamelCaseOperationCommandOutput>;
+  camelCaseOperation(
+    args: CamelCaseOperationCommandInput,
+    cb: (err: any, data?: CamelCaseOperationCommandOutput) => void
+  ): void;
+  camelCaseOperation(
+    args: CamelCaseOperationCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: CamelCaseOperationCommandOutput) => void
+  ): void;
+
   /**
    * @see {@link GetNumbersCommand}
    */
@@ -65,6 +91,17 @@ export interface XYZService {
     options: __HttpHandlerOptions,
     cb: (err: any, data?: TradeEventStreamCommandOutput) => void
   ): void;
+
+  /**
+   * @see {@link CamelCaseOperationCommand}
+   * @param args - command input.
+   * @param paginationConfig - optional pagination config.
+   * @returns AsyncIterable of {@link CamelCaseOperationCommandOutput}.
+   */
+  paginateCamelCaseOperation(
+    args?: CamelCaseOperationCommandInput,
+    paginationConfig?: Omit<PaginationConfiguration, "client">
+  ): Paginator<CamelCaseOperationCommandOutput>;
 
   /**
    * @see {@link GetNumbersCommand}

--- a/private/my-local-model/src/XYZServiceClient.ts
+++ b/private/my-local-model/src/XYZServiceClient.ts
@@ -49,6 +49,7 @@ import {
   defaultXYZServiceHttpAuthSchemeParametersProvider,
   resolveHttpAuthSchemeConfig,
 } from "./auth/httpAuthSchemeProvider";
+import { CamelCaseOperationCommandInput, CamelCaseOperationCommandOutput } from "./commands/CamelCaseOperationCommand";
 import { GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
 import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "./commands/TradeEventStreamCommand";
 import {
@@ -66,6 +67,7 @@ export { __Client };
  * @public
  */
 export type ServiceInputTypes =
+  | CamelCaseOperationCommandInput
   | GetNumbersCommandInput
   | TradeEventStreamCommandInput;
 
@@ -73,6 +75,7 @@ export type ServiceInputTypes =
  * @public
  */
 export type ServiceOutputTypes =
+  | CamelCaseOperationCommandOutput
   | GetNumbersCommandOutput
   | TradeEventStreamCommandOutput;
 

--- a/private/my-local-model/src/commands/CamelCaseOperationCommand.ts
+++ b/private/my-local-model/src/commands/CamelCaseOperationCommand.ts
@@ -1,0 +1,100 @@
+// smithy-typescript generated code
+import { getEndpointPlugin } from "@smithy/middleware-endpoint";
+import { getSerdePlugin } from "@smithy/middleware-serde";
+import { Command as $Command } from "@smithy/smithy-client";
+import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
+
+import { commonParams } from "../endpoint/EndpointParameters";
+import type { CamelCaseOperationInput, CamelCaseOperationOutput } from "../models/models_0";
+import { de_CamelCaseOperationCommand, se_CamelCaseOperationCommand } from "../protocols/Rpcv2cbor";
+import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+
+/**
+ * @public
+ */
+export type { __MetadataBearer };
+export { $Command };
+/**
+ * @public
+ *
+ * The input for {@link CamelCaseOperationCommand}.
+ */
+export interface CamelCaseOperationCommandInput extends CamelCaseOperationInput {}
+/**
+ * @public
+ *
+ * The output of {@link CamelCaseOperationCommand}.
+ */
+export interface CamelCaseOperationCommandOutput extends CamelCaseOperationOutput, __MetadataBearer {}
+
+/**
+ * @public
+ *
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { XYZServiceClient, CamelCaseOperationCommand } from "xyz"; // ES Modules import
+ * // const { XYZServiceClient, CamelCaseOperationCommand } = require("xyz"); // CommonJS import
+ * // import type { XYZServiceClientConfig } from "xyz";
+ * const config = {}; // type is XYZServiceClientConfig
+ * const client = new XYZServiceClient(config);
+ * const input = { // camelCaseOperationInput
+ *   token: "STRING_VALUE",
+ * };
+ * const command = new CamelCaseOperationCommand(input);
+ * const response = await client.send(command);
+ * // { // camelCaseOperationOutput
+ * //   token: "STRING_VALUE",
+ * //   results: [ // Blobs
+ * //     new Uint8Array(),
+ * //   ],
+ * // };
+ *
+ * ```
+ *
+ * @param CamelCaseOperationCommandInput - {@link CamelCaseOperationCommandInput}
+ * @returns {@link CamelCaseOperationCommandOutput}
+ * @see {@link CamelCaseOperationCommandInput} for command's `input` shape.
+ * @see {@link CamelCaseOperationCommandOutput} for command's `response` shape.
+ * @see {@link XYZServiceClientResolvedConfig | config} for XYZServiceClient's `config` shape.
+ *
+ * @throws {@link MainServiceLinkedError} (client fault)
+ *
+ * @throws {@link XYZServiceSyntheticServiceException}
+ * <p>Base exception class for all service exceptions from XYZService service.</p>
+ *
+ *
+ */
+export class CamelCaseOperationCommand extends $Command
+  .classBuilder<
+    CamelCaseOperationCommandInput,
+    CamelCaseOperationCommandOutput,
+    XYZServiceClientResolvedConfig,
+    ServiceInputTypes,
+    ServiceOutputTypes
+  >()
+  .ep(commonParams)
+  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+    ];
+  })
+  .s("XYZService", "camelCaseOperation", {})
+  .n("XYZServiceClient", "CamelCaseOperationCommand")
+  .f(void 0, void 0)
+  .ser(se_CamelCaseOperationCommand)
+  .de(de_CamelCaseOperationCommand)
+  .build() {
+  /** @internal type navigation helper, not in runtime. */
+  protected declare static __types: {
+    api: {
+      input: CamelCaseOperationInput;
+      output: CamelCaseOperationOutput;
+    };
+    sdk: {
+      input: CamelCaseOperationCommandInput;
+      output: CamelCaseOperationCommandOutput;
+    };
+  };
+}

--- a/private/my-local-model/src/commands/index.ts
+++ b/private/my-local-model/src/commands/index.ts
@@ -1,3 +1,4 @@
 // smithy-typescript generated code
+export * from "./CamelCaseOperationCommand";
 export * from "./GetNumbersCommand";
 export * from "./TradeEventStreamCommand";

--- a/private/my-local-model/src/models/errors.ts
+++ b/private/my-local-model/src/models/errors.ts
@@ -6,6 +6,25 @@ import { XYZServiceSyntheticServiceException as __BaseException } from "./XYZSer
 /**
  * @public
  */
+export class MainServiceLinkedError extends __BaseException {
+  readonly name = "MainServiceLinkedError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<MainServiceLinkedError, __BaseException>) {
+    super({
+      name: "MainServiceLinkedError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, MainServiceLinkedError.prototype);
+  }
+}
+
+/**
+ * @public
+ */
 export class CodedThrottlingError extends __BaseException {
   readonly name = "CodedThrottlingError" as const;
   readonly $fault = "client" as const;
@@ -41,25 +60,6 @@ export class HaltError extends __BaseException {
       ...opts,
     });
     Object.setPrototypeOf(this, HaltError.prototype);
-  }
-}
-
-/**
- * @public
- */
-export class MainServiceLinkedError extends __BaseException {
-  readonly name = "MainServiceLinkedError" as const;
-  readonly $fault = "client" as const;
-  /**
-   * @internal
-   */
-  constructor(opts: __ExceptionOptionType<MainServiceLinkedError, __BaseException>) {
-    super({
-      name: "MainServiceLinkedError",
-      $fault: "client",
-      ...opts,
-    });
-    Object.setPrototypeOf(this, MainServiceLinkedError.prototype);
   }
 }
 

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -12,6 +12,21 @@ export interface Alpha {
 /**
  * @public
  */
+export interface CamelCaseOperationInput {
+  token?: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CamelCaseOperationOutput {
+  token?: string | undefined;
+  results?: Uint8Array[] | undefined;
+}
+
+/**
+ * @public
+ */
 export interface GetNumbersRequest {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;

--- a/private/my-local-model/src/pagination/camelCaseOperationPaginator.ts
+++ b/private/my-local-model/src/pagination/camelCaseOperationPaginator.ts
@@ -1,0 +1,24 @@
+// smithy-typescript generated code
+import { createPaginator } from "@smithy/core";
+import type { Paginator } from "@smithy/types";
+
+import {
+  CamelCaseOperationCommand,
+  CamelCaseOperationCommandInput,
+  CamelCaseOperationCommandOutput,
+} from "../commands/CamelCaseOperationCommand";
+import { XYZServiceClient } from "../XYZServiceClient";
+import { XYZServicePaginationConfiguration } from "./Interfaces";
+
+/**
+ * @public
+ */
+export const paginatecamelCaseOperation: (
+  config: XYZServicePaginationConfiguration,
+  input: CamelCaseOperationCommandInput,
+  ...rest: any[]
+) => Paginator<CamelCaseOperationCommandOutput> = createPaginator<
+  XYZServicePaginationConfiguration,
+  CamelCaseOperationCommandInput,
+  CamelCaseOperationCommandOutput
+>(XYZServiceClient, CamelCaseOperationCommand, "token", "token", "");

--- a/private/my-local-model/src/pagination/index.ts
+++ b/private/my-local-model/src/pagination/index.ts
@@ -1,3 +1,4 @@
 // smithy-typescript generated code
 export * from "./Interfaces";
+export * from "./camelCaseOperationPaginator";
 export * from "./GetNumbersPaginator";

--- a/private/my-local-model/src/protocols/Rpcv2cbor.ts
+++ b/private/my-local-model/src/protocols/Rpcv2cbor.ts
@@ -30,6 +30,7 @@ import type {
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
 
+import { CamelCaseOperationCommandInput, CamelCaseOperationCommandOutput } from "../commands/CamelCaseOperationCommand";
 import { GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
 import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "../commands/TradeEventStreamCommand";
 import {
@@ -40,8 +41,29 @@ import {
   RetryableError,
   XYZServiceServiceException,
 } from "../models/errors";
-import { Alpha, GetNumbersRequest, GetNumbersResponse, TradeEvents, Unit } from "../models/models_0";
+import {
+  Alpha,
+  CamelCaseOperationInput,
+  CamelCaseOperationOutput,
+  GetNumbersRequest,
+  GetNumbersResponse,
+  TradeEvents,
+  Unit,
+} from "../models/models_0";
 import { XYZServiceSyntheticServiceException as __BaseException } from "../models/XYZServiceSyntheticServiceException";
+
+/**
+ * serializeRpcv2cborCamelCaseOperationCommand
+ */
+export const se_CamelCaseOperationCommand = async (
+  input: CamelCaseOperationCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const headers: __HeaderBag = SHARED_HEADERS;
+  let body: any;
+  body = cbor.serialize(_json(input));
+  return buildHttpRpcRequest(context, headers, "/service/XYZService/operation/camelCaseOperation", undefined, body);
+};
 
 /**
  * serializeRpcv2cborGetNumbersCommand
@@ -71,6 +93,28 @@ export const se_TradeEventStreamCommand = async (
   let body: any;
   body = se_TradeEvents(input.eventStream, context);
   return buildHttpRpcRequest(context, headers, "/service/XYZService/operation/TradeEventStream", undefined, body);
+};
+
+/**
+ * deserializeRpcv2cborCamelCaseOperationCommand
+ */
+export const de_CamelCaseOperationCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<CamelCaseOperationCommandOutput> => {
+  cr(output);
+  if (output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+
+  const data: any = await parseBody(output.body, context)
+  let contents: any = {};
+  contents = de_CamelCaseOperationOutput(data, context);
+  const response: CamelCaseOperationCommandOutput = {
+    $metadata: deserializeMetadata(output), ...contents,
+  };
+  return response;
+
 };
 
 /**
@@ -128,15 +172,15 @@ const de_CommandError = async (
   };
   const errorCode = loadSmithyRpcV2CborErrorCode(output, parsedOutput.body);
   switch (errorCode) {
+    case "MainServiceLinkedError":
+    case "org.xyz.v1#MainServiceLinkedError":
+      throw await de_MainServiceLinkedErrorRes(parsedOutput, context);
     case "CodedThrottlingError":
     case "org.xyz.v1#CodedThrottlingError":
       throw await de_CodedThrottlingErrorRes(parsedOutput, context);
     case "HaltError":
     case "org.xyz.v1#HaltError":
       throw await de_HaltErrorRes(parsedOutput, context);
-    case "MainServiceLinkedError":
-    case "org.xyz.v1#MainServiceLinkedError":
-      throw await de_MainServiceLinkedErrorRes(parsedOutput, context);
     case "MysteryThrottlingError":
     case "org.xyz.v1#MysteryThrottlingError":
       throw await de_MysteryThrottlingErrorRes(parsedOutput, context);
@@ -355,6 +399,8 @@ const se_Alpha_event = (
       });
     }
 
+    // se_CamelCaseOperationInput omitted.
+
     /**
      * serializeRpcv2cborGetNumbersRequest
      */
@@ -384,6 +430,30 @@ const se_Alpha_event = (
       return take(output, {
         'id': __expectString,
         'timestamp': (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
+      }) as any;
+    }
+
+    /**
+     * deserializeRpcv2cborBlobs
+     */
+    const de_Blobs = (
+      output: any,
+      context: __SerdeContext
+    ): Uint8Array[] => {
+      const collection = (output || []).filter((e: any) => e != null)
+      return collection;
+    }
+
+    /**
+     * deserializeRpcv2cborCamelCaseOperationOutput
+     */
+    const de_CamelCaseOperationOutput = (
+      output: any,
+      context: __SerdeContext
+    ): CamelCaseOperationOutput => {
+      return take(output, {
+        'results': (_: any) => de_Blobs(_, context),
+        'token': __expectString,
       }) as any;
     }
 

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
@@ -70,6 +70,7 @@ service XYZService {
     operations: [
         GetNumbers
         TradeEventStream
+        camelCaseOperation
     ]
     errors: [
         MainServiceLinkedError
@@ -238,3 +239,19 @@ structure UnusedServiceLinkedError {}
 @error("client")
 @httpError(400)
 structure CompletelyUnlinkedError {}
+
+@paginated(inputToken: "token", outputToken: "token", items: "results")
+@readonly
+operation camelCaseOperation {
+    input := {
+        token: String
+    }
+    output := {
+        token: String
+        results: Blobs
+    }
+}
+
+list Blobs {
+    member: Blob
+}


### PR DESCRIPTION
generate aggregated paginators correctly when the operation shape id is camelCase instead of TitleCase
