### PR TITLE
fix(smithy-client): set $retryable and $response in ServiceException constructor

### DIFF
--- a/.changeset/cuddly-ads-travel.md
+++ b/.changeset/cuddly-ads-travel.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": minor
+---
+
+include $retryable and $response in ServiceException

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -36,6 +36,8 @@ export class ServiceException extends Error implements SmithyException, Metadata
     this.name = options.name;
     this.$fault = options.$fault;
     this.$metadata = options.$metadata;
+    this.$retryable = options.$retryable;
+    this.$response = options.$response;
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1543

*Description of changes:*

The `ServiceException` constructor was not assigning `$retryable` or `$response` from the options parameter, even though both properties are declared on the class and defined in the `ServiceExceptionOptions` type (via `SmithyException`).

This meant that constructing a `ServiceException` (or subclass) with `$retryable` or `$response` in the options object would silently drop those values.

```js
const error = new ServiceException({
  name: "TestError",
  $fault: "client",
  $metadata: {},
  $retryable: { throttling: true },
});

error.$retryable; // was: undefined, now: { throttling: true }
```

The fix adds the two missing assignments in the constructor alongside the existing ones for `$fault` and `$metadata`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
