### PR TITLE
fix(ssdk): route on path and method only, not required query params

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -404,17 +404,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         writer.write("{ type: 'query_literal', key: $S, value: $S },", e.getKey(), e.getValue());
                     }
                 }
-                operation
-                    .getInput()
-                    .ifPresent(inputId -> {
-                        StructureShape inputShape = context.getModel().expectShape(inputId, StructureShape.class);
-                        for (MemberShape ms : inputShape.members()) {
-                            if (ms.isRequired() && ms.hasTrait(HttpQueryTrait.class)) {
-                                HttpQueryTrait queryTrait = ms.expectTrait(HttpQueryTrait.class);
-                                writer.write("{ type: 'query', key: $S },", queryTrait.getValue());
-                            }
-                        }
-                    });
+                // Required @httpQuery members are validated post-routing, not used for routing.
+                // Including them here would cause UnknownOperationException instead of ValidationException.
             });
             writer.writeInline("{ service: $S, operation: $S }", serviceName, operationName);
         });

--- a/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.spec.ts
@@ -88,6 +88,9 @@ describe("simple matching", () => {
       new HttpRequest({ method: "DELETE", path: "/", query: { foo: "bar", baz: "quux" } }),
       new HttpRequest({ method: "DELETE", path: "/", query: { foo: "bar", baz: null } }),
       new HttpRequest({ method: "DELETE", path: "", query: { foo: "bar", baz: ["quux", "grault"] } }),
+      // "query" type segments (from @required @httpQuery) are not used for routing,
+      // so missing "baz" still routes to Delete — validation catches it later
+      new HttpRequest({ method: "DELETE", path: "/", query: { foo: "bar" } }),
     ],
     "Test#QueryKeyOnly": [
       new HttpRequest({ method: "GET", path: "/query_key_only", query: { foo: "bar" } }),
@@ -115,7 +118,6 @@ describe("simple matching", () => {
     new HttpRequest({ method: "GET", path: "/mg/a/y/z/a" }),
     new HttpRequest({ method: "GET", path: "/mg/a/y/a" }),
     new HttpRequest({ method: "GET", path: "/mg/a/b/z/c" }),
-    new HttpRequest({ method: "DELETE", path: "/", query: { foo: "bar" } }),
     new HttpRequest({ method: "DELETE", path: "/", query: { baz: "quux" } }),
     new HttpRequest({ method: "DELETE", path: "/" }),
   ];

--- a/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.ts
@@ -44,6 +44,10 @@ export class UriSpec<S extends string, O extends string> {
   private readonly method: string;
   private readonly pathSegments: (PathLiteralSegment | PathLabelSegment | GreedySegment)[];
   private readonly querySegments: (QueryLiteralSegment | QuerySegment)[];
+  // Only query_literal segments participate in routing. "query" segments
+  // (from @required @httpQuery) are validated post-routing so they don't
+  // cause UnknownOperationException when missing.
+  private readonly routingQuerySegments: QueryLiteralSegment[];
   readonly rank: number;
   readonly target: ServiceCoordinate<S, O>;
 
@@ -56,7 +60,10 @@ export class UriSpec<S extends string, O extends string> {
     this.method = method;
     this.pathSegments = pathSegments;
     this.querySegments = querySegments;
-    this.rank = this.pathSegments.length + this.querySegments.length;
+    this.routingQuerySegments = this.querySegments.filter(
+      (s): s is QueryLiteralSegment => s.type === "query_literal"
+    );
+    this.rank = this.pathSegments.length + this.routingQuerySegments.length;
     this.target = target;
   }
 
@@ -108,7 +115,7 @@ export class UriSpec<S extends string, O extends string> {
       return false;
     }
 
-    if (this.querySegments.length === 0) {
+    if (this.routingQuerySegments.length === 0) {
       return true;
     }
 
@@ -116,19 +123,17 @@ export class UriSpec<S extends string, O extends string> {
       return false;
     }
 
-    for (const querySegment of this.querySegments) {
+    for (const querySegment of this.routingQuerySegments) {
       if (!(querySegment.key in req.query)) {
         return false;
       }
-      if (querySegment.type === "query_literal") {
-        const input_query_value = req.query[querySegment.key];
-        if (Array.isArray(input_query_value)) {
-          if (querySegment.value && !input_query_value.includes(querySegment.value)) {
-            return false;
-          }
-        } else if (querySegment.value && querySegment.value !== input_query_value) {
+      const input_query_value = req.query[querySegment.key];
+      if (Array.isArray(input_query_value)) {
+        if (querySegment.value && !input_query_value.includes(querySegment.value)) {
           return false;
         }
+      } else if (querySegment.value && querySegment.value !== input_query_value) {
+        return false;
       }
     }
     return true;


### PR DESCRIPTION
Fixes #1840

*Description of changes:*

When a Smithy operation has a `@required` `@httpQuery` parameter, the generated SSDK throws `UnknownOperationException` instead of `ValidationException` when the parameter is missing from the request.

### Root cause

The codegen emits required `@httpQuery` members as `{ type: 'query' }` segments in the `UriSpec` passed to `HttpBindingMux`. During routing, `UriSpec.match()` requires all query segments (including these) to be present in the request. When a required query param is missing, the mux fails to match any operation and the handler throws `UnknownOperationException`.

Meanwhile, the SSDK already generates proper `RequiredValidator` checks for these members, but that validation runs *after* routing, so it never executes when the query param is absent.

### Fix

Two complementary changes ensure required query params are validated, not routed on:

**`@aws-smithy/server-common` (runtime)**

`UriSpec.match()` now filters query segments to only enforce `query_literal` types (URI query literals like `?action=Foo`) during routing. `query` type segments (from `@required @httpQuery` members) are skipped — they don't participate in operation matching. The `rank` calculation was updated accordingly to only count `query_literal` segments for routing priority.

This also makes the runtime backward-compatible with already-generated code: existing SSDKs that include `query` segments in their mux will now simply ignore them during routing instead of using them to reject requests.

**`smithy-typescript-codegen` (codegen)**

`HttpBindingProtocolGenerator.generateUriSpec()` no longer emits required `@httpQuery` members as query segments. Only URI query literals (from `httpTrait.getUri().getQueryLiterals()`) are included. This means newly generated code won't include the unnecessary segments at all.

### Before

```
GET /resource  →  UnknownOperationException
```

### After

```
GET /resource  →  ValidationException (1 validation error: Missing value at '/id')
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
