### PR TITLE
fix(core/protocols): omit extraneous idempotency token serialized into http body

### DIFF
--- a/.changeset/quick-walls-nail.md
+++ b/.changeset/quick-walls-nail.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix extraneous serialization of idempotencyToken into http body


### PR DESCRIPTION
*Issue #, if available:*
issue described in https://github.com/smithy-lang/smithy-typescript/pull/1892

*Description of changes:*

This collects the list of non-http-bound members during the iteration of the input structure members. It then uses that sublist of members to serialize the http payload.

This avoids the payload serializer seeing an idempotency token member that was already bound to another HTTP location and serializing it into the body.
