### PR TITLE
fix(util-stream): warn when buffered readable encounters mixed Buffer/Uint8Array chunks

### DIFF
--- a/.changeset/mixed-chunks-warning.md
+++ b/.changeset/mixed-chunks-warning.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-stream": patch
+---
+
+warn when buffered readable encounters mixed Buffer/Uint8Array chunk types

--- a/packages/util-stream/src/createBufferedReadable.ts
+++ b/packages/util-stream/src/createBufferedReadable.ts
@@ -46,6 +46,13 @@ export function createBufferedReadable(
     if (mode !== chunkMode) {
       if (mode >= 0) {
         downstream.push(flush(buffers, mode));
+        if ((mode === 1 && chunkMode === 2) || (mode === 2 && chunkMode === 1)) {
+          logger?.warn(
+            "@smithy/util-stream - stream chunks are mixing Uint8Array and Buffer types," +
+              " which causes premature buffer flushing and may result in undersized chunks." +
+              " Normalize your stream to use a consistent chunk type."
+          );
+        }
       }
       mode = chunkMode;
     }

--- a/packages/util-stream/src/createBufferedReadableStream.ts
+++ b/packages/util-stream/src/createBufferedReadableStream.ts
@@ -39,6 +39,13 @@ export function createBufferedReadableStream(upstream: ReadableStream, size: num
       if (mode !== chunkMode) {
         if (mode >= 0) {
           controller.enqueue(flush(buffers, mode));
+          if ((mode === 1 && chunkMode === 2) || (mode === 2 && chunkMode === 1)) {
+            logger?.warn(
+              "@smithy/util-stream - stream chunks are mixing Uint8Array and Buffer types," +
+                " which causes premature buffer flushing and may result in undersized chunks." +
+                " Normalize your stream to use a consistent chunk type."
+            );
+          }
         }
         mode = chunkMode;
       }


### PR DESCRIPTION
*Issue #, if available:*

Resolves #1553

*Description of changes:*

When a stream mixes `Uint8Array` and `Buffer` chunk types, `createBufferedReadable` flushes its internal buffer on every type switch regardless of size. This can produce undersized chunks that downstream consumers (like S3's chunked upload) reject with `InvalidChunkSizeError`, which is confusing when the user has explicitly set `requestStreamBufferSize`.

This change adds a `logger.warn()` when the buffering logic detects a switch between `Buffer` (mode 2) and `Uint8Array` (mode 1) chunks, in both the Node `Readable` and `ReadableStream` code paths. The warning explains the cause and tells the user to normalize their stream to a consistent chunk type.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
