### PR TITLE
fix: Filter out http-bound members from schema passed to payload serializer

### DIFF
--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
@@ -21,6 +21,12 @@ import { extendedEncodeURIComponent } from "./extended-encode-uri-component";
 import { HttpProtocol } from "./HttpProtocol";
 
 /**
+ * Cache key for the body-only schema view that excludes HTTP-bound members.
+ * @internal
+ */
+const HTTP_BODY_MEMBERS = Symbol.for("@smithy/http-body-members");
+
+/**
  * Base for HTTP-binding protocols. Downstream examples
  * include AWS REST JSON and AWS REST XML.
  *
@@ -152,7 +158,17 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
     }
 
     if (hasNonHttpBindingMember && input) {
-      serializer.write(schema, input);
+      const bodyNs = ns.filterMembers(HTTP_BODY_MEMBERS, (_name, memberNs) => {
+        const traits = memberNs.getMergedTraits();
+        return !(
+          traits.httpHeader ||
+          traits.httpLabel ||
+          traits.httpQuery ||
+          traits.httpPayload ||
+          traits.httpPrefixHeaders
+        );
+      });
+      serializer.write(bodyNs, input);
       payload = serializer.flush() as Uint8Array;
 
       // Due to Smithy validation, we can assume that the members with no HTTP

--- a/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
+++ b/packages/core/src/submodules/schema/schemas/NormalizedSchema.ts
@@ -414,6 +414,43 @@ export class NormalizedSchema implements INormalizedSchema {
   }
 
   /**
+   * Returns a view of this schema whose structIterator only yields members
+   * matching the given predicate.
+   *
+   * The returned object delegates all other NormalizedSchema methods to this instance.
+   * This is useful when a caller needs to pass a subset of struct members to a
+   * generic serializer without copying the underlying schema arrays.
+   *
+   * Results are cached on the underlying struct schema keyed by the provided symbol,
+   * so the predicate only runs once per schema regardless of how many requests use it.
+   */
+  public filterMembers(
+    cacheKey: symbol,
+    predicate: (name: string, memberNs: NormalizedSchema) => boolean
+  ): NormalizedSchema {
+    const struct = this.getSchema() as StaticStructureSchema & {
+      [key: symbol]: NormalizedSchema;
+    };
+    if (struct[cacheKey]) {
+      return struct[cacheKey];
+    }
+
+    const entries: Array<[string, NormalizedSchema]> = [];
+    for (const [name, memberNs] of this.structIterator()) {
+      if (predicate(name, memberNs)) {
+        entries.push([name, memberNs]);
+      }
+    }
+
+    const view = Object.create(this) as NormalizedSchema;
+    (view as any).structIterator = function* (): Generator<[string, NormalizedSchema], undefined, undefined> {
+      yield* entries;
+    };
+    struct[cacheKey] = view;
+    return view;
+  }
+
+  /**
    * Allows iteration over members of a structure schema.
    * Each yield is a pair of the member name and member schema.
    *

--- a/packages/types/src/schema/schema.ts
+++ b/packages/types/src/schema/schema.ts
@@ -180,6 +180,7 @@ export interface NormalizedSchema {
    */
   getMemberSchema(member: string): NormalizedSchema | undefined;
   structIterator(): Generator<[string, NormalizedSchema], undefined, undefined>;
+  filterMembers(cacheKey: symbol, predicate: (name: string, memberNs: NormalizedSchema) => boolean): NormalizedSchema;
 }
 
 /**


### PR DESCRIPTION
*Context:*
- When a member has both `@httpHeader` and `@idempotencyToken`, the header is serialized correctly but the body also had that same member populated (with a different value)
- The payload serializer (e.g. `JsonShapeSerializer`) iterates schema members (not input keys), finds the member is undefined, sees `@IdempotencyToken`, and generates a fresh UUID bound to the request body (not the header)
  - If the server rejects unknown fields in a request, then the request will be rejected and will never be processable
- The root cause is that `HttpBindingProtocol.serializeRequest()` passes the full schema to the payload serializer including http-bound members (headers, params, etc)
  - The `delete input[memberName]` trick mostly works, but not for fields that get special treatment in the payload serializer
    - In this case, `@idempotencyToken` breaks it because the serializer treats `undefined` + `@idempotencyToken` as "generate a value."

*Description of changes:*
- This adds `filterMembers(cacheKey, predicate)` to `NormalizedSchema` as a wrapper that overrides `structIterator()` so that a "view" of the schema can be passed (without explicit copying)
  - It's also cached, this is just an optimization to not recompute the view every time
- This method is used in `HttpBindingProtocol` to give the payload serializer a view of the schema that excludes HTTP-bound members, so that it doesn't try to consume already bound members
- There may be a better way to do this, but I'll leave that to the team to figure out if this isn't sufficient (I didn't want to make a super disruptive change that could have higher surface area) 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
