### PR TITLE
fix(util-waiter): handle circular references and missing $response in waiter polling (#7459)

### DIFF
--- a/.changeset/fix-circular-reference-waiter.md
+++ b/.changeset/fix-circular-reference-waiter.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-waiter": patch
+---
+
+fix(util-waiter): add optional chaining for `$response?.statusCode` in `createMessageFromResponse` to prevent TypeError when `$response` is undefined but `message` is present.

--- a/packages/util-waiter/src/circular-reference-bug.spec.ts
+++ b/packages/util-waiter/src/circular-reference-bug.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression test for https://github.com/aws/aws-sdk-js-v3/issues/7459
+ *
+ * When a waiter receives a response/error containing circular references
+ * (e.g. Node.js IncomingMessage with req/res cycle), JSON.stringify should
+ * not throw "Converting circular structure to JSON".
+ */
+import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
+
+import { runPolling } from "./poller";
+import { sleep } from "./utils/sleep";
+import type { WaiterOptions, WaiterResult } from "./waiter";
+import { checkExceptions, WaiterState } from "./waiter";
+
+vi.mock("./utils/sleep");
+
+/**
+ * Creates a mock object that mimics the circular reference structure
+ * of a Node.js IncomingMessage/ClientRequest pair, which is the exact
+ * structure reported in the issue.
+ */
+function createCircularHttpResponse() {
+  const incomingMessage: any = {
+    constructor: { name: "IncomingMessage" },
+    statusCode: 403,
+    headers: { "content-type": "application/json" },
+  };
+  const clientRequest: any = {
+    constructor: { name: "ClientRequest" },
+    method: "POST",
+    path: "/",
+  };
+  incomingMessage.req = clientRequest;
+  clientRequest.res = incomingMessage;
+  return incomingMessage;
+}
+
+describe("GitHub Issue #7459: circular structure in waiter results", () => {
+  const config: WaiterOptions<any> = {
+    minDelay: 2,
+    maxDelay: 30,
+    maxWaitTime: 99999,
+    client: "mockClient",
+  };
+
+  describe("checkExceptions", () => {
+    it("should not throw TypeError for FAILURE result with circular reason", () => {
+      const result: WaiterResult = {
+        state: WaiterState.FAILURE,
+        reason: createCircularHttpResponse(),
+      };
+
+      expect(() => checkExceptions(result)).toThrow();
+      try {
+        checkExceptions(result);
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).not.toContain("Converting circular structure to JSON");
+        expect(e.message).toContain("[Circular]");
+      }
+    });
+  });
+
+  describe("runPolling", () => {
+    beforeEach(() => {
+      vi.mocked(sleep).mockResolvedValue("");
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should handle circular reason from acceptorChecks", async () => {
+      const circularResponse = createCircularHttpResponse();
+      const mockAcceptorChecks = vi.fn().mockResolvedValueOnce({
+        state: WaiterState.FAILURE,
+        reason: circularResponse,
+      });
+
+      const result = await runPolling(config, "input", mockAcceptorChecks);
+      expect(result.state).toBe(WaiterState.FAILURE);
+      expect(result.reason).toBe(circularResponse);
+      const keys = Object.keys(result.observedResponses!);
+      expect(keys.length).toBe(1);
+      expect(keys[0]).not.toContain("Converting circular structure");
+    });
+
+    it("should handle reason with $metadata and message but no $response", async () => {
+      const mockAcceptorChecks = vi.fn().mockResolvedValueOnce({
+        state: WaiterState.FAILURE,
+        reason: {
+          message: "User is not authorized to perform acm-pca:IssueCertificate",
+          $metadata: { httpStatusCode: 403 },
+        },
+      });
+
+      const result = await runPolling(config, "input", mockAcceptorChecks);
+      expect(result.state).toBe(WaiterState.FAILURE);
+      const keys = Object.keys(result.observedResponses!);
+      expect(keys.length).toBe(1);
+      expect(keys[0]).toContain("403");
+      expect(keys[0]).toContain("not authorized");
+    });
+  });
+});

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -91,7 +91,7 @@ const createMessageFromResponse = (reason: any): string => {
     // has a status code.
     if (reason.$response || reason.message) {
       // is an error object.
-      return `${reason.$response.statusCode ?? reason.$metadata.httpStatusCode ?? "Unknown"}: ${reason.message}`;
+      return `${reason.$response?.statusCode ?? reason.$metadata.httpStatusCode ?? "Unknown"}: ${reason.message}`;
     }
     // is an output object.
     return `${reason.$metadata.httpStatusCode}: OK`;


### PR DESCRIPTION
Fixes #7459

## Problem

When a waiter receives an error response that has `$metadata.httpStatusCode` and `message` but no `$response` property, `createMessageFromResponse` in `poller.ts` throws:

```
TypeError: Cannot read properties of undefined (reading 'statusCode')
```

This happens because the condition `reason.$response || reason.message` enters the branch when only `reason.message` is truthy, but the return statement unconditionally accesses `reason.$response.statusCode`.

In practice this surfaces as the "Converting circular structure to JSON" error reported in the issue, because the TypeError propagates through code paths that then attempt `JSON.stringify` on the raw response object (which contains the Node.js `IncomingMessage`/`ClientRequest` circular reference pair).

## Fix

Add optional chaining to `reason.$response?.statusCode` so the expression safely falls through to `reason.$metadata.httpStatusCode` when `$response` is undefined.

The circular-reference-safe `JSON.stringify` replacer (`getCircularReplacer`) was already wired into both `checkExceptions` and the fallback path of `createMessageFromResponse`, so no additional changes were needed there.

I've also added test coverage to prevent regressions.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
