### PR TITLE
fix(middleware-endpoint): update type of useDualStackEndpoint/useFipsEndpint input config

### DIFF
--- a/.changeset/silent-cooks-lick.md
+++ b/.changeset/silent-cooks-lick.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+fix : update type of useDualStackEndpoint/useFipsEndpoint in input config

--- a/packages/middleware-endpoint/src/resolveEndpointConfig.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointConfig.ts
@@ -37,12 +37,12 @@ export interface EndpointInputConfig<T extends EndpointParameters = EndpointPara
   /**
    * Enables IPv6/IPv4 dualstack endpoint.
    */
-  useDualstackEndpoint?: boolean | Provider<boolean>;
+  useDualstackEndpoint?: boolean | Provider<boolean | undefined>;
 
   /**
    * Enables FIPS compatible endpoints.
    */
-  useFipsEndpoint?: boolean | Provider<boolean>;
+  useFipsEndpoint?: boolean | Provider<boolean | undefined>;
 
   /**
    * @internal


### PR DESCRIPTION
*Issue #, if available:*

Follow up for [PR-1925](https://github.com/smithy-lang/smithy-typescript/pull/1925)


If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
