### PR TITLE
fix(codegen): use literal string keys in SchemaTraitWriter to fix esbuild tree-shaking

### DIFF
--- a/.changeset/fix-schema-trait-computed-keys.md
+++ b/.changeset/fix-schema-trait-computed-keys.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix(codegen): use literal string keys in SchemaTraitWriter to fix esbuild tree-shaking

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitWriter.java
@@ -86,8 +86,8 @@ class SchemaTraitWriter {
                 }
                 buffer.append(
                     """
-                    [%s]: %s,\s""".formatted(
-                        stringStore.var(shapeId.getName()),
+                    "%s": %s,\s""".formatted(
+                        shapeId.getName(),
                         traitGenerator.serializeTraitData(trait, stringStore)
                     )
                 );

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitWriterTest.java
@@ -40,7 +40,7 @@ class SchemaTraitWriterTest {
             String codeGeneration = subject.toString();
             assertEquals(
                 """
-                { [_s]: 1 }""",
+                { "streaming": 1 }""",
                 codeGeneration
             );
         }


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-js-v3/issues/7607

### Problem

Since aws-sdk-js-v3 v3.930.0, ESBuild users have seen significant bundle size regressions when importing only a few commands from a client. For example, importing `EC2Client` and 3 commands grew from ~30KB to ~492KB.

`SchemaTraitWriter.writeTraitsObject()` emits computed property keys using `StringStore` variable references as object keys:

```typescript
// generated output (before)
const _e = "error";
const _c = "client";
{ [_e]: _c, [_hE]: 400 }
```

ESBuild treats computed property keys (`[expr]`) as potentially having side effects because the expression could invoke a getter or `toString()`, so it marks the entire containing statement as non-tree-shakeable. This affects all ~416 generated AWS SDK clients.

### Solution

This PR changes `SchemaTraitWriter.writeTraitsObject()` to emit literal string keys instead of computed ones:

```typescript
// generated output (after)
const _c = "client";
{ "error": _c, "httpError": 400 }
```

Trait key names are short strings (`"error"`, `"httpError"`, `"httpQuery"`, `"streaming"`, etc.) so the size cost of inlining them is negligible. `StringStore` abbreviations are preserved for trait values where they continue to save bytes without affecting tree-shaking.

### Changes

- `SchemaTraitWriter.writeTraitsObject()` — format string changed from `[%s]: %s,` (with `stringStore.var()`) to `"%s": %s,` (with `shapeId.getName()`)
- `SchemaTraitWriterTest` — updated assertion to match new literal key output