### PR TITLE
fix(node-http-handler): enforce single-use connections for event-streams in http2

### DIFF
--- a/.changeset/neat-rockets-kick.md
+++ b/.changeset/neat-rockets-kick.md
@@ -1,0 +1,7 @@
+---
+"@smithy/node-http-handler": patch
+"@smithy/smithy-client": patch
+"@smithy/types": patch
+---
+
+add eventStream indicator signal for NodeHttp2ConnectionManager so it does not reuse connections for event streams

--- a/packages/node-http-handler/src/node-http2-connection-manager.ts
+++ b/packages/node-http-handler/src/node-http2-connection-manager.ts
@@ -28,8 +28,11 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
     const existingPool = this.sessionCache.get(url);
 
     if (existingPool) {
+      // This poll call needs to happen regardless of whether existingSession is returned.
+      // polling, and thereby dropping references to the session, allows it to be closed by garbage collection.
       const existingSession = existingPool.poll();
-      if (existingSession && !this.config.disableConcurrency) {
+
+      if (existingSession && !this.config.disableConcurrency && !connectionConfiguration.isEventStream) {
         return existingSession;
       }
     }

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -46,6 +46,19 @@ export interface NodeHttp2HandlerOptions {
 }
 
 /**
+ * This is derived from the smithyContext object. This signals to the NodeHttp2Handler specifically
+ * that the connection pool should not be used to acquire a connection. The event stream should
+ * have its own new connection.
+ *
+ * This does not apply to WebSocket event streams, since there is no pooling.
+ *
+ * @internal
+ */
+type EventStreamSignal = {
+  isEventStream?: boolean;
+};
+
+/**
  * A request handler using the node:http2 package.
  * @public
  */
@@ -86,23 +99,25 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
     });
   }
 
-  destroy(): void {
+  public destroy(): void {
     this.connectionManager.destroy();
   }
 
-  async handle(
+  public async handle(
     request: HttpRequest,
-    { abortSignal, requestTimeout }: HttpHandlerOptions = {}
+    { abortSignal, requestTimeout, isEventStream }: HttpHandlerOptions & EventStreamSignal = {}
   ): Promise<{ response: HttpResponse }> {
     if (!this.config) {
       this.config = await this.configProvider;
-      this.connectionManager.setDisableConcurrentStreams(this.config.disableConcurrentStreams || false);
+      this.connectionManager.setDisableConcurrentStreams(this.config.disableConcurrentStreams ?? false);
       if (this.config.maxConcurrentStreams) {
         this.connectionManager.setMaxConcurrentStreams(this.config.maxConcurrentStreams);
       }
     }
+
     const { requestTimeout: configRequestTimeout, disableConcurrentStreams } = this.config;
     const effectiveRequestTimeout = requestTimeout ?? configRequestTimeout;
+
     return new Promise((_resolve, _reject) => {
       // It's redundant to track fulfilled because promises use the first resolution/rejection
       // but avoids generating unnecessary stack traces in the "close" event handler.
@@ -137,8 +152,8 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
       const requestContext = { destination: new URL(authority) } as RequestContext;
       const session = this.connectionManager.lease(requestContext, {
         requestTimeout: this.config?.sessionTimeout,
-        disableConcurrentStreams: disableConcurrentStreams || false,
-      } as ConnectConfiguration);
+        isEventStream,
+      });
 
       const rejectWithDestroy = (err: Error) => {
         if (disableConcurrentStreams) {
@@ -148,7 +163,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
         reject(err);
       };
 
-      const queryString = buildQueryString(query || {});
+      const queryString = buildQueryString(query ?? {});
       let path = request.path;
       if (queryString) {
         path += `?${queryString}`;
@@ -168,7 +183,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
 
       req.on("response", (headers) => {
         const httpResponse = new HttpResponse({
-          statusCode: headers[":status"] || -1,
+          statusCode: headers[":status"] ?? -1,
           headers: getTransformedHeaders(headers),
           body: req,
         });
@@ -236,7 +251,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
     });
   }
 
-  updateHttpClientConfig(key: keyof NodeHttp2HandlerOptions, value: NodeHttp2HandlerOptions[typeof key]): void {
+  public updateHttpClientConfig(key: keyof NodeHttp2HandlerOptions, value: NodeHttp2HandlerOptions[typeof key]): void {
     this.config = undefined;
     this.configProvider = this.configProvider.then((config) => {
       return {
@@ -246,7 +261,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
     });
   }
 
-  httpHandlerConfigs(): NodeHttp2HandlerOptions {
+  public httpHandlerConfigs(): NodeHttp2HandlerOptions {
     return this.config ?? {};
   }
 

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -94,8 +94,15 @@ export abstract class Command<
       ...additionalContext,
     };
     const { requestHandler } = configuration;
+    let requestOptions = options ?? {};
+    if (smithyContext.eventStream) {
+      requestOptions = Object.assign({
+        isEventStream: true,
+        requestOptions,
+      });
+    }
     return stack.resolve(
-      (request: FinalizeHandlerArguments<any>) => requestHandler.handle(request.request as HttpRequest, options || {}),
+      (request: FinalizeHandlerArguments<any>) => requestHandler.handle(request.request as HttpRequest, requestOptions),
       handlerExecutionContext
     );
   }

--- a/packages/types/src/connection/config.ts
+++ b/packages/types/src/connection/config.ts
@@ -7,4 +7,10 @@ export interface ConnectConfiguration {
    * may take before the connection attempt is abandoned.
    */
   requestTimeout?: number;
+
+  /**
+   * Signal from the Command class object context,
+   * tells the connection manager to use a new connection.
+   */
+  isEventStream?: boolean;
 }


### PR DESCRIPTION
*Issue #, if available:*
JS-6779

*Description of changes:*

The connection pool feature of NodeHttp2Handler is not enabled in the code generator, so this doesn't change behavior, except to more strongly enforce that event stream operations do not have the possibility of reusing existing http2 sessions.
