### PR TITLE
Revert "Version NPM packages"

### DIFF
--- a/.changeset/weak-doors-hope.md
+++ b/.changeset/weak-doors-hope.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+omit absent resposne fields instead of assigning undefined

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Change Log
 
-## 3.23.1
-
-### Patch Changes
-
-- 3c18df8: omit absent resposne fields instead of assigning undefined
-
 ## 3.23.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/core",
-  "version": "3.23.1",
+  "version": "3.23.0",
   "scripts": {
     "build": "yarn lint && concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline core",

--- a/packages/experimental-identity-and-auth/CHANGELOG.md
+++ b/packages/experimental-identity-and-auth/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Change Log
 
-## 0.5.32
-
-### Patch Changes
-
-- @smithy/middleware-endpoint@4.4.15
-- @smithy/middleware-retry@4.4.32
-
 ## 0.5.31
 
 ### Patch Changes

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/experimental-identity-and-auth",
-  "version": "0.5.32",
+  "version": "0.5.31",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline experimental-identity-and-auth",

--- a/packages/middleware-compression/CHANGELOG.md
+++ b/packages/middleware-compression/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Change Log
 
-## 4.3.30
-
-### Patch Changes
-
-- Updated dependencies [3c18df8]
-  - @smithy/core@3.23.1
-
 ## 4.3.29
 
 ### Patch Changes

--- a/packages/middleware-compression/package.json
+++ b/packages/middleware-compression/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/middleware-compression",
-  "version": "4.3.30",
+  "version": "4.3.29",
   "description": "Middleware and Plugin for request compression.",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",

--- a/packages/middleware-endpoint/CHANGELOG.md
+++ b/packages/middleware-endpoint/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Change Log
 
-## 4.4.15
-
-### Patch Changes
-
-- Updated dependencies [3c18df8]
-  - @smithy/core@3.23.1
-
 ## 4.4.14
 
 ### Patch Changes

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/middleware-endpoint",
-  "version": "4.4.15",
+  "version": "4.4.14",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline middleware-endpoint",

--- a/packages/middleware-retry/CHANGELOG.md
+++ b/packages/middleware-retry/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Change Log
 
-## 4.4.32
-
-### Patch Changes
-
-- @smithy/smithy-client@4.11.4
-
 ## 4.4.31
 
 ### Patch Changes

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/middleware-retry",
-  "version": "4.4.32",
+  "version": "4.4.31",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline middleware-retry",

--- a/packages/smithy-client/CHANGELOG.md
+++ b/packages/smithy-client/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Change Log
 
-## 4.11.4
-
-### Patch Changes
-
-- Updated dependencies [3c18df8]
-  - @smithy/core@3.23.1
-  - @smithy/middleware-endpoint@4.4.15
-
 ## 4.11.3
 
 ### Patch Changes

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/smithy-client",
-  "version": "4.11.4",
+  "version": "4.11.3",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline smithy-client",

--- a/packages/typecheck/CHANGELOG.md
+++ b/packages/typecheck/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Change Log
 
-## 1.0.9
-
-### Patch Changes
-
-- Updated dependencies [3c18df8]
-  - @smithy/core@3.23.1
-
 ## 1.0.8
 
 ### Patch Changes

--- a/packages/typecheck/package.json
+++ b/packages/typecheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/typecheck",
-  "version": "1.0.9",
+  "version": "1.0.8",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline typecheck",

--- a/packages/util-defaults-mode-browser/CHANGELOG.md
+++ b/packages/util-defaults-mode-browser/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Change Log
 
-## 4.3.31
-
-### Patch Changes
-
-- @smithy/smithy-client@4.11.4
-
 ## 4.3.30
 
 ### Patch Changes

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/util-defaults-mode-browser",
-  "version": "4.3.31",
+  "version": "4.3.30",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline util-defaults-mode-browser",

--- a/packages/util-defaults-mode-node/CHANGELOG.md
+++ b/packages/util-defaults-mode-node/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Change Log
 
-## 4.2.34
-
-### Patch Changes
-
-- @smithy/smithy-client@4.11.4
-
 ## 4.2.33
 
 ### Patch Changes

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/util-defaults-mode-node",
-  "version": "4.2.34",
+  "version": "4.2.33",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "node ../../scripts/inline util-defaults-mode-node",


### PR DESCRIPTION
This reverts commit 107d60e783db8a7aca2e72ca6db969838edc195f.


*Description of changes:*
This reverts commit 107d60e783db8a7aca2e72ca6db969838edc195f to restore changesets and retry the failed release.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
