### PR TITLE
fix(config-resolver): update default value to undefined for dualstack/fips config

### DIFF
--- a/.changeset/chilled-seahorses-provide.md
+++ b/.changeset/chilled-seahorses-provide.md
@@ -1,0 +1,5 @@
+---
+"@smithy/config-resolver": patch
+---
+
+fix: update default value to undefined for dualstack/fips config

--- a/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.spec.ts
@@ -45,8 +45,8 @@ describe("NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS", () => {
     test(configFileSelector, profileContent, CONFIG_USE_DUALSTACK_ENDPOINT, SelectorType.CONFIG);
   });
 
-  it("returns false for default", () => {
+  it("returns undefined for default", () => {
     const { default: defaultValue } = NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS;
-    expect(defaultValue).toEqual(DEFAULT_USE_DUALSTACK_ENDPOINT);
+    expect(defaultValue).toBeUndefined();
   });
 });

--- a/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
@@ -17,9 +17,9 @@ export const DEFAULT_USE_DUALSTACK_ENDPOINT = false;
 /**
  * @internal
  */
-export const NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
+export const NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean | undefined> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, ENV_USE_DUALSTACK_ENDPOINT, SelectorType.ENV),
   configFileSelector: (profile) => booleanSelector(profile, CONFIG_USE_DUALSTACK_ENDPOINT, SelectorType.CONFIG),
-  default: false,
+  default: undefined,
 };

--- a/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.spec.ts
@@ -45,8 +45,8 @@ describe("NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS", () => {
     test(configFileSelector, profileContent, CONFIG_USE_FIPS_ENDPOINT, SelectorType.CONFIG);
   });
 
-  it("returns false for default", () => {
+  it("returns undefined for default", () => {
     const { default: defaultValue } = NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS;
-    expect(defaultValue).toEqual(DEFAULT_USE_FIPS_ENDPOINT);
+    expect(defaultValue).toBeUndefined();
   });
 });

--- a/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
@@ -17,9 +17,9 @@ export const DEFAULT_USE_FIPS_ENDPOINT = false;
 /**
  * @internal
  */
-export const NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
+export const NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean | undefined> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, ENV_USE_FIPS_ENDPOINT, SelectorType.ENV),
   configFileSelector: (profile) => booleanSelector(profile, CONFIG_USE_FIPS_ENDPOINT, SelectorType.CONFIG),
-  default: false,
+  default: undefined,
 };


### PR DESCRIPTION
*Issue #, if available:*
Internal V2145523984

*Description of changes:*
- models that define custom defaults for UseDualStack or UseFIPS in their endpoint ruleset were being overridden by the hardcoded false default in config options.
- Changed the default from false to undefined so ruleset specific defaults can take effect via fallback in generated client code.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
