### PR TITLE
test(codegen): generate http label bindings in response tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "turbo run build",
     "test": "make test-unit",
     "test:integration": "yarn build-test-packages && make test-integration",
-    "test:protocols": "make generate-protocol-tests test-protocols",
+    "test:protocols": "make generate-protocol-tests test-protocols benchmark",
     "lint": "turbo run lint",
     "lint-fix": "turbo run lint -- --fix",
     "lint:pkgJson": "yarn lint:dependencies",

--- a/private/my-local-model-schema/src/XYZService.ts
+++ b/private/my-local-model-schema/src/XYZService.ts
@@ -19,6 +19,11 @@ import {
   GetNumbersCommand,
 } from "./commands/GetNumbersCommand";
 import {
+  type HttpLabelCommandCommandInput,
+  type HttpLabelCommandCommandOutput,
+  HttpLabelCommandCommand,
+} from "./commands/HttpLabelCommandCommand";
+import {
   type TradeEventStreamCommandInput,
   type TradeEventStreamCommandOutput,
   TradeEventStreamCommand,
@@ -29,6 +34,7 @@ import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
+  HttpLabelCommandCommand,
   CamelCaseOperationCommand,
   GetNumbersCommand,
   TradeEventStreamCommand,
@@ -42,6 +48,23 @@ const waiters = {
 };
 
 export interface XYZService {
+  /**
+   * @see {@link HttpLabelCommandCommand}
+   */
+  httpLabelCommand(
+    args: HttpLabelCommandCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<HttpLabelCommandCommandOutput>;
+  httpLabelCommand(
+    args: HttpLabelCommandCommandInput,
+    cb: (err: any, data?: HttpLabelCommandCommandOutput) => void
+  ): void;
+  httpLabelCommand(
+    args: HttpLabelCommandCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: HttpLabelCommandCommandOutput) => void
+  ): void;
+
   /**
    * @see {@link CamelCaseOperationCommand}
    */

--- a/private/my-local-model-schema/src/XYZServiceClient.ts
+++ b/private/my-local-model-schema/src/XYZServiceClient.ts
@@ -55,6 +55,7 @@ import type {
   CamelCaseOperationCommandOutput,
 } from "./commands/CamelCaseOperationCommand";
 import type { GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
+import type { HttpLabelCommandCommandInput, HttpLabelCommandCommandOutput } from "./commands/HttpLabelCommandCommand";
 import type { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "./commands/TradeEventStreamCommand";
 import {
   type ClientInputEndpointParameters,
@@ -73,6 +74,7 @@ export { __Client };
 export type ServiceInputTypes =
   | CamelCaseOperationCommandInput
   | GetNumbersCommandInput
+  | HttpLabelCommandCommandInput
   | TradeEventStreamCommandInput;
 
 /**
@@ -81,6 +83,7 @@ export type ServiceInputTypes =
 export type ServiceOutputTypes =
   | CamelCaseOperationCommandOutput
   | GetNumbersCommandOutput
+  | HttpLabelCommandCommandOutput
   | TradeEventStreamCommandOutput;
 
 /**

--- a/private/my-local-model-schema/src/commands/HttpLabelCommandCommand.ts
+++ b/private/my-local-model-schema/src/commands/HttpLabelCommandCommand.ts
@@ -1,0 +1,89 @@
+// smithy-typescript generated code
+import { getEndpointPlugin } from "@smithy/middleware-endpoint";
+import { Command as $Command } from "@smithy/smithy-client";
+import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
+
+import { commonParams } from "../endpoint/EndpointParameters";
+import type { HttpLabelCommandInput, HttpLabelCommandOutput } from "../models/models_0";
+import { HttpLabelCommand$ } from "../schemas/schemas_0";
+import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+
+/**
+ * @public
+ */
+export type { __MetadataBearer };
+export { $Command };
+/**
+ * @public
+ *
+ * The input for {@link HttpLabelCommandCommand}.
+ */
+export interface HttpLabelCommandCommandInput extends HttpLabelCommandInput {}
+/**
+ * @public
+ *
+ * The output of {@link HttpLabelCommandCommand}.
+ */
+export interface HttpLabelCommandCommandOutput extends HttpLabelCommandOutput, __MetadataBearer {}
+
+/**
+ * @public
+ *
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { XYZServiceClient, HttpLabelCommandCommand } from "xyz-schema"; // ES Modules import
+ * // const { XYZServiceClient, HttpLabelCommandCommand } = require("xyz-schema"); // CommonJS import
+ * // import type { XYZServiceClientConfig } from "xyz-schema";
+ * const config = {}; // type is XYZServiceClientConfig
+ * const client = new XYZServiceClient(config);
+ * const input = { // HttpLabelCommandInput
+ *   LabelDoesNotApplyToRpcProtocol: "STRING_VALUE", // required
+ * };
+ * const command = new HttpLabelCommandCommand(input);
+ * const response = await client.send(command);
+ * // {};
+ *
+ * ```
+ *
+ * @param HttpLabelCommandCommandInput - {@link HttpLabelCommandCommandInput}
+ * @returns {@link HttpLabelCommandCommandOutput}
+ * @see {@link HttpLabelCommandCommandInput} for command's `input` shape.
+ * @see {@link HttpLabelCommandCommandOutput} for command's `response` shape.
+ * @see {@link XYZServiceClientResolvedConfig | config} for XYZServiceClient's `config` shape.
+ *
+ * @throws {@link MainServiceLinkedError} (client fault)
+ *
+ * @throws {@link XYZServiceSyntheticServiceException}
+ * <p>Base exception class for all service exceptions from XYZService service.</p>
+ *
+ *
+ */
+export class HttpLabelCommandCommand extends $Command
+  .classBuilder<
+    HttpLabelCommandCommandInput,
+    HttpLabelCommandCommandOutput,
+    XYZServiceClientResolvedConfig,
+    ServiceInputTypes,
+    ServiceOutputTypes
+  >()
+  .ep(commonParams)
+  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+  })
+  .s("XYZService", "HttpLabelCommand", {})
+  .n("XYZServiceClient", "HttpLabelCommandCommand")
+  .sc(HttpLabelCommand$)
+  .build() {
+  /** @internal type navigation helper, not in runtime. */
+  protected declare static __types: {
+    api: {
+      input: HttpLabelCommandInput;
+      output: {};
+    };
+    sdk: {
+      input: HttpLabelCommandCommandInput;
+      output: HttpLabelCommandCommandOutput;
+    };
+  };
+}

--- a/private/my-local-model-schema/src/commands/index.ts
+++ b/private/my-local-model-schema/src/commands/index.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
 export * from "./CamelCaseOperationCommand";
 export * from "./GetNumbersCommand";
+export * from "./HttpLabelCommandCommand";
 export * from "./TradeEventStreamCommand";

--- a/private/my-local-model-schema/src/models/models_0.ts
+++ b/private/my-local-model-schema/src/models/models_0.ts
@@ -4,6 +4,18 @@ import type { NumericValue } from "@smithy/core/serde";
 /**
  * @public
  */
+export interface HttpLabelCommandInput {
+  LabelDoesNotApplyToRpcProtocol: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface HttpLabelCommandOutput {}
+
+/**
+ * @public
+ */
 export interface Alpha {
   id?: string | undefined;
   timestamp?: Date | undefined;

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -4,6 +4,10 @@ const _GN = "GetNumbers";
 const _GNR = "GetNumbersRequest";
 const _GNRe = "GetNumbersResponse";
 const _HE = "HaltError";
+const _HLC = "HttpLabelCommand";
+const _HLCI = "HttpLabelCommandInput";
+const _HLCO = "HttpLabelCommandOutput";
+const _LDNATRP = "LabelDoesNotApplyToRpcProtocol";
 const _MSLE = "MainServiceLinkedError";
 const _MTE = "MysteryThrottlingError";
 const _RE = "RetryableError";
@@ -25,6 +29,7 @@ const _eS = "eventStream";
 const _fWM = "fieldWithoutMessage";
 const _fWMi = "fieldWithMessage";
 const _g = "gamma";
+const _h = "http";
 const _hE = "httpError";
 const _i = "id";
 const _mR = "maxResults";
@@ -36,7 +41,8 @@ const _sT = "startToken";
 const _st = "streaming";
 const _t = "timestamp";
 const _to = "token";
-const n0 = "org.xyz.v1";
+const n0 = "org.xyz.secondary";
+const n1 = "org.xyz.v1";
 
 // smithy-typescript generated code
 import { TypeRegistry } from "@smithy/core/schema";
@@ -59,93 +65,106 @@ import {
 import { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 
 /* eslint no-var: 0 */
-export var Alpha$: StaticStructureSchema = [3, n0, _A,
+export var HttpLabelCommandInput$: StaticStructureSchema = [3, n0, _HLCI,
+  0,
+  [_LDNATRP],
+  [[0, 1]], 1
+];
+export var HttpLabelCommandOutput$: StaticStructureSchema = [3, n0, _HLCO,
+  0,
+  [],
+  []
+];
+export var Alpha$: StaticStructureSchema = [3, n1, _A,
   0,
   [_i, _t],
   [0, 4]
 ];
-export var camelCaseOperationInput$: StaticStructureSchema = [3, n0, _cCOI,
+export var camelCaseOperationInput$: StaticStructureSchema = [3, n1, _cCOI,
   0,
   [_to],
   [0]
 ];
-export var camelCaseOperationOutput$: StaticStructureSchema = [3, n0, _cCOO,
+export var camelCaseOperationOutput$: StaticStructureSchema = [3, n1, _cCOO,
   0,
   [_to, _r],
   [0, 64 | 21]
 ];
-export var CodedThrottlingError$: StaticErrorSchema = [-3, n0, _CTE,
+export var CodedThrottlingError$: StaticErrorSchema = [-3, n1, _CTE,
   { [_e]: _c, [_hE]: 429 },
   [],
   []
 ];
-TypeRegistry.for(n0).registerError(CodedThrottlingError$, CodedThrottlingError);
-export var GetNumbersRequest$: StaticStructureSchema = [3, n0, _GNR,
+TypeRegistry.for(n1).registerError(CodedThrottlingError$, CodedThrottlingError);
+export var GetNumbersRequest$: StaticStructureSchema = [3, n1, _GNR,
   0,
   [_bD, _bI, _fWM, _fWMi, _sT, _mR],
   [19, 17, 0, 0, 0, 1]
 ];
-export var GetNumbersResponse$: StaticStructureSchema = [3, n0, _GNRe,
+export var GetNumbersResponse$: StaticStructureSchema = [3, n1, _GNRe,
   0,
   [_bD, _bI, _n, _nT],
   [19, 17, 64 | 1, 0]
 ];
-export var HaltError$: StaticErrorSchema = [-3, n0, _HE,
+export var HaltError$: StaticErrorSchema = [-3, n1, _HE,
   { [_e]: _c },
   [],
   []
 ];
-TypeRegistry.for(n0).registerError(HaltError$, HaltError);
-export var MainServiceLinkedError$: StaticErrorSchema = [-3, n0, _MSLE,
+TypeRegistry.for(n1).registerError(HaltError$, HaltError);
+export var MainServiceLinkedError$: StaticErrorSchema = [-3, n1, _MSLE,
   { [_e]: _c, [_hE]: 400 },
   [],
   []
 ];
-TypeRegistry.for(n0).registerError(MainServiceLinkedError$, MainServiceLinkedError);
-export var MysteryThrottlingError$: StaticErrorSchema = [-3, n0, _MTE,
+TypeRegistry.for(n1).registerError(MainServiceLinkedError$, MainServiceLinkedError);
+export var MysteryThrottlingError$: StaticErrorSchema = [-3, n1, _MTE,
   { [_e]: _c },
   [],
   []
 ];
-TypeRegistry.for(n0).registerError(MysteryThrottlingError$, MysteryThrottlingError);
-export var RetryableError$: StaticErrorSchema = [-3, n0, _RE,
+TypeRegistry.for(n1).registerError(MysteryThrottlingError$, MysteryThrottlingError);
+export var RetryableError$: StaticErrorSchema = [-3, n1, _RE,
   { [_e]: _c },
   [],
   []
 ];
-TypeRegistry.for(n0).registerError(RetryableError$, RetryableError);
-export var TradeEventStreamRequest$: StaticStructureSchema = [3, n0, _TESR,
+TypeRegistry.for(n1).registerError(RetryableError$, RetryableError);
+export var TradeEventStreamRequest$: StaticStructureSchema = [3, n1, _TESR,
   0,
   [_eS],
   [[() => TradeEvents$, 0]]
 ];
-export var TradeEventStreamResponse$: StaticStructureSchema = [3, n0, _TESRr,
+export var TradeEventStreamResponse$: StaticStructureSchema = [3, n1, _TESRr,
   0,
   [_eS],
   [[() => TradeEvents$, 0]]
 ];
-export var XYZServiceServiceException$: StaticErrorSchema = [-3, n0, _XYZSSE,
+export var XYZServiceServiceException$: StaticErrorSchema = [-3, n1, _XYZSSE,
   { [_e]: _c },
   [],
   []
 ];
-TypeRegistry.for(n0).registerError(XYZServiceServiceException$, XYZServiceServiceException);
+TypeRegistry.for(n1).registerError(XYZServiceServiceException$, XYZServiceServiceException);
 var __Unit = "unit" as const;
 export var XYZServiceSyntheticServiceException$: StaticErrorSchema = [-3, _s, "XYZServiceSyntheticServiceException", 0, [], []];
 TypeRegistry.for(_s).registerError(XYZServiceSyntheticServiceException$, XYZServiceSyntheticServiceException);
 var Blobs = 64 | 21;
 var IntegerList = 64 | 1;
-export var TradeEvents$: StaticUnionSchema = [4, n0, _TE,
+export var TradeEvents$: StaticUnionSchema = [4, n1, _TE,
   { [_st]: 1 },
   [_a, _b, _g],
   [() => Alpha$, () => __Unit, () => __Unit]
 ];
-export var camelCaseOperation$: StaticOperationSchema = [9, n0, _cCO,
-  0, () => camelCaseOperationInput$, () => camelCaseOperationOutput$
+export var HttpLabelCommand$: StaticOperationSchema = [9, n0, _HLC,
+  { [_h]: ["POST", "/{LabelDoesNotApplyToRpcProtocol}", 200] }, () => HttpLabelCommandInput$, () => HttpLabelCommandOutput$
 ];
-export var GetNumbers$: StaticOperationSchema = [9, n0, _GN,
-  0, () => GetNumbersRequest$, () => GetNumbersResponse$
+export var camelCaseOperation$: StaticOperationSchema = [9, n1, _cCO,
+  { [_h]: ["POST", "/camel-case", 200] }, () => camelCaseOperationInput$, () => camelCaseOperationOutput$
 ];
-export var TradeEventStream$: StaticOperationSchema = [9, n0, _TES,
-  0, () => TradeEventStreamRequest$, () => TradeEventStreamResponse$
+export var GetNumbers$: StaticOperationSchema = [9, n1, _GN,
+  { [_h]: ["POST", "/get-numbers", 200] }, () => GetNumbersRequest$, () => GetNumbersResponse$
+];
+export var TradeEventStream$: StaticOperationSchema = [9, n1, _TES,
+  { [_h]: ["POST", "/trade-event-stream", 200] }, () => TradeEventStreamRequest$, () => TradeEventStreamResponse$
 ];

--- a/private/my-local-model-schema/test/functional/rpcv2cbor.spec.ts
+++ b/private/my-local-model-schema/test/functional/rpcv2cbor.spec.ts
@@ -2,6 +2,7 @@
 import { afterAll, expect, test as it } from "vitest";
 
 import { GetNumbersCommand } from "../../src/commands/GetNumbersCommand";
+import { HttpLabelCommandCommand } from "../../src/commands/HttpLabelCommandCommand";
 import { XYZServiceClient } from "../../src/XYZServiceClient";
 import type { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
 import { type HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
@@ -273,6 +274,33 @@ function vizBenchmark({ name, p95, n, timings }: { name: string, p95: number, n:
   console.info(line + ` > ${(decile * (d - 1)) | 0}`);
   console.info("=".repeat(80));
 }
+
+it("HttpLabelCommandExample:Response", async () => {
+  const client = new XYZServiceClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "smithy-protocol": "rpc-v2-cbor",
+      }
+    ),
+  });
+
+  const params: any = {
+    LabelDoesNotApplyToRpcProtocol: "placeholder",
+  };
+  const command = new HttpLabelCommandCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r.$metadata.httpStatusCode).toBe(200);
+});
 
 it("GetNumbersRequestExample:SerdeBenchmark:Request", async () => {
   const client = new XYZServiceClient({

--- a/private/my-local-model-schema/test/index-objects.spec.mjs
+++ b/private/my-local-model-schema/test/index-objects.spec.mjs
@@ -12,6 +12,10 @@ import {
   GetNumbersResponse$,
   HaltError,
   HaltError$,
+  HttpLabelCommand$,
+  HttpLabelCommandCommand,
+  HttpLabelCommandInput$,
+  HttpLabelCommandOutput$,
   MainServiceLinkedError,
   MainServiceLinkedError$,
   MysteryThrottlingError,
@@ -38,6 +42,8 @@ import assert from "node:assert";
 assert(typeof XYZServiceClient === "function");
 assert(typeof XYZService === "function");
 // commands
+assert(typeof HttpLabelCommandCommand === "function");
+assert(typeof HttpLabelCommand$ === "object");
 assert(typeof CamelCaseOperationCommand === "function");
 assert(typeof camelCaseOperation$ === "object");
 assert(typeof GetNumbersCommand === "function");
@@ -45,6 +51,8 @@ assert(typeof GetNumbers$ === "object");
 assert(typeof TradeEventStreamCommand === "function");
 assert(typeof TradeEventStream$ === "object");
 // structural schemas
+assert(typeof HttpLabelCommandInput$ === "object");
+assert(typeof HttpLabelCommandOutput$ === "object");
 assert(typeof Alpha$ === "object");
 assert(typeof camelCaseOperationInput$ === "object");
 assert(typeof camelCaseOperationOutput$ === "object");

--- a/private/my-local-model-schema/test/index-types.ts
+++ b/private/my-local-model-schema/test/index-types.ts
@@ -2,6 +2,9 @@
 export type {
   XYZServiceClient,
   XYZService,
+  HttpLabelCommandCommand,
+  HttpLabelCommandCommandInput,
+  HttpLabelCommandCommandOutput,
   CamelCaseOperationCommand,
   CamelCaseOperationCommandInput,
   CamelCaseOperationCommandOutput,
@@ -11,6 +14,8 @@ export type {
   TradeEventStreamCommand,
   TradeEventStreamCommandInput,
   TradeEventStreamCommandOutput,
+  HttpLabelCommandInput,
+  HttpLabelCommandOutput,
   Alpha,
   CamelCaseOperationInput,
   CamelCaseOperationOutput,

--- a/private/my-local-model/src/XYZService.ts
+++ b/private/my-local-model/src/XYZService.ts
@@ -15,6 +15,11 @@ import {
 } from "./commands/CamelCaseOperationCommand";
 import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
 import {
+  HttpLabelCommandCommand,
+  HttpLabelCommandCommandInput,
+  HttpLabelCommandCommandOutput,
+} from "./commands/HttpLabelCommandCommand";
+import {
   TradeEventStreamCommand,
   TradeEventStreamCommandInput,
   TradeEventStreamCommandOutput,
@@ -25,6 +30,7 @@ import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
+  HttpLabelCommandCommand,
   CamelCaseOperationCommand,
   GetNumbersCommand,
   TradeEventStreamCommand,
@@ -38,6 +44,23 @@ const waiters = {
 };
 
 export interface XYZService {
+  /**
+   * @see {@link HttpLabelCommandCommand}
+   */
+  httpLabelCommand(
+    args: HttpLabelCommandCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<HttpLabelCommandCommandOutput>;
+  httpLabelCommand(
+    args: HttpLabelCommandCommandInput,
+    cb: (err: any, data?: HttpLabelCommandCommandOutput) => void
+  ): void;
+  httpLabelCommand(
+    args: HttpLabelCommandCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: HttpLabelCommandCommandOutput) => void
+  ): void;
+
   /**
    * @see {@link CamelCaseOperationCommand}
    */

--- a/private/my-local-model/src/XYZServiceClient.ts
+++ b/private/my-local-model/src/XYZServiceClient.ts
@@ -51,6 +51,7 @@ import {
 } from "./auth/httpAuthSchemeProvider";
 import { CamelCaseOperationCommandInput, CamelCaseOperationCommandOutput } from "./commands/CamelCaseOperationCommand";
 import { GetNumbersCommandInput, GetNumbersCommandOutput } from "./commands/GetNumbersCommand";
+import { HttpLabelCommandCommandInput, HttpLabelCommandCommandOutput } from "./commands/HttpLabelCommandCommand";
 import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "./commands/TradeEventStreamCommand";
 import {
   type ClientInputEndpointParameters,
@@ -69,6 +70,7 @@ export { __Client };
 export type ServiceInputTypes =
   | CamelCaseOperationCommandInput
   | GetNumbersCommandInput
+  | HttpLabelCommandCommandInput
   | TradeEventStreamCommandInput;
 
 /**
@@ -77,6 +79,7 @@ export type ServiceInputTypes =
 export type ServiceOutputTypes =
   | CamelCaseOperationCommandOutput
   | GetNumbersCommandOutput
+  | HttpLabelCommandCommandOutput
   | TradeEventStreamCommandOutput;
 
 /**

--- a/private/my-local-model/src/commands/HttpLabelCommandCommand.ts
+++ b/private/my-local-model/src/commands/HttpLabelCommandCommand.ts
@@ -1,0 +1,95 @@
+// smithy-typescript generated code
+import { getEndpointPlugin } from "@smithy/middleware-endpoint";
+import { getSerdePlugin } from "@smithy/middleware-serde";
+import { Command as $Command } from "@smithy/smithy-client";
+import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
+
+import { commonParams } from "../endpoint/EndpointParameters";
+import type { HttpLabelCommandInput, HttpLabelCommandOutput } from "../models/models_0";
+import { de_HttpLabelCommandCommand, se_HttpLabelCommandCommand } from "../protocols/Rpcv2cbor";
+import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
+
+/**
+ * @public
+ */
+export type { __MetadataBearer };
+export { $Command };
+/**
+ * @public
+ *
+ * The input for {@link HttpLabelCommandCommand}.
+ */
+export interface HttpLabelCommandCommandInput extends HttpLabelCommandInput {}
+/**
+ * @public
+ *
+ * The output of {@link HttpLabelCommandCommand}.
+ */
+export interface HttpLabelCommandCommandOutput extends HttpLabelCommandOutput, __MetadataBearer {}
+
+/**
+ * @public
+ *
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { XYZServiceClient, HttpLabelCommandCommand } from "xyz"; // ES Modules import
+ * // const { XYZServiceClient, HttpLabelCommandCommand } = require("xyz"); // CommonJS import
+ * // import type { XYZServiceClientConfig } from "xyz";
+ * const config = {}; // type is XYZServiceClientConfig
+ * const client = new XYZServiceClient(config);
+ * const input = { // HttpLabelCommandInput
+ *   LabelDoesNotApplyToRpcProtocol: "STRING_VALUE", // required
+ * };
+ * const command = new HttpLabelCommandCommand(input);
+ * const response = await client.send(command);
+ * // {};
+ *
+ * ```
+ *
+ * @param HttpLabelCommandCommandInput - {@link HttpLabelCommandCommandInput}
+ * @returns {@link HttpLabelCommandCommandOutput}
+ * @see {@link HttpLabelCommandCommandInput} for command's `input` shape.
+ * @see {@link HttpLabelCommandCommandOutput} for command's `response` shape.
+ * @see {@link XYZServiceClientResolvedConfig | config} for XYZServiceClient's `config` shape.
+ *
+ * @throws {@link MainServiceLinkedError} (client fault)
+ *
+ * @throws {@link XYZServiceSyntheticServiceException}
+ * <p>Base exception class for all service exceptions from XYZService service.</p>
+ *
+ *
+ */
+export class HttpLabelCommandCommand extends $Command
+  .classBuilder<
+    HttpLabelCommandCommandInput,
+    HttpLabelCommandCommandOutput,
+    XYZServiceClientResolvedConfig,
+    ServiceInputTypes,
+    ServiceOutputTypes
+  >()
+  .ep(commonParams)
+  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+    ];
+  })
+  .s("XYZService", "HttpLabelCommand", {})
+  .n("XYZServiceClient", "HttpLabelCommandCommand")
+  .f(void 0, void 0)
+  .ser(se_HttpLabelCommandCommand)
+  .de(de_HttpLabelCommandCommand)
+  .build() {
+  /** @internal type navigation helper, not in runtime. */
+  protected declare static __types: {
+    api: {
+      input: HttpLabelCommandInput;
+      output: {};
+    };
+    sdk: {
+      input: HttpLabelCommandCommandInput;
+      output: HttpLabelCommandCommandOutput;
+    };
+  };
+}

--- a/private/my-local-model/src/commands/index.ts
+++ b/private/my-local-model/src/commands/index.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
 export * from "./CamelCaseOperationCommand";
 export * from "./GetNumbersCommand";
+export * from "./HttpLabelCommandCommand";
 export * from "./TradeEventStreamCommand";

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -4,6 +4,18 @@ import { NumericValue } from "@smithy/core/serde";
 /**
  * @public
  */
+export interface HttpLabelCommandInput {
+  LabelDoesNotApplyToRpcProtocol: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface HttpLabelCommandOutput {}
+
+/**
+ * @public
+ */
 export interface Alpha {
   id?: string | undefined;
   timestamp?: Date | undefined;

--- a/private/my-local-model/src/protocols/Rpcv2cbor.ts
+++ b/private/my-local-model/src/protocols/Rpcv2cbor.ts
@@ -32,6 +32,7 @@ import type {
 
 import { CamelCaseOperationCommandInput, CamelCaseOperationCommandOutput } from "../commands/CamelCaseOperationCommand";
 import { GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
+import { HttpLabelCommandCommandInput, HttpLabelCommandCommandOutput } from "../commands/HttpLabelCommandCommand";
 import { TradeEventStreamCommandInput, TradeEventStreamCommandOutput } from "../commands/TradeEventStreamCommand";
 import {
   CodedThrottlingError,
@@ -47,10 +48,24 @@ import {
   CamelCaseOperationOutput,
   GetNumbersRequest,
   GetNumbersResponse,
+  HttpLabelCommandInput,
   TradeEvents,
   Unit,
 } from "../models/models_0";
 import { XYZServiceSyntheticServiceException as __BaseException } from "../models/XYZServiceSyntheticServiceException";
+
+/**
+ * serializeRpcv2cborHttpLabelCommandCommand
+ */
+export const se_HttpLabelCommandCommand = async (
+  input: HttpLabelCommandCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const headers: __HeaderBag = SHARED_HEADERS;
+  let body: any;
+  body = cbor.serialize(_json(input));
+  return buildHttpRpcRequest(context, headers, "/service/XYZService/operation/HttpLabelCommand", undefined, body);
+};
 
 /**
  * serializeRpcv2cborCamelCaseOperationCommand
@@ -93,6 +108,28 @@ export const se_TradeEventStreamCommand = async (
   let body: any;
   body = se_TradeEvents(input.eventStream, context);
   return buildHttpRpcRequest(context, headers, "/service/XYZService/operation/TradeEventStream", undefined, body);
+};
+
+/**
+ * deserializeRpcv2cborHttpLabelCommandCommand
+ */
+export const de_HttpLabelCommandCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<HttpLabelCommandCommandOutput> => {
+  cr(output);
+  if (output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+
+  const data: any = await parseBody(output.body, context)
+  let contents: any = {};
+  contents = _json(data);
+  const response: HttpLabelCommandCommandOutput = {
+    $metadata: deserializeMetadata(output), ...contents,
+  };
+  return response;
+
 };
 
 /**
@@ -386,6 +423,8 @@ const se_Alpha_event = (
       Object.assign(contents, _json(data));
       return contents;
     }
+    // se_HttpLabelCommandInput omitted.
+
     /**
      * serializeRpcv2cborAlpha
      */
@@ -419,6 +458,8 @@ const se_Alpha_event = (
     }
 
     // se_Unit omitted.
+
+    // de_HttpLabelCommandOutput omitted.
 
     /**
      * deserializeRpcv2cborAlpha

--- a/private/my-local-model/test/functional/rpcv2cbor.spec.ts
+++ b/private/my-local-model/test/functional/rpcv2cbor.spec.ts
@@ -2,6 +2,7 @@
 import { afterAll, expect, test as it } from "vitest";
 
 import { GetNumbersCommand } from "../../src/commands/GetNumbersCommand";
+import { HttpLabelCommandCommand } from "../../src/commands/HttpLabelCommandCommand";
 import { XYZServiceClient } from "../../src/XYZServiceClient";
 import type { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
 import { type HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
@@ -273,6 +274,33 @@ function vizBenchmark({ name, p95, n, timings }: { name: string, p95: number, n:
   console.info(line + ` > ${(decile * (d - 1)) | 0}`);
   console.info("=".repeat(80));
 }
+
+it("HttpLabelCommandExample:Response", async () => {
+  const client = new XYZServiceClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "smithy-protocol": "rpc-v2-cbor",
+      }
+    ),
+  });
+
+  const params: any = {
+    LabelDoesNotApplyToRpcProtocol: "placeholder",
+  };
+  const command = new HttpLabelCommandCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r.$metadata.httpStatusCode).toBe(200);
+});
 
 it("GetNumbersRequestExample:SerdeBenchmark:Request", async () => {
   const client = new XYZServiceClient({

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/HttpLabelCommand.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/HttpLabelCommand.smithy
@@ -1,0 +1,25 @@
+$version: "2.0"
+
+namespace org.xyz.secondary
+
+use smithy.protocols#rpcv2Cbor
+use smithy.test#httpResponseTests
+
+@httpResponseTests([
+    {
+        id: "HttpLabelCommandExample"
+        protocol: rpcv2Cbor
+        code: 200
+        headers: { "smithy-protocol": "rpc-v2-cbor" }
+    }
+])
+@http(method: "POST", uri: "/{LabelDoesNotApplyToRpcProtocol}", code: 200)
+operation HttpLabelCommand {
+    input := {
+        @httpLabel
+        @required
+        LabelDoesNotApplyToRpcProtocol: String
+    }
+
+    output := {}
+}

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
@@ -2,6 +2,7 @@ $version: "2.0"
 
 namespace org.xyz.v1
 
+use org.xyz.secondary#HttpLabelCommand
 use smithy.protocols#rpcv2Cbor
 use smithy.rules#clientContextParams
 use smithy.rules#endpointRuleSet
@@ -71,6 +72,7 @@ service XYZService {
         GetNumbers
         TradeEventStream
         camelCaseOperation
+        HttpLabelCommand
     ]
     errors: [
         MainServiceLinkedError
@@ -108,7 +110,6 @@ structure MainServiceLinkedError {}
         protocol: "smithy.protocols#rpcv2Cbor"
         method: "POST"
         uri: "/service/XYZService/operation/GetNumbers"
-        params: {}
         tags: ["serde-benchmark"]
     }
 ])
@@ -121,6 +122,7 @@ structure MainServiceLinkedError {}
         tags: ["serde-benchmark"]
     }
 ])
+@http(method: "POST", uri: "/get-numbers", code: 200)
 operation GetNumbers {
     input: GetNumbersRequest
     output: GetNumbersResponse
@@ -183,6 +185,7 @@ structure HaltError {}
 @error("client")
 structure XYZServiceServiceException {}
 
+@http(method: "POST", uri: "/trade-event-stream", code: 200)
 operation TradeEventStream {
     input: TradeEventStreamRequest
     output: TradeEventStreamResponse
@@ -220,6 +223,7 @@ service UnusedService {
     ]
 }
 
+@http(method: "POST", uri: "/unused", code: 200)
 operation UnusedOperation {
     input: Unit
     output: Unit
@@ -242,6 +246,7 @@ structure CompletelyUnlinkedError {}
 
 @paginated(inputToken: "token", outputToken: "token", items: "results")
 @readonly
+@http(method: "POST", uri: "/camel-case", code: 200)
 operation camelCaseOperation {
     input := {
         token: String


### PR DESCRIPTION
This change generates placeholder values for http label (https://smithy.io/2.0/spec/http-bindings.html#httplabel-trait) bindings in protocol tests.

The lack of a placeholder will cause the client-side validation to fail. 