### PR TITLE
test(snapshot-testing): add error snapshot tests

### DIFF
--- a/.changeset/brown-ears-kick.md
+++ b/.changeset/brown-ears-kick.md
@@ -1,0 +1,5 @@
+---
+"@smithy/snapshot-testing": major
+---
+
+add error snapshots

--- a/packages/snapshot-testing/integ-snapshots/res-err/ComplexError.txt
+++ b/packages/snapshot-testing/integ-snapshots/res-err/ComplexError.txt
@@ -1,0 +1,103 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.protocoltests.rpcv2Cbor#ComplexError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 43, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 67, 111, 109, 112, 108, 101, 120,
+69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+ComplexError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ComplexError",
+  TopLevel: (undefined),
+  Nested: (undefined),
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.protocoltests.rpcv2Cbor#ComplexError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 43, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 67, 111, 109, 112, 108, 101, 120,
+69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+ComplexError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ComplexError",
+  TopLevel: (undefined),
+  Nested: (undefined),
+  message: "Unknown"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 3,
+    totalRetryDelay: (number) 247
+  },
+  name: "Unknown"
+}
+

--- a/packages/snapshot-testing/integ-snapshots/res-err/InvalidGreeting.txt
+++ b/packages/snapshot-testing/integ-snapshots/res-err/InvalidGreeting.txt
@@ -1,0 +1,101 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.protocoltests.rpcv2Cbor#InvalidGreeting"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 46, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 73, 110, 118, 97, 108, 105, 100,
+71, 114, 101, 101, 116, 105, 110, 103
+
+
+--- [error name & message] ---
+InvalidGreeting: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "InvalidGreeting",
+  Message: (undefined),
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.protocoltests.rpcv2Cbor#InvalidGreeting"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 46, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 73, 110, 118, 97, 108, 105, 100,
+71, 114, 101, 101, 116, 105, 110, 103
+
+
+--- [error name & message] ---
+InvalidGreeting: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "InvalidGreeting",
+  Message: (undefined),
+  message: "Unknown"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 3,
+    totalRetryDelay: (number) 75
+  },
+  name: "Unknown"
+}
+

--- a/packages/snapshot-testing/integ-snapshots/res-err/RpcV2ProtocolServiceException.txt
+++ b/packages/snapshot-testing/integ-snapshots/res-err/RpcV2ProtocolServiceException.txt
@@ -1,0 +1,101 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.ts.sdk.synthetic.smithy.protocoltests.rpcv2Cbor#RpcV2ProtocolServiceException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 84, 115, 109, 105, 116, 104, 121, 46, 116, 115, 46, 115, 100, 107, 46,
+115, 121, 110, 116, 104, 101, 116, 105, 99, 46, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 82, 112, 99, 86, 50, 80, 114,
+111, 116, 111, 99, 111, 108, 83, 101, 114, 118, 105, 99, 101, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+RpcV2ProtocolServiceException: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "RpcV2ProtocolServiceException",
+  __type: "smithy.ts.sdk.synthetic.smithy.protocoltests.rpcv2Cbor#RpcV2ProtocolServiceException"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.ts.sdk.synthetic.smithy.protocoltests.rpcv2Cbor#RpcV2ProtocolServiceException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 84, 115, 109, 105, 116, 104, 121, 46, 116, 115, 46, 115, 100, 107, 46,
+115, 121, 110, 116, 104, 101, 116, 105, 99, 46, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 82, 112, 99, 86, 50, 80, 114,
+111, 116, 111, 99, 111, 108, 83, 101, 114, 118, 105, 99, 101, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+RpcV2ProtocolServiceException: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "RpcV2ProtocolServiceException",
+  __type: "smithy.ts.sdk.synthetic.smithy.protocoltests.rpcv2Cbor#RpcV2ProtocolServiceException"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 3,
+    totalRetryDelay: (number) 94
+  },
+  name: "Unknown"
+}
+

--- a/packages/snapshot-testing/integ-snapshots/res-err/ValidationException.txt
+++ b/packages/snapshot-testing/integ-snapshots/res-err/ValidationException.txt
@@ -1,0 +1,97 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.framework#ValidationException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 36, 115, 109, 105, 116, 104, 121, 46, 102, 114, 97, 109, 101, 119, 111,
+114, 107, 35, 86, 97, 108, 105, 100, 97, 116, 105, 111, 110, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+ValidationException: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ValidationException",
+  __type: "smithy.framework#ValidationException"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.framework#ValidationException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 36, 115, 109, 105, 116, 104, 121, 46, 102, 114, 97, 109, 101, 119, 111,
+114, 107, 35, 86, 97, 108, 105, 100, 97, 116, 105, 111, 110, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+ValidationException: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ValidationException",
+  __type: "smithy.framework#ValidationException"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 3,
+    totalRetryDelay: (number) 253
+  },
+  name: "Unknown"
+}
+

--- a/packages/snapshot-testing/integ-snapshots/res/EmptyInputOutput.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/EmptyInputOutput.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -36,7 +36,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,

--- a/packages/snapshot-testing/integ-snapshots/res/Float16.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/Float16.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -38,7 +38,7 @@ content-type: application/cbor
 161, 101, 118, 97, 108, 117, 101, 0
 
 
-[output]
+--- [output object] ---
 {
   value: (number) 0,
   $metadata: {

--- a/packages/snapshot-testing/integ-snapshots/res/FractionalSeconds.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/FractionalSeconds.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -41,9 +41,9 @@ content-type: application/cbor
 161, 104, 100, 97, 116, 101, 116, 105, 109, 101, 193, 251, 65, 204, 54, 196, 231, 255, 223, 59
 
 
-[output]
+--- [output object] ---
 {
-  datetime: (Date) 12/31/1999, 11:59:59 PM,
+  datetime: (Date) Fri, Dec 31, 1999, 20:59:59 Pacific Standard Time,
   $metadata: {
     httpStatusCode: (number) 200,
     requestId: (undefined),

--- a/packages/snapshot-testing/integ-snapshots/res/GreetingWithErrors.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/GreetingWithErrors.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -38,7 +38,7 @@ content-type: application/cbor
 161, 104, 103, 114, 101, 101, 116, 105, 110, 103, 108, 95, 95, 103, 114, 101, 101, 116, 105, 110, 103, 95, 95
 
 
-[output]
+--- [output object] ---
 {
   greeting: "__greeting__",
   $metadata: {

--- a/packages/snapshot-testing/integ-snapshots/res/NoInputOutput.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/NoInputOutput.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -36,7 +36,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,

--- a/packages/snapshot-testing/integ-snapshots/res/RecursiveShapes.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/RecursiveShapes.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -54,7 +54,7 @@ content-type: application/cbor
 115, 105, 118, 101, 77, 101, 109, 98, 101, 114, 160
 
 
-[output]
+--- [output object] ---
 {
   nested: {
     foo: "__foo__",

--- a/packages/snapshot-testing/integ-snapshots/res/RpcV2CborSparseMaps.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/RpcV2CborSparseMaps.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -79,7 +79,7 @@ content-type: application/cbor
 109, 101, 109, 98, 101, 114, 95, 95
 
 
-[output]
+--- [output object] ---
 {
   sparseStructMap: {
     key1: {

--- a/packages/snapshot-testing/integ-snapshots/res/SimpleScalarProperties.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/SimpleScalarProperties.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -61,7 +61,7 @@ content-type: application/cbor
 86, 97, 108, 117, 101, 68, 1, 0, 0, 1
 
 
-[output]
+--- [output object] ---
 {
   trueBooleanValue: (boolean) false,
   falseBooleanValue: (boolean) false,

--- a/packages/snapshot-testing/integ-snapshots/res/SparseNullsOperation.txt
+++ b/packages/snapshot-testing/integ-snapshots/res/SparseNullsOperation.txt
@@ -11,7 +11,7 @@ content-type: application/cbor
 160
 
 
-[output]
+--- [output object] ---
 {
   $metadata: {
     httpStatusCode: (number) 200,
@@ -50,7 +50,7 @@ content-type: application/cbor
 101, 95, 95
 
 
-[output]
+--- [output object] ---
 {
   sparseStringList: [
     "__member__",

--- a/packages/snapshot-testing/src/SnapshotRunner.ts
+++ b/packages/snapshot-testing/src/SnapshotRunner.ts
@@ -1,5 +1,12 @@
 import { NormalizedSchema } from "@smithy/core/schema";
-import type { Client, Command, HttpResponse as IHttpResponse, Logger, StaticOperationSchema } from "@smithy/types";
+import type {
+  Client,
+  Command,
+  HttpResponse as IHttpResponse,
+  Logger,
+  StaticErrorSchema,
+  StaticOperationSchema,
+} from "@smithy/types";
 import { readFileSync } from "fs";
 import { accessSync, constants, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -49,6 +56,11 @@ export interface SnapshotRunnerOptions {
   schemas: Map<StaticOperationSchema, $CommandCtor>;
 
   /**
+   * Errors for which to generate response-error snapshots.
+   */
+  errors?: StaticErrorSchema[];
+
+  /**
    * write - write the data without comparing.
    * compare - throw if comparison to existing files in the same folder contain mismatches.
    *
@@ -96,6 +108,7 @@ export class SnapshotRunner {
           throw new Error(`Serialization for ${caseName} does not match snapshot on disk.`);
         }
       },
+      errors = [],
     } = this.options;
 
     if (mode === "write") {
@@ -156,6 +169,7 @@ export class SnapshotRunner {
 
     // responses
     for (const [schema, CommandCtor] of schemas) {
+      const [, namespace, name, traits, input, output] = schema;
       const operationName = CommandCtor.name.replace(/Command$/, "");
 
       const testCaseExec = testCase(operationName + " (response)", async () => {
@@ -186,14 +200,11 @@ export class SnapshotRunner {
 
           // copies to allow two types of serializers to read the response stream.
           const [r1, r2] = [
-            await snapshotProtocol.serializeResponse(
-              schema,
-              createFromSchema(schema[5 /*output*/], undefined, options)
-            ),
-            await snapshotProtocol.serializeResponse(schema, createFromSchema(schema[5], undefined, options)),
+            await snapshotProtocol.serializeResponse(schema, createFromSchema(output, undefined, options)),
+            await snapshotProtocol.serializeResponse(schema, createFromSchema(output, undefined, options)),
           ];
 
-          const ns = NormalizedSchema.of(schema[5]);
+          const ns = NormalizedSchema.of(output);
           const mayBufferResponseBody =
             !ns.getEventStreamMember() &&
             !Object.values(ns.getMemberSchemas()).some(($) => $.isBlobSchema() && $.isStreaming());
@@ -201,7 +212,7 @@ export class SnapshotRunner {
           const serialization = await serializeHttpResponse(r1, mayBufferResponseBody);
           logger.trace(serialization);
 
-          const command = new CommandCtor(createFromSchema(schema[4 /*input*/]));
+          const command = new CommandCtor(createFromSchema(input));
           client.config.requestHandler = new SnapshotRequestHandler({
             response: r2,
           });
@@ -232,6 +243,109 @@ export class SnapshotRunner {
           } else {
             if (canonical !== buf) {
               throw new Error(`Deserialization for ${CommandCtor.name} does not match snapshot on disk.`);
+            }
+          }
+        } else {
+          writeFileSync(snapshotPath, buf, "utf-8");
+        }
+      });
+
+      promises.push(Promise.resolve(testCaseExec));
+    }
+
+    // errors
+    const [$operation, CommandCtor] = schemas[Symbol.iterator]().next().value!;
+    const [, ns] = $operation;
+
+    for (const $error of [
+      [-3, ns, "UnmodeledServiceException", { error: "server" }, ["Message"], [0]] satisfies StaticErrorSchema,
+      ...errors,
+    ]) {
+      const [, namespace, name, traits, memberNames, members, requiredMemberCount] = $error;
+      const $errorNormalized = NormalizedSchema.of($error);
+      const qualifiedName = $errorNormalized.getName(true);
+
+      const testCaseExec = testCase(qualifiedName + " (error)", async () => {
+        let buf = ``;
+        const logger = {
+          ...console,
+          trace(msg: string) {
+            buf += msg;
+          },
+        };
+
+        const client = this.initClient(Client, { endpoint: "https://localhost", logger, maxAttempts: 1 });
+        const protocolId = client.config.protocol.getShapeId();
+
+        for (const options of [{ mode: "min" }, { mode: "max" }, { mode: "frontend" }] as const) {
+          if (options.mode === "frontend") {
+            logger.trace("=".repeat(24) + ` frontend error ` + "=".repeat(24));
+          } else if (options.mode === "min") {
+            logger.trace("=".repeat(24) + ` minimal response ` + "=".repeat(24));
+          } else if (options.mode === "max") {
+            logger.trace("=".repeat(24) + ` w/ optional fields ` + "=".repeat(24));
+          }
+          logger.trace("\n");
+
+          const snapshotProtocol = snapshotTestingProtocolResponseSerializers[protocolId];
+          if (!snapshotProtocol) {
+            throw new Error(`No response serializer found for protocol: ${protocolId}`);
+          }
+          snapshotProtocol.setSerdeContext(client.config);
+
+          // copies to allow two types of serializers to read the response stream.
+          const [r1, r2] =
+            options.mode === "frontend"
+              ? [
+                  await snapshotProtocol.serializeGenericFrontendErrorResponse(),
+                  await snapshotProtocol.serializeGenericFrontendErrorResponse(),
+                ]
+              : [
+                  await snapshotProtocol.serializeErrorResponse($error, createFromSchema($error, undefined, options)),
+                  await snapshotProtocol.serializeErrorResponse($error, createFromSchema($error, undefined, options)),
+                ];
+
+          const ns = NormalizedSchema.of($operation[5]);
+          const mayBufferResponseBody =
+            !ns.getEventStreamMember() &&
+            !Object.values(ns.getMemberSchemas()).some(($) => $.isBlobSchema() && $.isStreaming());
+
+          const serialization = await serializeHttpResponse(r1, mayBufferResponseBody);
+          logger.trace(serialization);
+
+          const command = new CommandCtor(createFromSchema($operation[4 /*input*/]));
+          client.config.requestHandler = new SnapshotRequestHandler({
+            response: r2,
+          });
+          try {
+            const output = await client.send(command).catch((e: any) => e);
+            const outputSerialization = await serializeDocument(output);
+
+            logger.trace("\n\n--- [error name & message] ---\n");
+            logger.trace(`${output.name}: ${output.message}`);
+            logger.trace("\n\n--- [error object] ---\n");
+            logger.trace(outputSerialization);
+          } catch (e) {
+            logger.trace(`\n\n[CommandError]\n`);
+            logger.trace(e.stack);
+            logger.error(`${e.name}: ${e.message}`);
+          }
+          logger.trace("\n\n");
+        }
+
+        const snapshotPath = join(snapshotDirPath, "res-err", name + ".txt");
+        const containerFolder = dirname(snapshotPath);
+        if (!existsSync(containerFolder)) {
+          mkdirSync(containerFolder, { recursive: true });
+        }
+
+        if (mode === "compare") {
+          const canonical = readFileSync(snapshotPath, "utf-8");
+          if (assertions) {
+            assertions(name, canonical, buf);
+          } else {
+            if (canonical !== buf) {
+              throw new Error(`Error deserialization for ${name} does not match snapshot on disk.`);
             }
           }
         } else {
@@ -294,7 +408,12 @@ export class SnapshotRunner {
 
   private initClient(
     Client: any,
-    { endpoint, logger, response }: { endpoint?: string; logger?: Logger; response?: IHttpResponse }
+    {
+      endpoint,
+      logger,
+      response,
+      maxAttempts,
+    }: { endpoint?: string; logger?: Logger; response?: IHttpResponse; maxAttempts?: number }
   ): any {
     return new Client({
       region: "us-east-1",
@@ -308,6 +427,7 @@ export class SnapshotRunner {
         logger,
         response,
       }),
+      maxAttempts,
     });
   }
 

--- a/packages/snapshot-testing/src/protocols/SmithyRpcV2CborSnapshotProtocol.ts
+++ b/packages/snapshot-testing/src/protocols/SmithyRpcV2CborSnapshotProtocol.ts
@@ -1,6 +1,6 @@
 import { CborCodec } from "@smithy/core/cbor";
 import { NormalizedSchema } from "@smithy/core/schema";
-import type { HttpResponse, StaticOperationSchema } from "@smithy/types";
+import type { HttpResponse, StaticErrorSchema, StaticOperationSchema } from "@smithy/types";
 
 import type { SnapshotServerProtocol } from "../snapshot-testing-types";
 import { SnapshotProtocol } from "./SnapshotProtocol";
@@ -52,6 +52,34 @@ export class SmithyRpcV2CborSnapshotProtocol extends SnapshotProtocol implements
       // refrain from wrapping in Readable so the snapshot can use object view on the bytes.
       response.body = serializer.flush();
     }
+
+    return response;
+  }
+
+  public async serializeErrorResponse<Output extends object>(
+    errorSchema: StaticErrorSchema,
+    output: Output
+  ): Promise<HttpResponse> {
+    const $error = NormalizedSchema.of(errorSchema);
+    const clientFault = $error.getMergedTraits().error !== "server";
+    const httpError = $error.getMergedTraits().httpError;
+    const status = Number(typeof httpError === "number" ? httpError : clientFault ? 400 : 500);
+
+    const response: HttpResponse = {
+      statusCode: status,
+      headers: {
+        "smithy-protocol": "rpc-v2-cbor",
+        "content-type": this.getDefaultContentType(),
+      },
+    };
+
+    const { serializer } = this;
+
+    Object.assign(output, {
+      __type: $error.getName(true),
+    });
+    serializer.write($error, output);
+    response.body = serializer.flush();
 
     return response;
   }

--- a/packages/snapshot-testing/src/protocols/SnapshotProtocol.ts
+++ b/packages/snapshot-testing/src/protocols/SnapshotProtocol.ts
@@ -1,13 +1,16 @@
 import { EventStreamSerde } from "@smithy/core/event-streams";
 import { SerdeContext } from "@smithy/core/protocols";
+import { HttpResponse } from "@smithy/protocol-http";
 import type {
   $ShapeDeserializer,
   $ShapeSerializer,
   EventStreamMarshaller,
   EventStreamSerdeContext,
-  HttpResponse,
+  HttpResponse as IHttpResponse,
+  StaticErrorSchema,
   StaticOperationSchema,
 } from "@smithy/types";
+import { Readable } from "stream";
 
 import type { SnapshotServerProtocol } from "../snapshot-testing-types";
 
@@ -22,7 +25,22 @@ export abstract class SnapshotProtocol extends SerdeContext implements SnapshotS
   public abstract serializeResponse<Output extends object>(
     operationSchema: StaticOperationSchema,
     output: Output
-  ): Promise<HttpResponse>;
+  ): Promise<IHttpResponse>;
+
+  public abstract serializeErrorResponse<Output extends object>(
+    errorSchema: StaticErrorSchema,
+    output: Output
+  ): Promise<IHttpResponse>;
+
+  public async serializeGenericFrontendErrorResponse(): Promise<IHttpResponse> {
+    return new HttpResponse({
+      headers: {
+        "content-type": "text/html",
+      },
+      statusCode: 500,
+      body: Readable.from("An unmodeled error occurred in a front end layer."),
+    });
+  }
 
   protected getEventStreamSerde(
     serializer: $ShapeSerializer<string> | $ShapeSerializer,

--- a/packages/snapshot-testing/src/snapshot-testing.integ.spec.ts
+++ b/packages/snapshot-testing/src/snapshot-testing.integ.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ComplexError$,
   EmptyInputOutput$,
   EmptyInputOutputCommand,
   Float16$,
@@ -7,6 +8,7 @@ import {
   FractionalSecondsCommand,
   GreetingWithErrors$,
   GreetingWithErrorsCommand,
+  InvalidGreeting$,
   NoInputOutput$,
   NoInputOutputCommand,
   RecursiveShapes$,
@@ -14,10 +16,12 @@ import {
   RpcV2CborSparseMaps$,
   RpcV2CborSparseMapsCommand,
   RpcV2Protocol,
+  RpcV2ProtocolServiceException$,
   SimpleScalarProperties$,
   SimpleScalarPropertiesCommand,
   SparseNullsOperation$,
   SparseNullsOperationCommand,
+  ValidationException$,
 } from "@smithy/smithy-rpcv2-cbor-schema";
 import type { Command, StaticOperationSchema } from "@smithy/types";
 import * as path from "node:path";
@@ -42,6 +46,7 @@ describe("snapshot testing", () => {
       [SparseNullsOperation$, SparseNullsOperationCommand],
       [SimpleScalarProperties$, SimpleScalarPropertiesCommand],
     ]),
+    errors: [RpcV2ProtocolServiceException$, ValidationException$, ComplexError$, InvalidGreeting$],
     mode: "write",
     testCase(caseName: string, run: () => Promise<void>) {
       it(caseName, run);

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -36,6 +36,7 @@ const _h = "http";
 const _hE = "httpError";
 const _i = "id";
 const _iDN = "inexplicablyDeprecatedNumbers";
+const _m = "message";
 const _mR = "maxResults";
 const _n = "numbers";
 const _nT = "nextToken";
@@ -81,8 +82,8 @@ export var CodedThrottlingError$: StaticErrorSchema = [-3, n0, _CTE,
 n0_registry.registerError(CodedThrottlingError$, CodedThrottlingError);
 export var HaltError$: StaticErrorSchema = [-3, n0, _HE,
   { [_e]: _c },
-  [],
-  []
+  [_m],
+  [0]
 ];
 n0_registry.registerError(HaltError$, HaltError);
 export var MainServiceLinkedError$: StaticErrorSchema = [-3, n0, _MSLE,
@@ -99,8 +100,8 @@ export var MysteryThrottlingError$: StaticErrorSchema = [-3, n0, _MTE,
 n0_registry.registerError(MysteryThrottlingError$, MysteryThrottlingError);
 export var RetryableError$: StaticErrorSchema = [-3, n0, _RE,
   { [_e]: _c },
-  [],
-  []
+  [_m],
+  [0]
 ];
 n0_registry.registerError(RetryableError$, RetryableError);
 export var XYZServiceServiceException$: StaticErrorSchema = [-3, n0, _XYZSSE,

--- a/private/my-local-model-schema/test/snapshots.integ.spec.ts
+++ b/private/my-local-model-schema/test/snapshots.integ.spec.ts
@@ -6,13 +6,19 @@ import { describe, expect, test as it, vi } from "vitest";
 import {
   camelCaseOperation$,
   CamelCaseOperationCommand,
+  CodedThrottlingError$,
   GetNumbers$,
   GetNumbersCommand,
+  HaltError$,
   HttpLabelCommand$,
   HttpLabelCommandCommand,
+  MainServiceLinkedError$,
+  MysteryThrottlingError$,
+  RetryableError$,
   TradeEventStream$,
   TradeEventStreamCommand,
   XYZServiceClient,
+  XYZServiceServiceException$,
 } from "../src";
 
 vi.setSystemTime(new Date(946702799999));
@@ -32,15 +38,20 @@ describe("XYZServiceClient" + ` (${mode})`, () => {
       expect(actual).toEqual(expected);
       return Promise.resolve();
     },
-    schemas:
-      new Map<any, any>([
-        [HttpLabelCommand$, HttpLabelCommandCommand],
-        [camelCaseOperation$, CamelCaseOperationCommand],
-        [GetNumbers$, GetNumbersCommand],
-        [TradeEventStream$, TradeEventStreamCommand],
-      ]),
-
+    schemas: new Map<any, any>([
+      [HttpLabelCommand$, HttpLabelCommandCommand],
+      [camelCaseOperation$, CamelCaseOperationCommand],
+      [GetNumbers$, GetNumbersCommand],
+      [TradeEventStream$, TradeEventStreamCommand],
+    ]),
+    errors: [
+      CodedThrottlingError$,
+      HaltError$,
+      MainServiceLinkedError$,
+      MysteryThrottlingError$,
+      RetryableError$,
+      XYZServiceServiceException$,
+    ],
   });
-
   runner.run();
 }, 30_000);

--- a/private/my-local-model-schema/test/snapshots/res-err/CodedThrottlingError.txt
+++ b/private/my-local-model-schema/test/snapshots/res-err/CodedThrottlingError.txt
@@ -1,0 +1,102 @@
+======================== minimal response ========================
+[status] 429
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#CodedThrottlingError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 31, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 67, 111, 100,
+101, 100, 84, 104, 114, 111, 116, 116, 108, 105, 110, 103, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+CodedThrottlingError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: {
+    throttling: (boolean) true
+  },
+  $metadata: {
+    httpStatusCode: (number) 429,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "CodedThrottlingError",
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 429
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#CodedThrottlingError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 31, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 67, 111, 100,
+101, 100, 84, 104, 114, 111, 116, 116, 108, 105, 110, 103, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+CodedThrottlingError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: {
+    throttling: (boolean) true
+  },
+  $metadata: {
+    httpStatusCode: (number) 429,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "CodedThrottlingError",
+  message: "Unknown"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/my-local-model-schema/test/snapshots/res-err/HaltError.txt
+++ b/private/my-local-model-schema/test/snapshots/res-err/HaltError.txt
@@ -1,0 +1,100 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#HaltError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 116, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 72, 97, 108, 116,
+69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+HaltError: undefined
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "HaltError",
+  message: (undefined)
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "message": "__message__",
+  "__type": "org.xyz.v1#HaltError"
+}
+
+[actual bytes]
+162, 103, 109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 102, 95, 95,
+116, 121, 112, 101, 116, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 72, 97, 108, 116, 69, 114, 114, 111,
+114
+
+
+--- [error name & message] ---
+HaltError: __message__
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "HaltError",
+  message: "__message__"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/my-local-model-schema/test/snapshots/res-err/MainServiceLinkedError.txt
+++ b/private/my-local-model-schema/test/snapshots/res-err/MainServiceLinkedError.txt
@@ -1,0 +1,98 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#MainServiceLinkedError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 33, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 77, 97, 105,
+110, 83, 101, 114, 118, 105, 99, 101, 76, 105, 110, 107, 101, 100, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+MainServiceLinkedError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "MainServiceLinkedError",
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#MainServiceLinkedError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 33, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 77, 97, 105,
+110, 83, 101, 114, 118, 105, 99, 101, 76, 105, 110, 107, 101, 100, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+MainServiceLinkedError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "MainServiceLinkedError",
+  message: "Unknown"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/my-local-model-schema/test/snapshots/res-err/MysteryThrottlingError.txt
+++ b/private/my-local-model-schema/test/snapshots/res-err/MysteryThrottlingError.txt
@@ -1,0 +1,102 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#MysteryThrottlingError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 33, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 77, 121, 115,
+116, 101, 114, 121, 84, 104, 114, 111, 116, 116, 108, 105, 110, 103, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+MysteryThrottlingError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: {
+    throttling: (boolean) true
+  },
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "MysteryThrottlingError",
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#MysteryThrottlingError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 33, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 77, 121, 115,
+116, 101, 114, 121, 84, 104, 114, 111, 116, 116, 108, 105, 110, 103, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+MysteryThrottlingError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: {
+    throttling: (boolean) true
+  },
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "MysteryThrottlingError",
+  message: "Unknown"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/my-local-model-schema/test/snapshots/res-err/RetryableError.txt
+++ b/private/my-local-model-schema/test/snapshots/res-err/RetryableError.txt
@@ -1,0 +1,100 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#RetryableError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 25, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 82, 101, 116,
+114, 121, 97, 98, 108, 101, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+RetryableError: undefined
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: {},
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "RetryableError",
+  message: (undefined)
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "message": "__message__",
+  "__type": "org.xyz.v1#RetryableError"
+}
+
+[actual bytes]
+162, 103, 109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 102, 95, 95,
+116, 121, 112, 101, 120, 25, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 82, 101, 116, 114, 121, 97, 98,
+108, 101, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+RetryableError: __message__
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: {},
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "RetryableError",
+  message: "__message__"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/my-local-model-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/my-local-model-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -1,0 +1,104 @@
+======================== minimal response ========================
+[status] 500
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.secondary#UnmodeledServiceException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 43, 111, 114, 103, 46, 120, 121, 122, 46, 115, 101, 99, 111, 110, 100,
+97, 114, 121, 35, 85, 110, 109, 111, 100, 101, 108, 101, 100, 83, 101, 114, 118, 105, 99, 101, 69, 120, 99, 101,
+112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+UnmodeledServiceException: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "UnmodeledServiceException",
+  __type: "org.xyz.secondary#UnmodeledServiceException"
+}
+
+======================== w/ optional fields ========================
+[status] 500
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "Message": "__Message__",
+  "__type": "org.xyz.secondary#UnmodeledServiceException"
+}
+
+[actual bytes]
+162, 103, 77, 101, 115, 115, 97, 103, 101, 107, 95, 95, 77, 101, 115, 115, 97, 103, 101, 95, 95, 102, 95, 95,
+116, 121, 112, 101, 120, 43, 111, 114, 103, 46, 120, 121, 122, 46, 115, 101, 99, 111, 110, 100, 97, 114, 121, 35,
+85, 110, 109, 111, 100, 101, 108, 101, 100, 83, 101, 114, 118, 105, 99, 101, 69, 120, 99, 101, 112, 116, 105, 111,
+110
+
+
+--- [error name & message] ---
+UnmodeledServiceException: __Message__
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "UnmodeledServiceException",
+  Message: "__Message__",
+  __type: "org.xyz.secondary#UnmodeledServiceException",
+  message: "__Message__"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/my-local-model-schema/test/snapshots/res-err/XYZServiceServiceException.txt
+++ b/private/my-local-model-schema/test/snapshots/res-err/XYZServiceServiceException.txt
@@ -1,0 +1,98 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#XYZServiceServiceException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 37, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 88, 89, 90,
+83, 101, 114, 118, 105, 99, 101, 83, 101, 114, 118, 105, 99, 101, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+XYZServiceServiceException: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "XYZServiceServiceException",
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "org.xyz.v1#XYZServiceServiceException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 37, 111, 114, 103, 46, 120, 121, 122, 46, 118, 49, 35, 88, 89, 90,
+83, 101, 114, 118, 105, 99, 101, 83, 101, 114, 118, 105, 99, 101, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+XYZServiceServiceException: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "XYZServiceServiceException",
+  message: "Unknown"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/smithy-rpcv2-cbor-schema/test/snapshots.integ.spec.ts
+++ b/private/smithy-rpcv2-cbor-schema/test/snapshots.integ.spec.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, test as it, vi } from "vitest";
 
 import {
+  ComplexError$,
   EmptyInputOutput$,
   EmptyInputOutputCommand,
   Float16$,
@@ -12,6 +13,7 @@ import {
   FractionalSecondsCommand,
   GreetingWithErrors$,
   GreetingWithErrorsCommand,
+  InvalidGreeting$,
   NoInputOutput$,
   NoInputOutputCommand,
   OperationWithDefaults$,
@@ -31,6 +33,7 @@ import {
   SimpleScalarPropertiesCommand,
   SparseNullsOperation$,
   SparseNullsOperationCommand,
+  ValidationException$,
 } from "../src";
 
 vi.setSystemTime(new Date(946702799999));
@@ -50,24 +53,26 @@ describe("RpcV2ProtocolClient" + ` (${mode})`, () => {
       expect(actual).toEqual(expected);
       return Promise.resolve();
     },
-    schemas:
-      new Map<any, any>([
-        [EmptyInputOutput$, EmptyInputOutputCommand],
-        [Float16$, Float16Command],
-        [FractionalSeconds$, FractionalSecondsCommand],
-        [GreetingWithErrors$, GreetingWithErrorsCommand],
-        [NoInputOutput$, NoInputOutputCommand],
-        [OperationWithDefaults$, OperationWithDefaultsCommand],
-        [OptionalInputOutput$, OptionalInputOutputCommand],
-        [RecursiveShapes$, RecursiveShapesCommand],
-        [RpcV2CborDenseMaps$, RpcV2CborDenseMapsCommand],
-        [RpcV2CborLists$, RpcV2CborListsCommand],
-        [RpcV2CborSparseMaps$, RpcV2CborSparseMapsCommand],
-        [SimpleScalarProperties$, SimpleScalarPropertiesCommand],
-        [SparseNullsOperation$, SparseNullsOperationCommand],
-      ]),
-
+    schemas: new Map<any, any>([
+      [EmptyInputOutput$, EmptyInputOutputCommand],
+      [Float16$, Float16Command],
+      [FractionalSeconds$, FractionalSecondsCommand],
+      [GreetingWithErrors$, GreetingWithErrorsCommand],
+      [NoInputOutput$, NoInputOutputCommand],
+      [OperationWithDefaults$, OperationWithDefaultsCommand],
+      [OptionalInputOutput$, OptionalInputOutputCommand],
+      [RecursiveShapes$, RecursiveShapesCommand],
+      [RpcV2CborDenseMaps$, RpcV2CborDenseMapsCommand],
+      [RpcV2CborLists$, RpcV2CborListsCommand],
+      [RpcV2CborSparseMaps$, RpcV2CborSparseMapsCommand],
+      [SimpleScalarProperties$, SimpleScalarPropertiesCommand],
+      [SparseNullsOperation$, SparseNullsOperationCommand],
+    ]),
+    errors: [
+      ValidationException$,
+      ComplexError$,
+      InvalidGreeting$,
+    ],
   });
-
   runner.run();
 }, 30_000);

--- a/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/ComplexError.txt
@@ -1,0 +1,111 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.protocoltests.rpcv2Cbor#ComplexError"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 43, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 67, 111, 109, 112, 108, 101, 120,
+69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+ComplexError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ComplexError",
+  TopLevel: (undefined),
+  Nested: (undefined),
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "TopLevel": "__TopLevel__",
+  "Nested": {
+    "Foo": "__Foo__"
+  },
+  "__type": "smithy.protocoltests.rpcv2Cbor#ComplexError"
+}
+
+[actual bytes]
+163, 104, 84, 111, 112, 76, 101, 118, 101, 108, 108, 95, 95, 84, 111, 112, 76, 101, 118, 101, 108, 95, 95, 102,
+78, 101, 115, 116, 101, 100, 161, 99, 70, 111, 111, 103, 95, 95, 70, 111, 111, 95, 95, 102, 95, 95, 116, 121,
+112, 101, 120, 43, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111, 108, 116, 101, 115, 116, 115,
+46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 67, 111, 109, 112, 108, 101, 120, 69, 114, 114, 111, 114
+
+
+--- [error name & message] ---
+ComplexError: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ComplexError",
+  TopLevel: "__TopLevel__",
+  Nested: {
+    Foo: "__Foo__"
+  },
+  message: "Unknown"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -1,0 +1,104 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.protocoltests.rpcv2Cbor#InvalidGreeting"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 46, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 73, 110, 118, 97, 108, 105, 100,
+71, 114, 101, 101, 116, 105, 110, 103
+
+
+--- [error name & message] ---
+InvalidGreeting: Unknown
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "InvalidGreeting",
+  Message: (undefined),
+  message: "Unknown"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "Message": "__Message__",
+  "__type": "smithy.protocoltests.rpcv2Cbor#InvalidGreeting"
+}
+
+[actual bytes]
+162, 103, 77, 101, 115, 115, 97, 103, 101, 107, 95, 95, 77, 101, 115, 115, 97, 103, 101, 95, 95, 102, 95, 95,
+116, 121, 112, 101, 120, 46, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111, 108, 116, 101, 115,
+116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 73, 110, 118, 97, 108, 105, 100, 71, 114, 101, 101,
+116, 105, 110, 103
+
+
+--- [error name & message] ---
+InvalidGreeting: __Message__
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "InvalidGreeting",
+  Message: "__Message__",
+  message: "__Message__"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -1,0 +1,104 @@
+======================== minimal response ========================
+[status] 500
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "__type": "smithy.protocoltests.rpcv2Cbor#UnmodeledServiceException"
+}
+
+[actual bytes]
+161, 102, 95, 95, 116, 121, 112, 101, 120, 56, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111,
+108, 116, 101, 115, 116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 85, 110, 109, 111, 100, 101, 108,
+101, 100, 83, 101, 114, 118, 105, 99, 101, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+UnmodeledServiceException: 
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "UnmodeledServiceException",
+  __type: "smithy.protocoltests.rpcv2Cbor#UnmodeledServiceException"
+}
+
+======================== w/ optional fields ========================
+[status] 500
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "Message": "__Message__",
+  "__type": "smithy.protocoltests.rpcv2Cbor#UnmodeledServiceException"
+}
+
+[actual bytes]
+162, 103, 77, 101, 115, 115, 97, 103, 101, 107, 95, 95, 77, 101, 115, 115, 97, 103, 101, 95, 95, 102, 95, 95,
+116, 121, 112, 101, 120, 56, 115, 109, 105, 116, 104, 121, 46, 112, 114, 111, 116, 111, 99, 111, 108, 116, 101, 115,
+116, 115, 46, 114, 112, 99, 118, 50, 67, 98, 111, 114, 35, 85, 110, 109, 111, 100, 101, 108, 101, 100, 83, 101,
+114, 118, 105, 99, 101, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+UnmodeledServiceException: __Message__
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "UnmodeledServiceException",
+  Message: "__Message__",
+  __type: "smithy.protocoltests.rpcv2Cbor#UnmodeledServiceException",
+  message: "__Message__"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/ValidationException.txt
+++ b/private/smithy-rpcv2-cbor-schema/test/snapshots/res-err/ValidationException.txt
@@ -1,0 +1,170 @@
+======================== minimal response ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "message": "__message__",
+  "fieldList": [
+    {
+      "path": "__path__",
+      "message": "__message__"
+    },
+    {
+      "path": "__path__",
+      "message": "__message__"
+    },
+    {
+      "path": "__path__",
+      "message": "__message__"
+    }
+  ],
+  "__type": "smithy.framework#ValidationException"
+}
+
+[actual bytes]
+163, 103, 109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 105, 102, 105,
+101, 108, 100, 76, 105, 115, 116, 131, 162, 100, 112, 97, 116, 104, 104, 95, 95, 112, 97, 116, 104, 95, 95, 103,
+109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 162, 100, 112, 97, 116,
+104, 104, 95, 95, 112, 97, 116, 104, 95, 95, 103, 109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115,
+115, 97, 103, 101, 95, 95, 162, 100, 112, 97, 116, 104, 104, 95, 95, 112, 97, 116, 104, 95, 95, 103, 109, 101,
+115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 102, 95, 95, 116, 121, 112, 101,
+120, 36, 115, 109, 105, 116, 104, 121, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 35, 86, 97, 108, 105, 100,
+97, 116, 105, 111, 110, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+ValidationException: __message__
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ValidationException",
+  message: "__message__",
+  fieldList: [
+    {
+      path: "__path__",
+      message: "__message__"
+    },
+    {
+      path: "__path__",
+      message: "__message__"
+    },
+    {
+      path: "__path__",
+      message: "__message__"
+    }
+  ],
+  __type: "smithy.framework#ValidationException"
+}
+
+======================== w/ optional fields ========================
+[status] 400
+  
+smithy-protocol: rpc-v2-cbor
+content-type: application/cbor
+
+[Uint8Array (cbor object view)]
+{
+  "message": "__message__",
+  "fieldList": [
+    {
+      "path": "__path__",
+      "message": "__message__"
+    },
+    {
+      "path": "__path__",
+      "message": "__message__"
+    },
+    {
+      "path": "__path__",
+      "message": "__message__"
+    }
+  ],
+  "__type": "smithy.framework#ValidationException"
+}
+
+[actual bytes]
+163, 103, 109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 105, 102, 105,
+101, 108, 100, 76, 105, 115, 116, 131, 162, 100, 112, 97, 116, 104, 104, 95, 95, 112, 97, 116, 104, 95, 95, 103,
+109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 162, 100, 112, 97, 116,
+104, 104, 95, 95, 112, 97, 116, 104, 95, 95, 103, 109, 101, 115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115,
+115, 97, 103, 101, 95, 95, 162, 100, 112, 97, 116, 104, 104, 95, 95, 112, 97, 116, 104, 95, 95, 103, 109, 101,
+115, 115, 97, 103, 101, 107, 95, 95, 109, 101, 115, 115, 97, 103, 101, 95, 95, 102, 95, 95, 116, 121, 112, 101,
+120, 36, 115, 109, 105, 116, 104, 121, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 35, 86, 97, 108, 105, 100,
+97, 116, 105, 111, 110, 69, 120, 99, 101, 112, 116, 105, 111, 110
+
+
+--- [error name & message] ---
+ValidationException: __message__
+
+--- [error object] ---
+{
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 400,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "ValidationException",
+  message: "__message__",
+  fieldList: [
+    {
+      path: "__path__",
+      message: "__message__"
+    },
+    {
+      path: "__path__",
+      message: "__message__"
+    },
+    {
+      path: "__path__",
+      message: "__message__"
+    }
+  ],
+  __type: "smithy.framework#ValidationException"
+}
+
+======================== frontend error ========================
+[status] 500
+  
+content-type: text/html
+
+[Uint8Array (text)]
+An unmodeled error occurred in a front end layer.
+
+
+--- [error name & message] ---
+Unknown: 
+
+--- [error object] ---
+{
+  0: (number) 110,
+  $fault: "client",
+  $retryable: (undefined),
+  $metadata: {
+    httpStatusCode: (number) 500,
+    requestId: (undefined),
+    extendedRequestId: (undefined),
+    cfId: (undefined),
+    attempts: (number) 1,
+    totalRetryDelay: (number) 0
+  },
+  name: "Unknown"
+}
+

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageApiValidationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageApiValidationGenerator.java
@@ -296,23 +296,20 @@ public final class PackageApiValidationGenerator {
                 assertions(caseName: string, expected: string, actual: string): Promise<void> {
                   expect(actual).toEqual(expected);
                   return Promise.resolve();
-                },
-                schemas:""",
+                },""",
             """
               });
-
               runner.run();
             }, 30_000);
             """,
             clientName,
             () -> {
-                writer.indent(2);
+                writer.indent();
                 writer.openBlock(
                     """
-                    new Map<any, any>([""",
+                    schemas: new Map<any, any>([""",
                     """
-                    ]),
-                    """,
+                    ]),""",
                     () -> {
                         for (OperationShape operationShape : closure.getOperationShapes()) {
                             String operationSchema = closure.getShapeSchemaVariableName(operationShape, null);
@@ -338,7 +335,30 @@ public final class PackageApiValidationGenerator {
                         }
                     }
                 );
-                writer.dedent(2);
+                writer.openBlock(
+                    """
+                    errors: [""",
+                    """
+                    ],""",
+                    () -> {
+
+                        for (Shape errorShape : closure.getErrorShapes()) {
+                            String schemaName = closure.getShapeSchemaVariableName(errorShape, null);
+                            writer.addRelativeImport(
+                                schemaName,
+                                null,
+                                srcIndex
+                            );
+                            writer.write(
+                                """
+                                $L,""",
+                                schemaName
+                            );
+                        }
+
+                    }
+                );
+                writer.dedent();
             }
         );
     }

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
@@ -194,10 +194,14 @@ structure MysteryThrottlingError {}
 
 @error("client")
 @retryable
-structure RetryableError {}
+structure RetryableError {
+    message: String
+}
 
 @error("client")
-structure HaltError {}
+structure HaltError {
+    message: String
+}
 
 @error("client")
 structure XYZServiceServiceException {}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/7788

*Description of changes:*

This adds error-response snapshots for v2.x of `@smithy/snapshot-testing`.