### PR TITLE
fix(core/protocols): create composite type registry on protocol instances

### DIFF
--- a/.changeset/slimy-seals-hug.md
+++ b/.changeset/slimy-seals-hug.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+compose error TypeRegistry on protocol

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
@@ -1,4 +1,5 @@
 import { op } from "@smithy/core/schema";
+import { type TypeRegistry } from "@smithy/core/schema";
 import { streamCollector } from "@smithy/node-http-handler";
 import { HttpResponse } from "@smithy/protocol-http";
 import type {
@@ -33,9 +34,21 @@ describe(HttpBindingProtocol.name, () => {
     protected serializer: ShapeSerializer<string | Uint8Array>;
     protected deserializer: ShapeDeserializer<string | Uint8Array>;
 
-    public constructor() {
-      super({
+    public constructor(
+      {
+        defaultNamespace = "",
+        errorTypeRegistries = [],
+      }: {
+        defaultNamespace: string;
+        errorTypeRegistries?: TypeRegistry[];
+      } = {
         defaultNamespace: "",
+        errorTypeRegistries: [],
+      }
+    ) {
+      super({
+        defaultNamespace,
+        errorTypeRegistries,
       });
       const settings: CodecSettings = {
         timestampFormat: {

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
@@ -1,4 +1,4 @@
-import { NormalizedSchema, translateTraits } from "@smithy/core/schema";
+import { NormalizedSchema, translateTraits, type TypeRegistry } from "@smithy/core/schema";
 import { splitEvery, splitHeader } from "@smithy/core/serde";
 import { HttpRequest } from "@smithy/protocol-http";
 import type {
@@ -27,6 +27,11 @@ import { HttpProtocol } from "./HttpProtocol";
  * @public
  */
 export abstract class HttpBindingProtocol extends HttpProtocol {
+  /**
+   * @override
+   */
+  protected declare compositeErrorRegistry: TypeRegistry;
+
   public async serializeRequest<Input extends object>(
     operationSchema: OperationSchema,
     _input: Input,

--- a/packages/core/src/submodules/protocols/RpcProtocol.ts
+++ b/packages/core/src/submodules/protocols/RpcProtocol.ts
@@ -1,4 +1,4 @@
-import { NormalizedSchema } from "@smithy/core/schema";
+import { type TypeRegistry, NormalizedSchema } from "@smithy/core/schema";
 import { HttpRequest } from "@smithy/protocol-http";
 import type {
   DocumentSchema,
@@ -21,6 +21,11 @@ import { HttpProtocol } from "./HttpProtocol";
  * @public
  */
 export abstract class RpcProtocol extends HttpProtocol {
+  /**
+   * @override
+   */
+  protected declare compositeErrorRegistry: TypeRegistry;
+
   public async serializeRequest<Input extends object>(
     operationSchema: OperationSchema,
     input: Input,

--- a/private/my-local-model-schema/src/runtimeConfig.shared.ts
+++ b/private/my-local-model-schema/src/runtimeConfig.shared.ts
@@ -9,6 +9,7 @@ import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 
 import { defaultXYZServiceHttpAuthSchemeProvider } from "./auth/httpAuthSchemeProvider";
 import { defaultEndpointResolver } from "./endpoint/endpointResolver";
+import { errorTypeRegistries } from "./schemas/schemas_0";
 import type { XYZServiceClientConfig } from "./XYZServiceClient";
 
 /**
@@ -35,6 +36,7 @@ export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
     protocol: config?.protocol ?? SmithyRpcV2CborProtocol,
     protocolSettings: config?.protocolSettings ?? {
       defaultNamespace: "org.xyz.v1",
+      errorTypeRegistries,
     },
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -41,8 +41,8 @@ const _sT = "startToken";
 const _st = "streaming";
 const _t = "timestamp";
 const _to = "token";
-const n0 = "org.xyz.secondary";
-const n1 = "org.xyz.v1";
+const n0 = "org.xyz.v1";
+const n1 = "org.xyz.secondary";
 
 // smithy-typescript generated code
 import { TypeRegistry } from "@smithy/core/schema";
@@ -65,106 +65,117 @@ import {
 import { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 
 /* eslint no-var: 0 */
-export var HttpLabelCommandInput$: StaticStructureSchema = [3, n0, _HLCI,
-  0,
-  [_LDNATRP],
-  [[0, 1]], 1
-];
-export var HttpLabelCommandOutput$: StaticStructureSchema = [3, n0, _HLCO,
-  0,
-  [],
-  []
-];
-export var Alpha$: StaticStructureSchema = [3, n1, _A,
-  0,
-  [_i, _t],
-  [0, 4]
-];
-export var camelCaseOperationInput$: StaticStructureSchema = [3, n1, _cCOI,
-  0,
-  [_to],
-  [0]
-];
-export var camelCaseOperationOutput$: StaticStructureSchema = [3, n1, _cCOO,
-  0,
-  [_to, _r],
-  [0, 64 | 21]
-];
-export var CodedThrottlingError$: StaticErrorSchema = [-3, n1, _CTE,
+const _s_registry = TypeRegistry.for(_s);
+export var XYZServiceSyntheticServiceException$: StaticErrorSchema = [-3, _s, "XYZServiceSyntheticServiceException", 0, [], []];
+_s_registry.registerError(XYZServiceSyntheticServiceException$, XYZServiceSyntheticServiceException);
+const n0_registry = TypeRegistry.for(n0);
+export var CodedThrottlingError$: StaticErrorSchema = [-3, n0, _CTE,
   { [_e]: _c, [_hE]: 429 },
   [],
   []
 ];
-TypeRegistry.for(n1).registerError(CodedThrottlingError$, CodedThrottlingError);
-export var GetNumbersRequest$: StaticStructureSchema = [3, n1, _GNR,
-  0,
-  [_bD, _bI, _fWM, _fWMi, _sT, _mR],
-  [19, 17, 0, 0, 0, 1]
-];
-export var GetNumbersResponse$: StaticStructureSchema = [3, n1, _GNRe,
-  0,
-  [_bD, _bI, _n, _nT],
-  [19, 17, 64 | 1, 0]
-];
-export var HaltError$: StaticErrorSchema = [-3, n1, _HE,
+n0_registry.registerError(CodedThrottlingError$, CodedThrottlingError);
+export var HaltError$: StaticErrorSchema = [-3, n0, _HE,
   { [_e]: _c },
   [],
   []
 ];
-TypeRegistry.for(n1).registerError(HaltError$, HaltError);
-export var MainServiceLinkedError$: StaticErrorSchema = [-3, n1, _MSLE,
+n0_registry.registerError(HaltError$, HaltError);
+export var MainServiceLinkedError$: StaticErrorSchema = [-3, n0, _MSLE,
   { [_e]: _c, [_hE]: 400 },
   [],
   []
 ];
-TypeRegistry.for(n1).registerError(MainServiceLinkedError$, MainServiceLinkedError);
-export var MysteryThrottlingError$: StaticErrorSchema = [-3, n1, _MTE,
+n0_registry.registerError(MainServiceLinkedError$, MainServiceLinkedError);
+export var MysteryThrottlingError$: StaticErrorSchema = [-3, n0, _MTE,
   { [_e]: _c },
   [],
   []
 ];
-TypeRegistry.for(n1).registerError(MysteryThrottlingError$, MysteryThrottlingError);
-export var RetryableError$: StaticErrorSchema = [-3, n1, _RE,
+n0_registry.registerError(MysteryThrottlingError$, MysteryThrottlingError);
+export var RetryableError$: StaticErrorSchema = [-3, n0, _RE,
   { [_e]: _c },
   [],
   []
 ];
-TypeRegistry.for(n1).registerError(RetryableError$, RetryableError);
-export var TradeEventStreamRequest$: StaticStructureSchema = [3, n1, _TESR,
+n0_registry.registerError(RetryableError$, RetryableError);
+export var XYZServiceServiceException$: StaticErrorSchema = [-3, n0, _XYZSSE,
+  { [_e]: _c },
+  [],
+  []
+];
+n0_registry.registerError(XYZServiceServiceException$, XYZServiceServiceException);
+/**
+ * TypeRegistry instances containing modeled errors.
+ * @internal
+ *
+ */
+export const errorTypeRegistries = [
+  _s_registry,
+  n0_registry,
+]
+export var HttpLabelCommandInput$: StaticStructureSchema = [3, n1, _HLCI,
+  0,
+  [_LDNATRP],
+  [[0, 1]], 1
+];
+export var HttpLabelCommandOutput$: StaticStructureSchema = [3, n1, _HLCO,
+  0,
+  [],
+  []
+];
+export var Alpha$: StaticStructureSchema = [3, n0, _A,
+  0,
+  [_i, _t],
+  [0, 4]
+];
+export var camelCaseOperationInput$: StaticStructureSchema = [3, n0, _cCOI,
+  0,
+  [_to],
+  [0]
+];
+export var camelCaseOperationOutput$: StaticStructureSchema = [3, n0, _cCOO,
+  0,
+  [_to, _r],
+  [0, 64 | 21]
+];
+export var GetNumbersRequest$: StaticStructureSchema = [3, n0, _GNR,
+  0,
+  [_bD, _bI, _fWM, _fWMi, _sT, _mR],
+  [19, 17, 0, 0, 0, 1]
+];
+export var GetNumbersResponse$: StaticStructureSchema = [3, n0, _GNRe,
+  0,
+  [_bD, _bI, _n, _nT],
+  [19, 17, 64 | 1, 0]
+];
+export var TradeEventStreamRequest$: StaticStructureSchema = [3, n0, _TESR,
   0,
   [_eS],
   [[() => TradeEvents$, 0]]
 ];
-export var TradeEventStreamResponse$: StaticStructureSchema = [3, n1, _TESRr,
+export var TradeEventStreamResponse$: StaticStructureSchema = [3, n0, _TESRr,
   0,
   [_eS],
   [[() => TradeEvents$, 0]]
 ];
-export var XYZServiceServiceException$: StaticErrorSchema = [-3, n1, _XYZSSE,
-  { [_e]: _c },
-  [],
-  []
-];
-TypeRegistry.for(n1).registerError(XYZServiceServiceException$, XYZServiceServiceException);
 var __Unit = "unit" as const;
-export var XYZServiceSyntheticServiceException$: StaticErrorSchema = [-3, _s, "XYZServiceSyntheticServiceException", 0, [], []];
-TypeRegistry.for(_s).registerError(XYZServiceSyntheticServiceException$, XYZServiceSyntheticServiceException);
 var Blobs = 64 | 21;
 var IntegerList = 64 | 1;
-export var TradeEvents$: StaticUnionSchema = [4, n1, _TE,
+export var TradeEvents$: StaticUnionSchema = [4, n0, _TE,
   { [_st]: 1 },
   [_a, _b, _g],
   [() => Alpha$, () => __Unit, () => __Unit]
 ];
-export var HttpLabelCommand$: StaticOperationSchema = [9, n0, _HLC,
+export var HttpLabelCommand$: StaticOperationSchema = [9, n1, _HLC,
   { [_h]: ["POST", "/{LabelDoesNotApplyToRpcProtocol}", 200] }, () => HttpLabelCommandInput$, () => HttpLabelCommandOutput$
 ];
-export var camelCaseOperation$: StaticOperationSchema = [9, n1, _cCO,
+export var camelCaseOperation$: StaticOperationSchema = [9, n0, _cCO,
   { [_h]: ["POST", "/camel-case", 200] }, () => camelCaseOperationInput$, () => camelCaseOperationOutput$
 ];
-export var GetNumbers$: StaticOperationSchema = [9, n1, _GN,
+export var GetNumbers$: StaticOperationSchema = [9, n0, _GN,
   { [_h]: ["POST", "/get-numbers", 200] }, () => GetNumbersRequest$, () => GetNumbersResponse$
 ];
-export var TradeEventStream$: StaticOperationSchema = [9, n1, _TES,
+export var TradeEventStream$: StaticOperationSchema = [9, n0, _TES,
   { [_h]: ["POST", "/trade-event-stream", 200] }, () => TradeEventStreamRequest$, () => TradeEventStreamResponse$
 ];

--- a/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.shared.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.shared.ts
@@ -10,6 +10,7 @@ import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 import { defaultRpcV2ProtocolHttpAuthSchemeProvider } from "./auth/httpAuthSchemeProvider";
 import { defaultEndpointResolver } from "./endpoint/endpointResolver";
 import type { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
+import { errorTypeRegistries } from "./schemas/schemas_0";
 
 /**
  * @internal
@@ -35,6 +36,7 @@ export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
     protocol: config?.protocol ?? SmithyRpcV2CborProtocol,
     protocolSettings: config?.protocolSettings ?? {
       defaultNamespace: "smithy.protocoltests.rpcv2Cbor",
+      errorTypeRegistries,
     },
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,

--- a/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/schemas/schemas_0.ts
@@ -144,13 +144,40 @@ import { ComplexError, InvalidGreeting, ValidationException } from "../models/er
 import { RpcV2ProtocolServiceException } from "../models/RpcV2ProtocolServiceException";
 
 /* eslint no-var: 0 */
-var __Unit = "unit" as const;
+const _sC_registry = TypeRegistry.for(_sC);
+export var RpcV2ProtocolServiceException$: StaticErrorSchema = [-3, _sC, "RpcV2ProtocolServiceException", 0, [], []];
+_sC_registry.registerError(RpcV2ProtocolServiceException$, RpcV2ProtocolServiceException);
+const n0_registry = TypeRegistry.for(n0);
+const n1_registry = TypeRegistry.for(n1);
 export var ValidationException$: StaticErrorSchema = [-3, n0, _VE,
   { [_e]: _c },
   [_m, _fL],
   [0, () => ValidationExceptionFieldList], 1
 ];
-TypeRegistry.for(n0).registerError(ValidationException$, ValidationException);
+n0_registry.registerError(ValidationException$, ValidationException);
+export var ComplexError$: StaticErrorSchema = [-3, n1, _CE,
+  { [_e]: _c },
+  [_TL, _N],
+  [0, () => ComplexNestedErrorData$]
+];
+n1_registry.registerError(ComplexError$, ComplexError);
+export var InvalidGreeting$: StaticErrorSchema = [-3, n1, _IG,
+  { [_e]: _c },
+  [_M],
+  [0]
+];
+n1_registry.registerError(InvalidGreeting$, InvalidGreeting);
+/**
+ * TypeRegistry instances containing modeled errors.
+ * @internal
+ *
+ */
+export const errorTypeRegistries = [
+  _sC_registry,
+  n0_registry,
+  n1_registry,
+]
+var __Unit = "unit" as const;
 export var ValidationExceptionField$: StaticStructureSchema = [3, n0, _VEF,
   0,
   [_p, _m],
@@ -161,12 +188,6 @@ export var ClientOptionalDefaults$: StaticStructureSchema = [3, n1, _COD,
   [_me],
   [1]
 ];
-export var ComplexError$: StaticErrorSchema = [-3, n1, _CE,
-  { [_e]: _c },
-  [_TL, _N],
-  [0, () => ComplexNestedErrorData$]
-];
-TypeRegistry.for(n1).registerError(ComplexError$, ComplexError);
 export var ComplexNestedErrorData$: StaticStructureSchema = [3, n1, _CNED,
   0,
   [_F],
@@ -197,12 +218,6 @@ export var GreetingWithErrorsOutput$: StaticStructureSchema = [3, n1, _GWEO,
   [_g],
   [0]
 ];
-export var InvalidGreeting$: StaticErrorSchema = [-3, n1, _IG,
-  { [_e]: _c },
-  [_M],
-  [0]
-];
-TypeRegistry.for(n1).registerError(InvalidGreeting$, InvalidGreeting);
 export var OperationWithDefaultsInput$: StaticStructureSchema = [3, n1, _OWDI,
   0,
   [_de, _cOD, _tLD, _oTLD],
@@ -268,8 +283,6 @@ export var GreetingStruct$: StaticStructureSchema = [3, n2, _GS,
   [_h],
   [0]
 ];
-export var RpcV2ProtocolServiceException$: StaticErrorSchema = [-3, _sC, "RpcV2ProtocolServiceException", 0, [], []];
-TypeRegistry.for(_sC).registerError(RpcV2ProtocolServiceException$, RpcV2ProtocolServiceException);
 var ValidationExceptionFieldList: StaticListSchema = [1, n0, _VEFL,
   0, () => ValidationExceptionField$
 ];

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddProtocolConfig.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddProtocolConfig.java
@@ -4,6 +4,9 @@
  */
 package software.amazon.smithy.typescript.codegen.integration;
 
+import static software.amazon.smithy.typescript.codegen.schema.SchemaGenerator.SCHEMAS_FOLDER;
+
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -11,6 +14,7 @@ import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -54,10 +58,16 @@ public final class AddProtocolConfig implements TypeScriptIntegration {
                         },
                         "protocolSettings",
                         writer -> {
+                            writer.addRelativeImport(
+                                "errorTypeRegistries",
+                                null,
+                                Paths.get(".", CodegenUtils.SOURCE_FOLDER, SCHEMAS_FOLDER, "schemas_0")
+                            );
                             writer.write(
                                 """
                                 {
                                   defaultNamespace: $S,
+                                  errorTypeRegistries,
                                 }""",
                                 namespace
                             );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/util/StringStore.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/util/StringStore.java
@@ -4,7 +4,6 @@
  */
 package software.amazon.smithy.typescript.codegen.util;
 
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,7 +15,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -171,35 +169,5 @@ public class StringStore {
             }
         }
         return true;
-    }
-
-    public WithSchemaWriter useSchemaWriter(TypeScriptWriter writer) {
-        return new WithSchemaWriter(writer, this);
-    }
-
-    @SmithyInternalApi
-    public static final class WithSchemaWriter extends StringStore {
-
-        private final TypeScriptWriter writer;
-        private final StringStore store;
-
-        private WithSchemaWriter(TypeScriptWriter writer, StringStore store) {
-            this.writer = writer;
-            this.store = store;
-        }
-
-        @Override
-        public String var(String literal) {
-            String var = store.var(literal);
-            writer.addRelativeImport(var, null, Path.of("./schemas_0"));
-            return var;
-        }
-
-        @Override
-        public String var(String literal, String preferredPrefix) {
-            String var = store.var(literal, preferredPrefix);
-            writer.addRelativeImport(var, null, Path.of("./schemas_0"));
-            return var;
-        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

D390621325

*Description of changes:*

Exports error type registries from the generated schemas so that the client's protocol instance can look up locally registered errors, rather than requesting lookup from the global TypeRegistry.

The global instance is defeated by node_modules nesting, and may fail to respond with the correct errors.