### PR TITLE
fix(protocols): resolve empty httpPayload bindings by content-type

### DIFF
--- a/.changeset/fix-empty-http-payload-binding.md
+++ b/.changeset/fix-empty-http-payload-binding.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Resolve empty httpPayload bindings based on content-type and target schema type, returning empty containers for unstructured formats instead of leaving the member unset.

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.spec.ts
@@ -5,6 +5,7 @@ import { HttpResponse } from "@smithy/protocol-http";
 import type {
   $Schema,
   $ShapeSerializer,
+  BlobSchema,
   Codec,
   CodecSettings,
   HandlerExecutionContext,
@@ -481,6 +482,97 @@ describe(HttpBindingProtocol.name, () => {
     // Only $metadata should be present
     const keys = Object.keys(output);
     expect(keys).toEqual(["$metadata"]);
+  });
+
+  describe("empty httpPayload resolution", () => {
+    const protocol = new StringRestProtocol();
+
+    const makeOutputSchema = (payloadSchemaType: number): StaticStructureSchema => [
+      3,
+      "",
+      "",
+      0,
+      ["payload"],
+      [[payloadSchemaType, { httpPayload: 1 }]],
+    ];
+
+    const deserialize = async (
+      payloadSchemaType: number,
+      headers: Record<string, string>,
+      body?: Readable
+    ) => {
+      const response = new HttpResponse({
+        statusCode: 200,
+        headers,
+        body: body ?? Readable.from(Buffer.alloc(0)),
+      });
+      const output = (await protocol.deserializeResponse(
+        op("", "", 0, "unit", makeOutputSchema(payloadSchemaType)),
+        { streamCollector } as any,
+        response
+      )) as any;
+      return output.payload;
+    };
+
+    it("should return null for empty body with no content-type (blob)", async () => {
+      const result = await deserialize(21 satisfies BlobSchema, {});
+      expect(result).toBeNull();
+    });
+
+    it("should return null for empty body with no content-type (string)", async () => {
+      const result = await deserialize(0 satisfies StringSchema, {});
+      expect(result).toBeNull();
+    });
+
+    it("should return null for empty body with structured content-type (application/json)", async () => {
+      const result = await deserialize(21 satisfies BlobSchema, { "content-type": "application/json" });
+      expect(result).toBeNull();
+    });
+
+    it("should return null for empty body with structured content-type (application/xml)", async () => {
+      const result = await deserialize(21 satisfies BlobSchema, { "content-type": "application/xml" });
+      expect(result).toBeNull();
+    });
+
+    it("should return Uint8Array(0) for empty body with application/octet-stream on blob schema", async () => {
+      const result = await deserialize(21 satisfies BlobSchema, { "content-type": "application/octet-stream" });
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.byteLength).toBe(0);
+    });
+
+    it("should return empty string for empty body with text/plain on string schema", async () => {
+      const result = await deserialize(0 satisfies StringSchema, { "content-type": "text/plain" });
+      expect(result).toBe("");
+    });
+
+    it("should return null when response.body is absent", async () => {
+      const response = new HttpResponse({
+        statusCode: 200,
+        headers: {},
+      });
+      const output = (await protocol.deserializeResponse(
+        op("", "", 0, "unit", makeOutputSchema(21 satisfies BlobSchema)),
+        { streamCollector } as any,
+        response
+      )) as any;
+      expect(output.payload).toBeNull();
+    });
+
+    it("should return empty string for content-type with parameters (text/plain; charset=utf-8)", async () => {
+      const result = await deserialize(0 satisfies StringSchema, { "content-type": "text/plain; charset=utf-8" });
+      expect(result).toBe("");
+    });
+
+    it("should return empty string for application/octet-stream on a string schema (schema type determines container)", async () => {
+      const result = await deserialize(0 satisfies StringSchema, { "content-type": "application/octet-stream" });
+      expect(result).toBe("");
+    });
+
+    it("should return Uint8Array(0) for text/plain on a blob schema (schema type determines container)", async () => {
+      const result = await deserialize(21 satisfies BlobSchema, { "content-type": "text/plain" });
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.byteLength).toBe(0);
+    });
   });
 
   describe("httpLabel", () => {

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
@@ -335,7 +335,11 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
           const bytes: Uint8Array = await collectBody(response.body, context as SerdeFunctions);
           if (bytes.byteLength > 0) {
             dataObject[memberName] = await deserializer.read(memberSchema, bytes);
+          } else {
+            dataObject[memberName] = resolveEmptyPayload(response.headers["content-type"], memberSchema);
           }
+        } else {
+          dataObject[memberName] = null;
         }
       } else if (memberTraits.httpHeader) {
         const key = String(memberTraits.httpHeader).toLowerCase();
@@ -384,3 +388,31 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
     return nonHttpBindingMembers;
   }
 }
+
+/**
+ * Determines the value for an httpPayload member when the response body is
+ * empty (0 bytes). The decision is based on the content-type header and the
+ * target schema type, per the Smithy spec for REST protocol bindings.
+ */
+const STRUCTURED_CONTENT_RE = /\b(json|xml|cbor|yaml)\b/i;
+
+function resolveEmptyPayload(contentType: string | undefined, memberSchema: NormalizedSchema): null | Uint8Array | string {
+  if (!contentType) {
+    return null;
+  }
+
+  if (STRUCTURED_CONTENT_RE.test(contentType)) {
+    return null;
+  }
+
+  // Unstructured content-type — return an empty container matching the schema.
+  if (memberSchema.isBlobSchema()) {
+    return new Uint8Array(0);
+  }
+  if (memberSchema.isStringSchema()) {
+    return "";
+  }
+
+  return null;
+}
+


### PR DESCRIPTION
Refs: aws/aws-sdk-js-v3#7787

### Problem

When a REST protocol response has an empty body (0 bytes) and the output shape has an `httpPayload` member, `HttpBindingProtocol.deserializeHttpMessage` skips assignment entirely — the member is never set on the output object. Downstream protocols paper over this inconsistently: `AwsRestJsonProtocol` patches it to `null`, `AwsRestXmlProtocol` leaves it as `undefined`.

Both behaviors are wrong when the response carries a `content-type` header for an unstructured format (e.g. `application/octet-stream`, `text/plain`). Per the Smithy spec, an empty body with such a content-type should produce an empty container (`Uint8Array(0)` for blobs, `""` for strings), not `null` or `undefined`.

### Changes

In `HttpBindingProtocol.deserializeHttpMessage`, the httpPayload branch now handles empty bodies explicitly instead of silently dropping them:

- Empty body + no content-type → `null`
- Empty body + structured content-type (json/xml/cbor/yaml) → `null`
- Empty body + unstructured content-type + blob schema → `Uint8Array(0)`
- Empty body + unstructured content-type + string schema → `""`
- No body at all → `null`
- Non-empty body → deserialized value (unchanged)

A `resolveEmptyPayload` helper encapsulates this logic so both REST JSON and
REST XML get correct behavior from the base class without per-protocol
post-processing.

### Behavioral impact

The behavior only changes when all three conditions hold simultaneously:

1. The HTTP response body is empty (0 bytes).
2. A `content-type` header is present.
3. The content-type is not a structured format.

In practice, AWS services do not return an empty body with an unstructured content-type today, so the first two rows of the table (no content-type, structured content-type) cover all real-world cases. Their behavior is unchanged or strictly improved (XML: `undefined` → `null`). The unstructured rows become correct if a service ever starts returning them.

Once this is released, aws-sdk-js-v3 can be updated to:
- Remove the `httpPayload` null-assignment loop from `AwsRestJsonProtocol.deserializeResponse`
- Unskip `RestJsonHttpPayloadWithStructureAndEmptyResponseBody:Response` protocol tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
