### PR TITLE
fix(util-retry): restore attempt count private APIs

### DIFF
--- a/.changeset/thin-cameras-count.md
+++ b/.changeset/thin-cameras-count.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-retry": patch
+---
+
+add maxAttempts and maxAttemptsProvider public methods to StandardRetryStrategy/AdaptiveRetryStrategy

--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -450,7 +450,8 @@
     "RETRY_COST": "number, since <=4.2.5",
     "StandardRetryStrategy": "function, since <=4.2.5",
     "THROTTLING_RETRY_DELAY_BASE": "number, since <=4.2.5",
-    "TIMEOUT_RETRY_COST": "number, since <=4.2.5"
+    "TIMEOUT_RETRY_COST": "number, since <=4.2.5",
+    "Retry": "function, since 4.3.0"
   },
   "@smithy/util-stream": {
     "Uint8ArrayBlobAdapter": "function, since <=4.5.6",

--- a/packages/util-retry/src/AdaptiveRetryStrategy.ts
+++ b/packages/util-retry/src/AdaptiveRetryStrategy.ts
@@ -62,4 +62,12 @@ export class AdaptiveRetryStrategy implements RetryStrategyV2 {
     this.rateLimiter.updateClientSendingRate({});
     this.standardRetryStrategy.recordSuccess(token);
   }
+
+  /**
+   * There is an existing integration which accesses this field.
+   * @deprecated
+   */
+  public async maxAttemptsProvider(): Promise<number> {
+    return this.standardRetryStrategy.maxAttempts();
+  }
 }

--- a/packages/util-retry/src/StandardRetryStrategy.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.ts
@@ -142,4 +142,12 @@ export class StandardRetryStrategy implements RetryStrategyV2 {
   private isRetryableError(errorType: RetryErrorType): boolean {
     return errorType === "THROTTLING" || errorType === "TRANSIENT";
   }
+
+  /**
+   * There is an existing integration which accesses this field.
+   * @deprecated
+   */
+  public async maxAttempts(): Promise<number> {
+    return this.maxAttemptsProvider();
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

This establishes backwards compatible public APIs for reporting attempt counts in retry strategies due to an integration point that accessed the private properties at runtime.
