### PR TITLE
fix(util-retry): detect throttling from RetryErrorInfo.errorType in DefaultRateLimiter

### DIFF
--- a/.changeset/fix-rate-limiter-throttle-detection.md
+++ b/.changeset/fix-rate-limiter-throttle-detection.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-retry": patch
+---
+
+fix(util-retry): detect throttling errors from RetryErrorInfo.errorType in DefaultRateLimiter

--- a/packages/util-retry/src/DefaultRateLimiter.ts
+++ b/packages/util-retry/src/DefaultRateLimiter.ts
@@ -97,7 +97,7 @@ export class DefaultRateLimiter implements RateLimiter {
     let calculatedRate: number;
     this.updateMeasuredRate();
 
-    if (isThrottlingError(response)) {
+    if (this.isThrottlingResponse(response)) {
       const rateToUse = !this.enabled ? this.measuredTxRate : Math.min(this.measuredTxRate, this.fillRate);
       this.lastMaxRate = rateToUse;
       this.calculateTimeWindow();
@@ -112,6 +112,14 @@ export class DefaultRateLimiter implements RateLimiter {
     const newRate = Math.min(calculatedRate, 2 * this.measuredTxRate);
     this.updateTokenBucketRate(newRate);
   }
+
+  private isThrottlingResponse(response: any): boolean {
+    if (response?.errorType) {
+      return response.errorType === "THROTTLING";
+    }
+    return isThrottlingError(response);
+  }
+
 
   private calculateTimeWindow() {
     this.timeWindow = this.getPrecise(Math.pow((this.lastMaxRate * (1 - this.beta)) / this.scaleConstant, 1 / 3));


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1328

*Description of changes:*

`DefaultRateLimiter.updateClientSendingRate()` calls `isThrottlingError(response)` to decide whether to enable client-side throttling. However, the `AdaptiveRetryStrategy` in `@smithy/util-retry` passes a `RetryErrorInfo` object — not an `SdkError`. Since `RetryErrorInfo` has none of the properties `isThrottlingError` checks (`$metadata`, `$retryable`, `name`), the call always returns `false` and the rate limiter is never enabled, completely defeating adaptive retry.

The fix adds a private `isThrottlingResponse()` method that checks for `RetryErrorInfo.errorType === "THROTTLING"` first, and falls back to `isThrottlingError()` when `errorType` is absent. This preserves backward compatibility with the deprecated `AdaptiveRetryStrategy` in `@smithy/middleware-retry`, which passes a raw HTTP response.

```ts
// Before — always false for RetryErrorInfo
if (isThrottlingError(response)) {

// After — checks errorType first, falls back to isThrottlingError
if (this.isThrottlingResponse(response)) {

private isThrottlingResponse(response: any): boolean {
  if (response?.errorType) {
    return response.errorType === "THROTTLING";
  }
  return isThrottlingError(response);
}
```

Tests added:
- Enables rate limiter when `errorType` is `"THROTTLING"`
- Does not enable rate limiter for non-throttling `errorType`
- Does not call `isThrottlingError` when `errorType` is present
- Falls back to `isThrottlingError` when `errorType` is absent

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
