### PR TITLE
fix(config-resolver): add new config selectors

### DIFF
--- a/.changeset/wicked-students-lick.md
+++ b/.changeset/wicked-students-lick.md
@@ -1,0 +1,7 @@
+---
+"@smithy/middleware-endpoint": patch
+"@smithy/config-resolver": patch
+---
+
+fix(middleware-endpoint): update type of useDualStackEndpoint/useFipsEndpoint input config
+fix(config-resolver): add alternate values for NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS and NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS

--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -26,7 +26,9 @@
     "getRegionInfo": "function, since <=4.4.3",
     "resolveCustomEndpointsConfig": "function, since <=4.4.3",
     "resolveEndpointsConfig": "function, since <=4.4.3",
-    "resolveRegionConfig": "function, since <=4.4.3"
+    "resolveRegionConfig": "function, since <=4.4.3",
+    "nodeDualstackConfigSelectors": "object, since 4.4.12",
+    "nodeFipsConfigSelectors": "object, since 4.4.12"
   },
   "@smithy/core": {
     "requestBuilder": "function, since <=3.18.0",

--- a/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.spec.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_USE_DUALSTACK_ENDPOINT,
   ENV_USE_DUALSTACK_ENDPOINT,
   NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS,
+  nodeDualstackConfigSelectors,
 } from "./NodeUseDualstackEndpointConfigOptions";
 
 vi.mock("@smithy/util-config-provider");
@@ -47,6 +48,11 @@ describe("NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS", () => {
 
   it("returns undefined for default", () => {
     const { default: defaultValue } = NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS;
+    expect(defaultValue).toEqual(DEFAULT_USE_DUALSTACK_ENDPOINT);
+  });
+
+  it("returns undefined for default when using nodeFipsConfigSelectors", () => {
+    const { default: defaultValue } = nodeDualstackConfigSelectors;
     expect(defaultValue).toBeUndefined();
   });
 });

--- a/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
@@ -15,9 +15,21 @@ export const CONFIG_USE_DUALSTACK_ENDPOINT = "use_dualstack_endpoint";
 export const DEFAULT_USE_DUALSTACK_ENDPOINT = false;
 
 /**
+ * Don't delete this, used by older clients.
+ * @deprecated replaced by nodeDualstackConfigSelectors in newer clients.
  * @internal
  */
-export const NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean | undefined> = {
+export const NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
+  environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
+    booleanSelector(env, ENV_USE_DUALSTACK_ENDPOINT, SelectorType.ENV),
+  configFileSelector: (profile) => booleanSelector(profile, CONFIG_USE_DUALSTACK_ENDPOINT, SelectorType.CONFIG),
+  default: false,
+};
+
+/**
+ * @internal
+ */
+export const nodeDualstackConfigSelectors: LoadedConfigSelectors<boolean | undefined> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, ENV_USE_DUALSTACK_ENDPOINT, SelectorType.ENV),
   configFileSelector: (profile) => booleanSelector(profile, CONFIG_USE_DUALSTACK_ENDPOINT, SelectorType.CONFIG),

--- a/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.spec.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_USE_FIPS_ENDPOINT,
   ENV_USE_FIPS_ENDPOINT,
   NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS,
+  nodeFipsConfigSelectors,
 } from "./NodeUseFipsEndpointConfigOptions";
 
 vi.mock("@smithy/util-config-provider");
@@ -45,8 +46,13 @@ describe("NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS", () => {
     test(configFileSelector, profileContent, CONFIG_USE_FIPS_ENDPOINT, SelectorType.CONFIG);
   });
 
-  it("returns undefined for default", () => {
+  it("returns false for default", () => {
     const { default: defaultValue } = NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS;
+    expect(defaultValue).toBe(false);
+  });
+
+  it("returns undefined for default when using nodeFipsConfigSelectors", () => {
+    const { default: defaultValue } = nodeFipsConfigSelectors;
     expect(defaultValue).toBeUndefined();
   });
 });

--- a/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
@@ -15,9 +15,21 @@ export const CONFIG_USE_FIPS_ENDPOINT = "use_fips_endpoint";
 export const DEFAULT_USE_FIPS_ENDPOINT = false;
 
 /**
+ * Don't delete this, used by older clients.
+ * @deprecated replaced by nodeFipsConfigSelectors in newer clients.
  * @internal
  */
-export const NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean | undefined> = {
+export const NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
+  environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
+    booleanSelector(env, ENV_USE_FIPS_ENDPOINT, SelectorType.ENV),
+  configFileSelector: (profile) => booleanSelector(profile, CONFIG_USE_FIPS_ENDPOINT, SelectorType.CONFIG),
+  default: false,
+};
+
+/**
+ * @internal
+ */
+export const nodeFipsConfigSelectors: LoadedConfigSelectors<boolean | undefined> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, ENV_USE_FIPS_ENDPOINT, SelectorType.ENV),
   configFileSelector: (profile) => booleanSelector(profile, CONFIG_USE_FIPS_ENDPOINT, SelectorType.CONFIG),

--- a/packages/middleware-endpoint/src/resolveEndpointConfig.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointConfig.ts
@@ -37,12 +37,12 @@ export interface EndpointInputConfig<T extends EndpointParameters = EndpointPara
   /**
    * Enables IPv6/IPv4 dualstack endpoint.
    */
-  useDualstackEndpoint?: boolean | Provider<boolean>;
+  useDualstackEndpoint?: boolean | Provider<boolean | undefined>;
 
   /**
    * Enables FIPS compatible endpoints.
    */
-  useFipsEndpoint?: boolean | Provider<boolean>;
+  useFipsEndpoint?: boolean | Provider<boolean | undefined>;
 
   /**
    * @internal


### PR DESCRIPTION
*Issue #, if available:*
Follow up for [PR-1925](https://github.com/smithy-lang/smithy-typescript/pull/1925)

*Description of changes:*
add new config selectors while preserving deprecated ones for backward compatibility


If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
