### PR TITLE
feat(util-retry): support AbortSignal in DefaultRateLimiter.getSendToken

### DIFF
--- a/.changeset/fix-rate-limiter-abort-signal.md
+++ b/.changeset/fix-rate-limiter-abort-signal.md
@@ -1,0 +1,12 @@
+---
+"@smithy/util-retry": minor
+"@smithy/middleware-retry": minor
+"@smithy/smithy-client": minor
+---
+
+feat(util-retry): support AbortSignal in DefaultRateLimiter.getSendToken
+
+Thread AbortSignal from command options through the middleware stack so that
+retry delays (both V1 StandardRetryStrategy/AdaptiveRetryStrategy and V2
+RetryStrategyV2) can be cancelled early. This enables graceful abort of
+retry waits in environments like AWS Lambda.

--- a/packages/middleware-retry/src/AdaptiveRetryStrategy.spec.ts
+++ b/packages/middleware-retry/src/AdaptiveRetryStrategy.spec.ts
@@ -95,5 +95,30 @@ describe(AdaptiveRetryStrategy.name, () => {
       await mockedSuperRetry.mock.calls[0][2]!.afterRequest();
       expect(mockDefaultRateLimiter.updateClientSendingRate).toHaveBeenCalledTimes(1);
     });
+
+    it("passes abortSignal to rateLimiter.getSendToken", async () => {
+      vi.clearAllMocks();
+      const next = vi.fn();
+      const retryStrategy = new AdaptiveRetryStrategy(maxAttemptsProvider);
+      const abortController = new AbortController();
+      await retryStrategy.retry(next, { request: { headers: {} } } as any, {
+        abortSignal: abortController.signal,
+      });
+      expect(mockedSuperRetry).toHaveBeenCalledTimes(1);
+      await mockedSuperRetry.mock.calls[0][2]!.beforeRequest();
+      expect(mockDefaultRateLimiter.getSendToken).toHaveBeenCalledWith(abortController.signal);
+    });
+
+    it("passes abortSignal through to super.retry options", async () => {
+      vi.clearAllMocks();
+      const next = vi.fn();
+      const retryStrategy = new AdaptiveRetryStrategy(maxAttemptsProvider);
+      const abortController = new AbortController();
+      await retryStrategy.retry(next, { request: { headers: {} } } as any, {
+        abortSignal: abortController.signal,
+      });
+      expect(mockedSuperRetry).toHaveBeenCalledTimes(1);
+      expect(mockedSuperRetry.mock.calls[0][2]!.abortSignal).toBe(abortController.signal);
+    });
   });
 });

--- a/packages/middleware-retry/src/AdaptiveRetryStrategy.ts
+++ b/packages/middleware-retry/src/AdaptiveRetryStrategy.ts
@@ -29,15 +29,19 @@ export class AdaptiveRetryStrategy extends StandardRetryStrategy {
 
   async retry<Input extends object, Ouput extends MetadataBearer>(
     next: FinalizeHandler<Input, Ouput>,
-    args: FinalizeHandlerArguments<Input>
+    args: FinalizeHandlerArguments<Input>,
+    options?: {
+      abortSignal?: AbortSignal;
+    }
   ) {
     return super.retry(next, args, {
       beforeRequest: async () => {
-        return this.rateLimiter.getSendToken();
+        return this.rateLimiter.getSendToken(options?.abortSignal);
       },
       afterRequest: (response: any) => {
         this.rateLimiter.updateClientSendingRate(response);
       },
+      abortSignal: options?.abortSignal,
     });
   }
 }

--- a/packages/middleware-retry/src/types.ts
+++ b/packages/middleware-retry/src/types.ts
@@ -59,8 +59,10 @@ export interface RateLimiter {
    * If there is not sufficient capacity, it will either sleep a certain amount
    * of time until the rate limiter can retrieve a token from its token bucket
    * or raise an exception indicating there is insufficient capacity.
+   *
+   * @param abortSignal - optional signal to abort the token wait early.
    */
-  getSendToken: () => Promise<void>;
+  getSendToken: (abortSignal?: AbortSignal) => Promise<void>;
 
   /**
    * Updates the client sending rate based on response.

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -93,6 +93,9 @@ export abstract class Command<
       },
       ...additionalContext,
     };
+    if (options?.abortSignal) {
+      handlerExecutionContext.abortSignal = options.abortSignal;
+    }
     const { requestHandler } = configuration;
     return stack.resolve(
       (request: FinalizeHandlerArguments<any>) => requestHandler.handle(request.request as HttpRequest, options || {}),

--- a/packages/util-retry/src/types.ts
+++ b/packages/util-retry/src/types.ts
@@ -7,8 +7,10 @@ export interface RateLimiter {
    * If there is not sufficient capacity, it will either sleep a certain amount
    * of time until the rate limiter can retrieve a token from its token bucket
    * or raise an exception indicating there is insufficient capacity.
+   *
+   * @param abortSignal - optional signal to abort the token wait early.
    */
-  getSendToken: () => Promise<void>;
+  getSendToken: (abortSignal?: AbortSignal) => Promise<void>;
 
   /**
    * Updates the client sending rate based on response.


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1758

*Description of changes:*

When the `DefaultRateLimiter` is waiting for token bucket capacity via `getSendToken`, the internal `setTimeout` delay cannot be cancelled. In environments like AWS Lambda, this means you can't abort a retry wait as the function timeout approaches — the Lambda just fails with a "task timed out" error instead of letting you handle it gracefully.

`getSendToken` now accepts an optional `AbortSignal`. When provided, the signal is raced against the delay timer:

- If the signal is already aborted, the promise rejects immediately with `signal.reason`.
- If the signal fires during the wait, the timer is cleared and the promise rejects with `signal.reason`.
- If no signal is provided, behavior is unchanged (fully backward compatible).

```ts
const rateLimiter = new DefaultRateLimiter();

// Without signal — existing behavior, no change
await rateLimiter.getSendToken();

// With signal — can now abort the wait
const controller = new AbortController();
setTimeout(() => controller.abort(new Error("Lambda timeout approaching")), 5000);
await rateLimiter.getSendToken(controller.signal);
```

The `RateLimiter` interface is updated in both `@smithy/util-retry` and `@smithy/middleware-retry` to accept the optional parameter.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
