### PR TITLE
Bump codegen version to 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Smithy Typescript Codegen Changelog
 
+## 0.48.0 (2026-04-08)
+
+### Features
+
+- Generated nullable types for sparse collections ([#1943](https://github.com/smithy-lang/smithy-typescript/pull/1943))
+- Enabled type-only symbols in Schema mode ([#1938](https://github.com/smithy-lang/smithy-typescript/pull/1938)) 
+
 ## 0.47.0 (2026-03-17)
 
 ### Features
 
 - Added `versionScheme` option for automatic versioning of generated packages ([#1914](https://github.com/smithy-lang/smithy-typescript/pull/1914))
 - (experimental) Added option to generate request/response/error snapshots from service models ([#7788](https://github.com/aws/aws-sdk-js-v3/issues/7788))
-
 
 ## 0.46.0 (2026-03-05)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.47.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.48.0"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -139,7 +139,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.47.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.48.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.47.0"
+    version = "0.48.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6753

*Description of changes:*

Bump codegen version to 0.48.0

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
