### PR TITLE
fix(protocols): handle null/undefined from labelValueProvider in resolvedPath

### DIFF
--- a/.changeset/fix-resolve-path-null-safety.md
+++ b/.changeset/fix-resolve-path-null-safety.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix(protocols): remove unsafe type cast in resolvedPath to handle null/undefined from labelValueProvider

--- a/packages/core/src/submodules/protocols/resolve-path.spec.ts
+++ b/packages/core/src/submodules/protocols/resolve-path.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test as it } from "vitest";
+
+import { resolvedPath } from "./resolve-path";
+
+describe("resolvedPath", () => {
+  const basePath = "/items/{itemId}";
+  const uriLabel = "{itemId}";
+
+  it("replaces the label with the encoded value", () => {
+    const result = resolvedPath(basePath, { itemId: "abc" }, "itemId", () => "abc", uriLabel, false);
+    expect(result).toBe("/items/abc");
+  });
+
+  it("encodes greedy labels segment by segment", () => {
+    const result = resolvedPath(basePath, { itemId: "a/b/c" }, "itemId", () => "a/b/c", uriLabel, true);
+    expect(result).toBe("/items/a/b/c");
+  });
+
+  it("throws when labelValueProvider returns undefined", () => {
+    expect(() => resolvedPath(basePath, { itemId: "x" }, "itemId", () => undefined, uriLabel, false)).toThrow(
+      "Empty value provided for input HTTP label: itemId."
+    );
+  });
+
+  it("throws when labelValueProvider returns null", () => {
+    expect(() =>
+      resolvedPath(basePath, { itemId: "x" }, "itemId", () => null as unknown as string, uriLabel, false)
+    ).toThrow("Empty value provided for input HTTP label: itemId.");
+  });
+
+  it("throws when labelValueProvider returns an empty string", () => {
+    expect(() => resolvedPath(basePath, { itemId: "x" }, "itemId", () => "", uriLabel, false)).toThrow(
+      "Empty value provided for input HTTP label: itemId."
+    );
+  });
+
+  it("throws when the member is not present in input", () => {
+    expect(() => resolvedPath(basePath, {}, "itemId", () => "abc", uriLabel, false)).toThrow(
+      "No value provided for input HTTP label: itemId."
+    );
+  });
+});

--- a/packages/core/src/submodules/protocols/resolve-path.ts
+++ b/packages/core/src/submodules/protocols/resolve-path.ts
@@ -12,8 +12,8 @@ export const resolvedPath = (
   isGreedyLabel: boolean
 ): string => {
   if (input != null && (input as Record<string, unknown>)[memberName] !== undefined) {
-    const labelValue = labelValueProvider() as string;
-    if (labelValue.length <= 0) {
+    const labelValue = labelValueProvider();
+    if (labelValue == null || labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: " + memberName + ".");
     }
     resolvedPath = resolvedPath.replace(


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1532

*Description of changes:*

The `resolvedPath` function in `@smithy/core` (protocols submodule) casts the return value of `labelValueProvider()` to `string` via `as string`, then immediately accesses `.length` on it. The function's declared return type is `string | undefined`, and in practice it can also return `null` (e.g. when an input field is explicitly set to `null`). This causes a `TypeError: Cannot read properties of null (reading 'length')` at runtime, which is confusing because it gives no indication of what went wrong.

```ts
// Before — unsafe cast, crashes on null/undefined
const labelValue = labelValueProvider() as string;
if (labelValue.length <= 0) {

// After — proper null check, throws a descriptive error
const labelValue = labelValueProvider();
if (labelValue == null || labelValue.length <= 0) {
```

The `== null` check covers both `null` and `undefined`, and falls through to the existing `.length <= 0` check for empty strings. In all three cases the function now throws the existing descriptive error: `"Empty value provided for input HTTP label: <memberName>."`.

Also adds unit tests for `resolvedPath` covering normal replacement, greedy labels, and the `null`/`undefined`/empty-string edge cases.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
