### PR TITLE
fix(codegen): omit added punctuation from deprecation messages ending with non-alphanumeric

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -390,7 +390,7 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
      */
     static String punctuate(String s) {
         String state = s.trim();
-        if (!state.endsWith(".") && !state.endsWith("?") && !state.endsWith("!")) {
+        if (state.matches("(.*?)\\w$")) {
             return state + ".";
         }
         return s;

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
@@ -190,4 +190,13 @@ public class TypeScriptWriterTest {
         String result = TypeScriptWriter.buildDeprecationAnnotation(trait);
         assertEquals("@deprecated Noo!!!", result);
     }
+
+    @Test
+    public void buildHtmlDeprecationAnnotation() {
+        DeprecatedTrait trait = DeprecatedTrait.builder()
+            .message("<p>Hello</p>")
+            .build();
+        String result = TypeScriptWriter.buildDeprecationAnnotation(trait);
+        assertEquals("@deprecated <p>Hello</p>", result);
+    }
 }


### PR DESCRIPTION
adds periods to deprecation messages only if they end with alphanumerics.