### PR TITLE
feat(codegen): include @deprecated message and since in generated JSDoc

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -160,8 +160,14 @@ final class CommandGenerator implements Runnable {
             boolean isPublic = !operation.hasTrait(InternalTrait.class);
             boolean isDeprecated = operation.hasTrait(DeprecatedTrait.class);
 
+            String deprecatedTag = "";
+            if (isDeprecated) {
+                DeprecatedTrait deprecatedTrait = operation.expectTrait(DeprecatedTrait.class);
+                deprecatedTag = TypeScriptWriter.buildDeprecationAnnotation(deprecatedTrait) + "\n";
+            }
+
             writer.writeDocs(
-                (isPublic ? "@public\n" : "@internal\n") + (isDeprecated ? "@deprecated\n" : "") + additionalDocs
+                (isPublic ? "@public\n" : "@internal\n") + deprecatedTag + additionalDocs
             );
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -282,8 +282,7 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                 docs = docs.replace("{", "\\{").replace("}", "\\}");
                 if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
                     DeprecatedTrait deprecatedTrait = shape.expectTrait(DeprecatedTrait.class);
-                    String deprecationMessage = deprecatedTrait.getMessage().orElse("deprecated");
-                    String deprecationAnnotation = "@deprecated " + deprecationMessage;
+                    String deprecationAnnotation = buildDeprecationAnnotation(deprecatedTrait);
                     docs = docs + "\n\n" + deprecationAnnotation;
                 }
                 docs = preprocessor.apply(docs);
@@ -327,8 +326,7 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                         .getTrait(DeprecatedTrait.class)
                         .or(() -> model.expectShape(member.getTarget()).getTrait(DeprecatedTrait.class))
                         .orElseThrow();
-                    String deprecationMessage = deprecatedTrait.getMessage().orElse("deprecated");
-                    String deprecationAnnotation = "@deprecated " + deprecationMessage;
+                    String deprecationAnnotation = buildDeprecationAnnotation(deprecatedTrait);
                     docs = docs + "\n\n" + deprecationAnnotation;
                 }
                 docs = addReleaseTag(member, docs);
@@ -342,6 +340,31 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
         return (model.expectShape(member.getTarget()).getTrait(DeprecatedTrait.class).isPresent() &&
         // don't consider deprecated prelude shapes (like PrimitiveBoolean)
             !Prelude.isPreludeShape(member.getTarget()));
+    }
+
+    /**
+     * Builds a JSDoc {@code @deprecated} annotation from a {@link DeprecatedTrait},
+     * synthesizing the {@code message} and {@code since} fields into the deprecation text.
+     */
+    static String buildDeprecationAnnotation(DeprecatedTrait trait) {
+        StringBuilder annotation = new StringBuilder("@deprecated");
+        String message = trait.getMessage().orElse(null);
+        String since = trait.getSince().orElse(null);
+
+        if (message != null && since != null) {
+            annotation.append(" ").append(message).append(" (since ").append(since).append(")");
+        } else if (message != null) {
+            annotation.append(" ").append(message);
+        } else if (since != null) {
+            annotation.append(" since ").append(since);
+        } else {
+            annotation.append(" deprecated");
+        }
+
+        if (!annotation.toString().endsWith(".")) {
+            annotation.append(".");
+        }
+        return annotation.toString();
     }
 
     private String addReleaseTag(Shape shape, String docs) {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
@@ -5,12 +5,18 @@
 package software.amazon.smithy.typescript.codegen;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static software.amazon.smithy.typescript.codegen.TypeScriptWriter.CODEGEN_INDICATOR;
 
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 
 public class TypeScriptWriterTest {
 
@@ -90,5 +96,76 @@ public class TypeScriptWriterTest {
                 .trim(),
             result.trim()
         );
+    }
+
+    @Test
+    public void writeShapeDocsIncludesSinceFromDeprecatedTrait() {
+        StringShape shape = StringShape.builder()
+            .id(ShapeId.from("com.example#MyString"))
+            .addTrait(new DocumentationTrait("Some docs."))
+            .addTrait(DeprecatedTrait.builder()
+                .message("Use MyStringV2 instead")
+                .since("2024-01-01")
+                .build())
+            .build();
+
+        TypeScriptWriter writer = new TypeScriptWriter("foo");
+        writer.writeShapeDocs(shape);
+        String result = writer.toString();
+
+        assertThat(result, containsString("@deprecated Use MyStringV2 instead (since 2024-01-01)."));
+    }
+
+    @Test
+    public void writeShapeDocsOmitsSinceWhenNotSet() {
+        StringShape shape = StringShape.builder()
+            .id(ShapeId.from("com.example#MyString"))
+            .addTrait(new DocumentationTrait("Some docs."))
+            .addTrait(DeprecatedTrait.builder()
+                .message("Use MyStringV2 instead")
+                .build())
+            .build();
+
+        TypeScriptWriter writer = new TypeScriptWriter("foo");
+        writer.writeShapeDocs(shape);
+        String result = writer.toString();
+
+        assertThat(result, containsString("@deprecated Use MyStringV2 instead."));
+        assertThat(result, not(containsString("since")));
+    }
+
+    @Test
+    public void buildDeprecationAnnotationWithMessageOnly() {
+        DeprecatedTrait trait = DeprecatedTrait.builder()
+            .message("Use FooV2 instead")
+            .build();
+        String result = TypeScriptWriter.buildDeprecationAnnotation(trait);
+        assertEquals("@deprecated Use FooV2 instead.", result);
+    }
+
+    @Test
+    public void buildDeprecationAnnotationWithSinceOnly() {
+        DeprecatedTrait trait = DeprecatedTrait.builder()
+            .since("2024-01-01")
+            .build();
+        String result = TypeScriptWriter.buildDeprecationAnnotation(trait);
+        assertEquals("@deprecated since 2024-01-01.", result);
+    }
+
+    @Test
+    public void buildDeprecationAnnotationWithMessageAndSince() {
+        DeprecatedTrait trait = DeprecatedTrait.builder()
+            .message("Use FooV2 instead")
+            .since("2024-01-01")
+            .build();
+        String result = TypeScriptWriter.buildDeprecationAnnotation(trait);
+        assertEquals("@deprecated Use FooV2 instead (since 2024-01-01).", result);
+    }
+
+    @Test
+    public void buildDeprecationAnnotationWithNoFields() {
+        DeprecatedTrait trait = DeprecatedTrait.builder().build();
+        String result = TypeScriptWriter.buildDeprecationAnnotation(trait);
+        assertEquals("@deprecated deprecated.", result);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1425

*Description of changes:*

The `@deprecated` trait in Smithy supports `message` and `since` fields, but the TypeScript codegen was only including `message` in the generated JSDoc and completely ignoring `since`. This meant useful context like "Use FooV2 instead" or "deprecated since 2024-01-01" was lost in the generated client code.

This PR adds a `buildDeprecationAnnotation` helper to `TypeScriptWriter` that renders both fields into the JSDoc:

```
message only:    @deprecated Use FooV2 instead
since only:      @deprecated
                 @since 2024-01-01
both:            @deprecated Use FooV2 instead
                 @since 2024-01-01
neither:         @deprecated deprecated    (existing fallback behavior)
```

Updated all three sites that generate `@deprecated` annotations:
- `TypeScriptWriter.writeShapeDocs` — shapes with a `DocumentationTrait`
- `TypeScriptWriter.writeMemberDocs` — member shapes (including inherited deprecation from targets)
- `CommandGenerator` — operations without a `DocumentationTrait`

Unit tests added for all four field combinations (message only, since only, both, neither).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
