### PR TITLE
test(codegen): test for event stream event-type header corresponding to member name

### DIFF
--- a/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
@@ -45,6 +45,10 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  *     },
  *     beta: {},
  *     gamma: {},
+ *     delta: { // DifferentShapeName
+ *       name: "STRING_VALUE",
+ *       number: Number("int"),
+ *     },
  *   },
  * };
  * const command = new TradeEventStreamCommand(input);
@@ -57,6 +61,10 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  * //     },
  * //     beta: {},
  * //     gamma: {},
+ * //     delta: { // DifferentShapeName
+ * //       name: "STRING_VALUE",
+ * //       number: Number("int"),
+ * //     },
  * //   },
  * // };
  *

--- a/private/my-local-model-schema/src/models/models_0.ts
+++ b/private/my-local-model-schema/src/models/models_0.ts
@@ -39,6 +39,14 @@ export interface CamelCaseOperationOutput {
 /**
  * @public
  */
+export interface DifferentShapeName {
+  name?: string | undefined;
+  number?: number | undefined;
+}
+
+/**
+ * @public
+ */
 export interface GetNumbersRequest {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;
@@ -111,6 +119,7 @@ export interface Unit {}
 export type TradeEvents =
   | TradeEvents.AlphaMember
   | TradeEvents.BetaMember
+  | TradeEvents.DeltaMember
   | TradeEvents.GammaMember
   | TradeEvents.$UnknownMember;
 
@@ -122,6 +131,7 @@ export namespace TradeEvents {
     alpha: Alpha;
     beta?: never;
     gamma?: never;
+    delta?: never;
     $unknown?: never;
   }
 
@@ -129,6 +139,7 @@ export namespace TradeEvents {
     alpha?: never;
     beta: Unit;
     gamma?: never;
+    delta?: never;
     $unknown?: never;
   }
 
@@ -136,6 +147,15 @@ export namespace TradeEvents {
     alpha?: never;
     beta?: never;
     gamma: Unit;
+    delta?: never;
+    $unknown?: never;
+  }
+
+  export interface DeltaMember {
+    alpha?: never;
+    beta?: never;
+    gamma?: never;
+    delta: DifferentShapeName;
     $unknown?: never;
   }
 
@@ -146,6 +166,7 @@ export namespace TradeEvents {
     alpha?: never;
     beta?: never;
     gamma?: never;
+    delta?: never;
     $unknown: [string, any];
   }
 
@@ -157,6 +178,7 @@ export namespace TradeEvents {
     alpha: (value: Alpha) => T;
     beta: (value: Unit) => T;
     gamma: (value: Unit) => T;
+    delta: (value: DifferentShapeName) => T;
     _: (name: string, value: any) => T;
   }
 }

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -1,5 +1,6 @@
 const _A = "Alpha";
 const _CTE = "CodedThrottlingError";
+const _DSN = "DifferentShapeName";
 const _GN = "GetNumbers";
 const _GNR = "GetNumbersRequest";
 const _GNRe = "GetNumbersResponse";
@@ -25,6 +26,7 @@ const _cCO = "camelCaseOperation";
 const _cCOI = "camelCaseOperationInput";
 const _cCOO = "camelCaseOperationOutput";
 const _cHI = "customHeaderInput";
+const _d = "delta";
 const _dN = "deprecatedNumbers";
 const _dNWC = "deprecatedNumbersWithoutChronology";
 const _dNWE = "deprecatedNumbersWithoutExplanation";
@@ -39,8 +41,10 @@ const _i = "id";
 const _iDN = "inexplicablyDeprecatedNumbers";
 const _m = "message";
 const _mR = "maxResults";
-const _n = "numbers";
+const _n = "name";
 const _nT = "nextToken";
+const _nu = "number";
+const _num = "numbers";
 const _r = "results";
 const _s = "smithy.ts.sdk.synthetic.org.xyz.v1";
 const _sT = "startToken";
@@ -145,6 +149,11 @@ export var camelCaseOperationOutput$: StaticStructureSchema = [3, n0, _cCOO,
   [_to, _r],
   [0, 64 | 21]
 ];
+export var DifferentShapeName$: StaticStructureSchema = [3, n0, _DSN,
+  0,
+  [_n, _nu],
+  [0, 1]
+];
 export var GetNumbersRequest$: StaticStructureSchema = [3, n0, _GNR,
   0,
   [_bD, _bI, _fWM, _fWMi, _sT, _mR, _cHI],
@@ -152,7 +161,7 @@ export var GetNumbersRequest$: StaticStructureSchema = [3, n0, _GNR,
 ];
 export var GetNumbersResponse$: StaticStructureSchema = [3, n0, _GNRe,
   0,
-  [_bD, _bI, _n, _nT, _dN, _dNWE, _dNWC, _iDN],
+  [_bD, _bI, _num, _nT, _dN, _dNWE, _dNWC, _iDN],
   [19, 17, 64 | 1, 0, 64 | 1, 64 | 1, 64 | 1, 64 | 1]
 ];
 export var TradeEventStreamRequest$: StaticStructureSchema = [3, n0, _TESR,
@@ -170,8 +179,8 @@ var Blobs = 64 | 21;
 var IntegerList = 64 | 1;
 export var TradeEvents$: StaticUnionSchema = [4, n0, _TE,
   { [_st]: 1 },
-  [_a, _b, _g],
-  [() => Alpha$, () => __Unit, () => __Unit]
+  [_a, _b, _g, _d],
+  [() => Alpha$, () => __Unit, () => __Unit, () => DifferentShapeName$]
 ];
 export var HttpLabelCommand$: StaticOperationSchema = [9, n1, _HLC,
   { [_h]: ["POST", "/{LabelDoesNotApplyToRpcProtocol}", 200] }, () => HttpLabelCommandInput$, () => HttpLabelCommandOutput$

--- a/private/my-local-model-schema/test/index-objects.spec.mjs
+++ b/private/my-local-model-schema/test/index-objects.spec.mjs
@@ -6,6 +6,7 @@ import {
   camelCaseOperationOutput$,
   CodedThrottlingError,
   CodedThrottlingError$,
+  DifferentShapeName$,
   GetNumbers$,
   GetNumbersCommand,
   GetNumbersRequest$,
@@ -56,6 +57,7 @@ assert(typeof HttpLabelCommandOutput$ === "object");
 assert(typeof Alpha$ === "object");
 assert(typeof camelCaseOperationInput$ === "object");
 assert(typeof camelCaseOperationOutput$ === "object");
+assert(typeof DifferentShapeName$ === "object");
 assert(typeof GetNumbersRequest$ === "object");
 assert(typeof GetNumbersResponse$ === "object");
 assert(typeof TradeEvents$ === "object");

--- a/private/my-local-model-schema/test/index-types.ts
+++ b/private/my-local-model-schema/test/index-types.ts
@@ -19,6 +19,7 @@ export type {
   Alpha,
   CamelCaseOperationInput,
   CamelCaseOperationOutput,
+  DifferentShapeName,
   GetNumbersRequest,
   GetNumbersResponse,
   TradeEvents,

--- a/private/my-local-model-schema/test/snapshots/req/CamelCaseOperation.txt
+++ b/private/my-local-model-schema/test/snapshots/req/CamelCaseOperation.txt
@@ -1,6 +1,7 @@
 POST https://localhost 
 /mock-required-endpoint/service/XYZService/operation/camelCaseOperation
 
+x-api-key: [object Object]
 content-type: application/cbor
 smithy-protocol: rpc-v2-cbor
 accept: application/cbor

--- a/private/my-local-model-schema/test/snapshots/req/GetNumbers.txt
+++ b/private/my-local-model-schema/test/snapshots/req/GetNumbers.txt
@@ -1,10 +1,12 @@
 POST https://localhost 
 /mock-required-endpoint/service/XYZService/operation/GetNumbers
 
+x-api-key: [object Object]
+x-custom-header: __customHeaderInput__
 content-type: application/cbor
 smithy-protocol: rpc-v2-cbor
 accept: application/cbor
-content-length: 162
+content-length: 202
 amz-sdk-invocation-id: 1111abcd-uuid-uuid-uuid-000000001111
 amz-sdk-request: attempt=1; max=3
 X-Api-Key: MOCK_api_key
@@ -19,14 +21,17 @@ X-Api-Key: MOCK_api_key
   "fieldWithoutMessage": "__fieldWithoutMessage__",
   "fieldWithMessage": "__fieldWithMessage__",
   "startToken": "__startToken__",
-  "maxResults": 0
+  "maxResults": 0,
+  "customHeaderInput": "__customHeaderInput__"
 }
 
 [actual bytes]
-166, 106, 98, 105, 103, 68, 101, 99, 105, 109, 97, 108, 196, 130, 41, 194, 73, 5, 90, 165, 77, 54, 159, 210,
+167, 106, 98, 105, 103, 68, 101, 99, 105, 109, 97, 108, 196, 130, 41, 194, 73, 5, 90, 165, 77, 54, 159, 210,
 53, 21, 106, 98, 105, 103, 73, 110, 116, 101, 103, 101, 114, 26, 0, 15, 66, 65, 115, 102, 105, 101, 108, 100,
 87, 105, 116, 104, 111, 117, 116, 77, 101, 115, 115, 97, 103, 101, 119, 95, 95, 102, 105, 101, 108, 100, 87, 105,
 116, 104, 111, 117, 116, 77, 101, 115, 115, 97, 103, 101, 95, 95, 112, 102, 105, 101, 108, 100, 87, 105, 116, 104,
 77, 101, 115, 115, 97, 103, 101, 116, 95, 95, 102, 105, 101, 108, 100, 87, 105, 116, 104, 77, 101, 115, 115, 97,
 103, 101, 95, 95, 106, 115, 116, 97, 114, 116, 84, 111, 107, 101, 110, 110, 95, 95, 115, 116, 97, 114, 116, 84,
-111, 107, 101, 110, 95, 95, 106, 109, 97, 120, 82, 101, 115, 117, 108, 116, 115, 0
+111, 107, 101, 110, 95, 95, 106, 109, 97, 120, 82, 101, 115, 117, 108, 116, 115, 0, 113, 99, 117, 115, 116, 111,
+109, 72, 101, 97, 100, 101, 114, 73, 110, 112, 117, 116, 117, 95, 95, 99, 117, 115, 116, 111, 109, 72, 101, 97,
+100, 101, 114, 73, 110, 112, 117, 116, 95, 95

--- a/private/my-local-model-schema/test/snapshots/req/HttpLabelCommand.txt
+++ b/private/my-local-model-schema/test/snapshots/req/HttpLabelCommand.txt
@@ -1,6 +1,7 @@
 POST https://localhost 
 /mock-required-endpoint/service/XYZService/operation/HttpLabelCommand
 
+x-api-key: [object Object]
 content-type: application/cbor
 smithy-protocol: rpc-v2-cbor
 accept: application/cbor

--- a/private/my-local-model-schema/test/snapshots/req/TradeEventStream.txt
+++ b/private/my-local-model-schema/test/snapshots/req/TradeEventStream.txt
@@ -1,6 +1,7 @@
 POST https://localhost 
 /mock-required-endpoint/service/XYZService/operation/TradeEventStream
 
+x-api-key: [object Object]
 content-type: application/cbor
 smithy-protocol: rpc-v2-cbor
 accept: application/cbor
@@ -76,6 +77,24 @@ X-Api-Key: MOCK_api_key
 160
 
 [message-crc] 2477278713
+============================================================
+
+[chunk (event-stream object view)]
+  [total-size] 114 [header-size] 75 [prelude-crc] 121566430
+:event-type: delta
+:message-type: event
+:content-type: application/cbor
+
+[cbor object view]
+{
+  "name": "__name__",
+  "number": 0
+}
+
+[actual bytes]
+162, 100, 110, 97, 109, 101, 104, 95, 95, 110, 97, 109, 101, 95, 95, 102, 110, 117, 109, 98, 101, 114, 0
+
+[message-crc] 3691208368
 ============================================================
 
 [chunk (b64)]

--- a/private/my-local-model-schema/test/snapshots/res/TradeEventStream.txt
+++ b/private/my-local-model-schema/test/snapshots/res/TradeEventStream.txt
@@ -82,6 +82,24 @@ content-type: application/cbor
 [message-crc] 2477278713
 ============================================================
 
+[chunk (event-stream object view)]
+  [total-size] 114 [header-size] 75 [prelude-crc] 121566430
+:event-type: delta
+:message-type: event
+:content-type: application/cbor
+
+[cbor object view]
+{
+  "name": "__name__",
+  "number": 0
+}
+
+[actual bytes]
+162, 100, 110, 97, 109, 101, 104, 95, 95, 110, 97, 109, 101, 95, 95, 102, 110, 117, 109, 98, 101, 114, 0
+
+[message-crc] 3691208368
+============================================================
+
 [chunk (b64)]
 Cg==
 
@@ -101,6 +119,12 @@ Cg==
     },
     {
       gamma: {}
+    },
+    {
+      delta: {
+        name: "__name__",
+        number: (number) 0
+      }
     }
   ],
   $metadata: {

--- a/private/my-local-model/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model/src/commands/TradeEventStreamCommand.ts
@@ -51,6 +51,10 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  *     },
  *     beta: {},
  *     gamma: {},
+ *     delta: { // DifferentShapeName
+ *       name: "STRING_VALUE",
+ *       number: Number("int"),
+ *     },
  *   },
  * };
  * const command = new TradeEventStreamCommand(input);
@@ -63,6 +67,10 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  * //     },
  * //     beta: {},
  * //     gamma: {},
+ * //     delta: { // DifferentShapeName
+ * //       name: "STRING_VALUE",
+ * //       number: Number("int"),
+ * //     },
  * //   },
  * // };
  *

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -39,6 +39,14 @@ export interface CamelCaseOperationOutput {
 /**
  * @public
  */
+export interface DifferentShapeName {
+  name?: string | undefined;
+  number?: number | undefined;
+}
+
+/**
+ * @public
+ */
 export interface GetNumbersRequest {
   bigDecimal?: NumericValue | undefined;
   bigInteger?: bigint | undefined;
@@ -111,6 +119,7 @@ export interface Unit {}
 export type TradeEvents =
   | TradeEvents.AlphaMember
   | TradeEvents.BetaMember
+  | TradeEvents.DeltaMember
   | TradeEvents.GammaMember
   | TradeEvents.$UnknownMember;
 
@@ -122,6 +131,7 @@ export namespace TradeEvents {
     alpha: Alpha;
     beta?: never;
     gamma?: never;
+    delta?: never;
     $unknown?: never;
   }
 
@@ -129,6 +139,7 @@ export namespace TradeEvents {
     alpha?: never;
     beta: Unit;
     gamma?: never;
+    delta?: never;
     $unknown?: never;
   }
 
@@ -136,6 +147,15 @@ export namespace TradeEvents {
     alpha?: never;
     beta?: never;
     gamma: Unit;
+    delta?: never;
+    $unknown?: never;
+  }
+
+  export interface DeltaMember {
+    alpha?: never;
+    beta?: never;
+    gamma?: never;
+    delta: DifferentShapeName;
     $unknown?: never;
   }
 
@@ -146,6 +166,7 @@ export namespace TradeEvents {
     alpha?: never;
     beta?: never;
     gamma?: never;
+    delta?: never;
     $unknown: [string, any];
   }
 
@@ -153,6 +174,7 @@ export namespace TradeEvents {
     alpha: (value: Alpha) => T;
     beta: (value: Unit) => T;
     gamma: (value: Unit) => T;
+    delta: (value: DifferentShapeName) => T;
     _: (name: string, value: any) => T;
   }
 
@@ -160,6 +182,7 @@ export namespace TradeEvents {
     if (value.alpha !== undefined) return visitor.alpha(value.alpha);
     if (value.beta !== undefined) return visitor.beta(value.beta);
     if (value.gamma !== undefined) return visitor.gamma(value.gamma);
+    if (value.delta !== undefined) return visitor.delta(value.delta);
     return visitor._(value.$unknown[0], value.$unknown[1]);
   };
 }
@@ -180,6 +203,11 @@ export const TradeEventsFilterSensitiveLog = (obj: TradeEvents): any => {
   if (obj.gamma !== undefined) {
     return {
       gamma: obj.gamma
+    };
+  }
+  if (obj.delta !== undefined) {
+    return {
+      delta: obj.delta
     };
   }
   if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };

--- a/private/my-local-model/src/protocols/Rpcv2cbor.ts
+++ b/private/my-local-model/src/protocols/Rpcv2cbor.ts
@@ -46,6 +46,7 @@ import {
   Alpha,
   CamelCaseOperationInput,
   CamelCaseOperationOutput,
+  DifferentShapeName,
   GetNumbersRequest,
   GetNumbersResponse,
   HttpLabelCommandInput,
@@ -344,6 +345,7 @@ const se_TradeEvents = (
     alpha: value => se_Alpha_event(value, context),
     beta: value => se_Unit_event(value, context),
     gamma: value => se_Unit_event(value, context),
+    delta: value => se_DifferentShapeName_event(value, context),
     _: value => value as any
   });
   return context.eventStreamMarshaller.serialize(input, eventMarshallingVisitor);
@@ -362,12 +364,12 @@ const se_Alpha_event = (
   body = cbor.serialize(body);
   return { headers, body };
   }
-  const se_Unit_event = (
-    input: Unit,
+  const se_DifferentShapeName_event = (
+    input: DifferentShapeName,
     context: __SerdeContext
   ): __Message => {
     const headers: __MessageHeaders = {
-      ":event-type": { type: "string", value: "beta" },
+      ":event-type": { type: "string", value: "delta" },
       ":message-type": { type: "string", value: "event" },
       ":content-type": { type: "string", value: "application/cbor" },
     }
@@ -376,175 +378,207 @@ const se_Alpha_event = (
     body = cbor.serialize(body);
     return { headers, body };
     }
-    /**
-     * deserializeRpcv2cborTradeEvents
-     */
-    const de_TradeEvents = (
-      output: any,
-      context: __SerdeContext & __EventStreamSerdeContext
-    ): AsyncIterable<TradeEvents> => {
-      return context.eventStreamMarshaller.deserialize(
-        output,
-        async event => {
-          if (event["alpha"] != null) {
-            return {
-              alpha: await de_Alpha_event(event["alpha"], context),
-            };
-          }
-          if (event["beta"] != null) {
-            return {
-              beta: await de_Unit_event(event["beta"], context),
-            };
-          }
-          if (event["gamma"] != null) {
-            return {
-              gamma: await de_Unit_event(event["gamma"], context),
-            };
-          }
-          return {$unknown: event as any};
-        }
-      );
-    }
-    const de_Alpha_event = async (
-      output: any,
+    const se_Unit_event = (
+      input: Unit,
       context: __SerdeContext
-    ): Promise<Alpha> => {
-      const contents: Alpha = {} as any;
-      const data: any = await parseBody(output.body, context);
-      Object.assign(contents, de_Alpha(data, context));
-      return contents;
-    }
-    const de_Unit_event = async (
-      output: any,
-      context: __SerdeContext
-    ): Promise<Unit> => {
-      const contents: Unit = {} as any;
-      const data: any = await parseBody(output.body, context);
-      Object.assign(contents, _json(data));
-      return contents;
-    }
-    // se_HttpLabelCommandInput omitted.
+    ): __Message => {
+      const headers: __MessageHeaders = {
+        ":event-type": { type: "string", value: "beta" },
+        ":message-type": { type: "string", value: "event" },
+        ":content-type": { type: "string", value: "application/cbor" },
+      }
+      let body = new Uint8Array();
+      body = _json(input);
+      body = cbor.serialize(body);
+      return { headers, body };
+      }
+      /**
+       * deserializeRpcv2cborTradeEvents
+       */
+      const de_TradeEvents = (
+        output: any,
+        context: __SerdeContext & __EventStreamSerdeContext
+      ): AsyncIterable<TradeEvents> => {
+        return context.eventStreamMarshaller.deserialize(
+          output,
+          async event => {
+            if (event["alpha"] != null) {
+              return {
+                alpha: await de_Alpha_event(event["alpha"], context),
+              };
+            }
+            if (event["beta"] != null) {
+              return {
+                beta: await de_Unit_event(event["beta"], context),
+              };
+            }
+            if (event["gamma"] != null) {
+              return {
+                gamma: await de_Unit_event(event["gamma"], context),
+              };
+            }
+            if (event["delta"] != null) {
+              return {
+                delta: await de_DifferentShapeName_event(event["delta"], context),
+              };
+            }
+            return {$unknown: event as any};
+          }
+        );
+      }
+      const de_Alpha_event = async (
+        output: any,
+        context: __SerdeContext
+      ): Promise<Alpha> => {
+        const contents: Alpha = {} as any;
+        const data: any = await parseBody(output.body, context);
+        Object.assign(contents, de_Alpha(data, context));
+        return contents;
+      }
+      const de_DifferentShapeName_event = async (
+        output: any,
+        context: __SerdeContext
+      ): Promise<DifferentShapeName> => {
+        const contents: DifferentShapeName = {} as any;
+        const data: any = await parseBody(output.body, context);
+        Object.assign(contents, _json(data));
+        return contents;
+      }
+      const de_Unit_event = async (
+        output: any,
+        context: __SerdeContext
+      ): Promise<Unit> => {
+        const contents: Unit = {} as any;
+        const data: any = await parseBody(output.body, context);
+        Object.assign(contents, _json(data));
+        return contents;
+      }
+      // se_HttpLabelCommandInput omitted.
 
-    /**
-     * serializeRpcv2cborAlpha
-     */
-    const se_Alpha = (
-      input: Alpha,
-      context: __SerdeContext
-    ): any => {
-      return take(input, {
-        'id': [],
-        'timestamp': __dateToTag,
+      /**
+       * serializeRpcv2cborAlpha
+       */
+      const se_Alpha = (
+        input: Alpha,
+        context: __SerdeContext
+      ): any => {
+        return take(input, {
+          'id': [],
+          'timestamp': __dateToTag,
+        });
+      }
+
+      // se_CamelCaseOperationInput omitted.
+
+      // se_DifferentShapeName omitted.
+
+      /**
+       * serializeRpcv2cborGetNumbersRequest
+       */
+      const se_GetNumbersRequest = (
+        input: GetNumbersRequest,
+        context: __SerdeContext
+      ): any => {
+        return take(input, {
+          'bigDecimal': __nv,
+          'bigInteger': [],
+          'customHeaderInput': [],
+          'fieldWithMessage': [],
+          'fieldWithoutMessage': [],
+          'maxResults': [],
+          'startToken': [],
+        });
+      }
+
+      // se_Unit omitted.
+
+      // de_HttpLabelCommandOutput omitted.
+
+      /**
+       * deserializeRpcv2cborAlpha
+       */
+      const de_Alpha = (
+        output: any,
+        context: __SerdeContext
+      ): Alpha => {
+        return take(output, {
+          'id': __expectString,
+          'timestamp': (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
+        }) as any;
+      }
+
+      /**
+       * deserializeRpcv2cborBlobs
+       */
+      const de_Blobs = (
+        output: any,
+        context: __SerdeContext
+      ): Uint8Array[] => {
+        const collection = (output || []).filter((e: any) => e != null)
+        return collection;
+      }
+
+      /**
+       * deserializeRpcv2cborCamelCaseOperationOutput
+       */
+      const de_CamelCaseOperationOutput = (
+        output: any,
+        context: __SerdeContext
+      ): CamelCaseOperationOutput => {
+        return take(output, {
+          'results': (_: any) => de_Blobs(_, context),
+          'token': __expectString,
+        }) as any;
+      }
+
+      // de_CodedThrottlingError omitted.
+
+      // de_DifferentShapeName omitted.
+
+      /**
+       * deserializeRpcv2cborGetNumbersResponse
+       */
+      const de_GetNumbersResponse = (
+        output: any,
+        context: __SerdeContext
+      ): GetNumbersResponse => {
+        return take(output, {
+          'bigDecimal': [],
+          'bigInteger': [],
+          'deprecatedNumbers': _json,
+          'deprecatedNumbersWithoutChronology': _json,
+          'deprecatedNumbersWithoutExplanation': _json,
+          'inexplicablyDeprecatedNumbers': _json,
+          'nextToken': __expectString,
+          'numbers': _json,
+        }) as any;
+      }
+
+      // de_HaltError omitted.
+
+      // de_IntegerList omitted.
+
+      // de_MainServiceLinkedError omitted.
+
+      // de_MysteryThrottlingError omitted.
+
+      // de_RetryableError omitted.
+
+      // de_XYZServiceServiceException omitted.
+
+      // de_Unit omitted.
+
+      const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
+        httpStatusCode: output.statusCode,
+        requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
+        extendedRequestId: output.headers["x-amz-id-2"],
+        cfId: output.headers["x-amz-cf-id"],
       });
-    }
 
-    // se_CamelCaseOperationInput omitted.
+      const throwDefaultError = withBaseException(__BaseException);
+      const SHARED_HEADERS: __HeaderBag = {
+        'content-type': "application/cbor",
+        "smithy-protocol": "rpc-v2-cbor",
+        "accept": "application/cbor",
 
-    /**
-     * serializeRpcv2cborGetNumbersRequest
-     */
-    const se_GetNumbersRequest = (
-      input: GetNumbersRequest,
-      context: __SerdeContext
-    ): any => {
-      return take(input, {
-        'bigDecimal': __nv,
-        'bigInteger': [],
-        'customHeaderInput': [],
-        'fieldWithMessage': [],
-        'fieldWithoutMessage': [],
-        'maxResults': [],
-        'startToken': [],
-      });
-    }
-
-    // se_Unit omitted.
-
-    // de_HttpLabelCommandOutput omitted.
-
-    /**
-     * deserializeRpcv2cborAlpha
-     */
-    const de_Alpha = (
-      output: any,
-      context: __SerdeContext
-    ): Alpha => {
-      return take(output, {
-        'id': __expectString,
-        'timestamp': (_: any) => __expectNonNull(__parseEpochTimestamp(_)),
-      }) as any;
-    }
-
-    /**
-     * deserializeRpcv2cborBlobs
-     */
-    const de_Blobs = (
-      output: any,
-      context: __SerdeContext
-    ): Uint8Array[] => {
-      const collection = (output || []).filter((e: any) => e != null)
-      return collection;
-    }
-
-    /**
-     * deserializeRpcv2cborCamelCaseOperationOutput
-     */
-    const de_CamelCaseOperationOutput = (
-      output: any,
-      context: __SerdeContext
-    ): CamelCaseOperationOutput => {
-      return take(output, {
-        'results': (_: any) => de_Blobs(_, context),
-        'token': __expectString,
-      }) as any;
-    }
-
-    // de_CodedThrottlingError omitted.
-
-    /**
-     * deserializeRpcv2cborGetNumbersResponse
-     */
-    const de_GetNumbersResponse = (
-      output: any,
-      context: __SerdeContext
-    ): GetNumbersResponse => {
-      return take(output, {
-        'bigDecimal': [],
-        'bigInteger': [],
-        'deprecatedNumbers': _json,
-        'deprecatedNumbersWithoutChronology': _json,
-        'deprecatedNumbersWithoutExplanation': _json,
-        'inexplicablyDeprecatedNumbers': _json,
-        'nextToken': __expectString,
-        'numbers': _json,
-      }) as any;
-    }
-
-    // de_HaltError omitted.
-
-    // de_IntegerList omitted.
-
-    // de_MainServiceLinkedError omitted.
-
-    // de_MysteryThrottlingError omitted.
-
-    // de_RetryableError omitted.
-
-    // de_XYZServiceServiceException omitted.
-
-    // de_Unit omitted.
-
-    const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
-      httpStatusCode: output.statusCode,
-      requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
-      extendedRequestId: output.headers["x-amz-id-2"],
-      cfId: output.headers["x-amz-cf-id"],
-    });
-
-    const throwDefaultError = withBaseException(__BaseException);
-    const SHARED_HEADERS: __HeaderBag = {
-      'content-type': "application/cbor",
-      "smithy-protocol": "rpc-v2-cbor",
-      "accept": "application/cbor",
-
-    };
+      };

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
@@ -267,11 +267,19 @@ union TradeEvents {
     alpha: Alpha
     beta: Unit
     gamma: Unit
+    delta: DifferentShapeName
 }
 
 structure Alpha {
     id: String
     timestamp: Timestamp
+}
+
+// this tests that the event stream member associated with it
+// generates using :event-type: delta rather than :event-type: DifferentShapeName.
+structure DifferentShapeName {
+    name: String
+    number: Integer
 }
 
 @rpcv2Cbor


### PR DESCRIPTION
*Issue #, if available:*
JS-5312
https://github.com/smithy-lang/smithy-typescript/pull/1349

*Description of changes:*

This adds a snapshot that asserts the event stream event type header uses the event stream shape's member name rather than the target event's shape id. 