### PR TITLE
Bump codegen version to 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.45.0 (2026-02-19)
+
+### Features
+
+- Upgraded smithy version to 1.67.0 ([#1868](https://github.com/smithy-lang/smithy-typescript/pull/1868))
+
+### Bug Fixes
+
+- Created composite type registry on protocol instances ([#1867](https://github.com/smithy-lang/smithy-typescript/pull/1867))
+
 ## 0.44.0 (2026-02-06)
 
 ### Chores

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.44.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.45.0"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -139,7 +139,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.44.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.45.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.44.0"
+    version = "0.45.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-6640

*Description of changes:*
Bumps codegen version to 0.45.0

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
