### PR TITLE
fix(node-http-handler): avoid calling httpRequest.end() with empty Buffer

### DIFF
--- a/.changeset/bright-ladybugs-burn.md
+++ b/.changeset/bright-ladybugs-burn.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+write request.end() with no arg if empty buffer

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -80,8 +80,16 @@ function writeBody(
   }
 
   if (body) {
-    if (Buffer.isBuffer(body) || typeof body === "string") {
-      httpRequest.end(body);
+    const isBuffer = Buffer.isBuffer(body);
+    const isString = typeof body === "string";
+    if (isBuffer || isString) {
+      // https://github.com/aws/aws-sdk-js-v3/issues/6426
+      // describes why we don't send an empty Buffer.
+      if (isBuffer && body.byteLength === 0) {
+        httpRequest.end();
+      } else {
+        httpRequest.end(body);
+      }
       return;
     }
 


### PR DESCRIPTION
- ~~deferred load for node:http (https://github.com/aws/aws-sdk-js-v3/issues/6914)~~
  - this change was backed out of this PR
- avoid empty buffers to httpRequest.end() (https://github.com/aws/aws-sdk-js-v3/issues/6426)
- rewrite some super sketchy tests from https://github.com/smithy-lang/smithy-typescript/pull/1636
