### PR TITLE
fix(signature-v4): allow optional static credentials for event stream requests

### DIFF
--- a/.changeset/orange-wasps-cry.md
+++ b/.changeset/orange-wasps-cry.md
@@ -1,0 +1,6 @@
+---
+"@smithy/signature-v4": patch
+"@smithy/types": patch
+---
+
+allow snapshot of credentials for event-stream signing

--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -794,6 +794,54 @@ describe("SignatureV4", () => {
       );
       expect(eventSignature).toEqual("204bb5e2713e95354680e9522986d3ac0304aeafd33397f39e6540ca51ffe226");
     });
+
+    it("should use eventStreamCredentials when provided instead of credential provider", async () => {
+      const credentialProvider = vi.fn().mockRejectedValue(new Error("should not be called"));
+      const signer = new SignatureV4({
+        ...signerInit,
+        credentials: credentialProvider,
+      });
+      const eventSignature = await signer.sign(
+        {
+          headers: Uint8Array.from([5, 58, 100, 97, 116, 101, 8, 0, 0, 1, 103, 247, 125, 87, 112]),
+          payload: "foo" as any,
+        },
+        {
+          signingDate: new Date(1369353600000),
+          priorSignature: "",
+          eventStreamCredentials: {
+            accessKeyId: "akid",
+            secretAccessKey: "secret",
+          },
+        }
+      );
+      expect(credentialProvider).not.toHaveBeenCalled();
+      expect(eventSignature).toEqual("204bb5e2713e95354680e9522986d3ac0304aeafd33397f39e6540ca51ffe226");
+    });
+
+    it("should produce different signature when eventStreamCredentials differ from signer credentials", async () => {
+      const signer = new SignatureV4(signerInit);
+      const differentCreds = {
+        accessKeyId: "other-akid",
+        secretAccessKey: "other-secret",
+      };
+      const event = {
+        headers: Uint8Array.from([5, 58, 100, 97, 116, 101, 8, 0, 0, 1, 103, 247, 125, 87, 112]),
+        payload: "foo" as any,
+      };
+      const opts = {
+        signingDate: new Date(1369353600000),
+        priorSignature: "",
+      };
+
+      const signatureWithDefault = await signer.sign(event, opts);
+      const signatureWithOverride = await signer.sign(event, {
+        ...opts,
+        eventStreamCredentials: differentCreds,
+      });
+
+      expect(signatureWithDefault).not.toEqual(signatureWithOverride);
+    });
   });
 
   describe("#sign (message)", () => {
@@ -832,6 +880,38 @@ describe("SignatureV4", () => {
       expect(signedMessage.signature).toEqual("204bb5e2713e95354680e9522986d3ac0304aeafd33397f39e6540ca51ffe226");
       expect(signedMessage.message.body).toEqual("foo");
       expect(signedMessage.message.headers).toEqual(headers);
+    });
+
+    it("should use eventStreamCredentials when provided instead of credential provider", async () => {
+      const credentialProvider = vi.fn().mockRejectedValue(new Error("should not be called"));
+      const signer = new SignatureV4({
+        ...signerInit,
+        credentials: credentialProvider,
+      });
+
+      const signedMessage = await signer.sign(
+        {
+          message: {
+            headers: {
+              ":date": {
+                type: "timestamp",
+                value: new Date("2018-12-29T01:04:06.000Z"),
+              } as TimestampHeaderValue,
+            },
+            body: "foo" as any,
+          },
+          priorSignature: "",
+        } as SignableMessage,
+        {
+          signingDate: new Date(1369353600000),
+          eventStreamCredentials: {
+            accessKeyId: "akid",
+            secretAccessKey: "secret",
+          },
+        }
+      );
+      expect(credentialProvider).not.toHaveBeenCalled();
+      expect(signedMessage.signature).toEqual("204bb5e2713e95354680e9522986d3ac0304aeafd33397f39e6540ca51ffe226");
     });
   });
 

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -5,6 +5,7 @@ import type {
   FormattedEvent,
   HttpRequest,
   MessageSigner,
+  MessageSigningArguments,
   RequestPresigner,
   RequestPresigningArguments,
   RequestSigner,
@@ -118,7 +119,7 @@ export class SignatureV4
 
   public async sign(stringToSign: string, options?: SigningArguments): Promise<string>;
   public async sign(event: FormattedEvent, options: EventSigningArguments): Promise<string>;
-  public async sign(event: SignableMessage, options: SigningArguments): Promise<SignedMessage>;
+  public async sign(event: SignableMessage, options: MessageSigningArguments): Promise<SignedMessage>;
   public async sign(requestToSign: HttpRequest, options?: RequestSigningArguments): Promise<HttpRequest>;
   public async sign(toSign: any, options: any): Promise<any> {
     if (typeof toSign === "string") {
@@ -134,7 +135,13 @@ export class SignatureV4
 
   private async signEvent(
     { headers, payload }: FormattedEvent,
-    { signingDate = new Date(), priorSignature, signingRegion, signingService }: EventSigningArguments
+    {
+      signingDate = new Date(),
+      priorSignature,
+      signingRegion,
+      signingService,
+      eventStreamCredentials,
+    }: EventSigningArguments
   ): Promise<string> {
     const region = signingRegion ?? (await this.regionProvider());
     const { shortDate, longDate } = this.formatDate(signingDate);
@@ -151,12 +158,17 @@ export class SignatureV4
       hashedHeaders,
       hashedPayload,
     ].join("\n");
-    return this.signString(stringToSign, { signingDate, signingRegion: region, signingService });
+    return this.signString(stringToSign, {
+      signingDate,
+      signingRegion: region,
+      signingService,
+      eventStreamCredentials,
+    });
   }
 
   async signMessage(
     signableMessage: SignableMessage,
-    { signingDate = new Date(), signingRegion, signingService }: SigningArguments
+    { signingDate = new Date(), signingRegion, signingService, eventStreamCredentials }: MessageSigningArguments
   ): Promise<SignedMessage> {
     const promise = this.signEvent(
       {
@@ -168,6 +180,7 @@ export class SignatureV4
         signingRegion,
         signingService,
         priorSignature: signableMessage.priorSignature,
+        eventStreamCredentials,
       }
     );
 
@@ -178,9 +191,14 @@ export class SignatureV4
 
   private async signString(
     stringToSign: string,
-    { signingDate = new Date(), signingRegion, signingService }: SigningArguments = {}
+    {
+      signingDate = new Date(),
+      signingRegion,
+      signingService,
+      eventStreamCredentials,
+    }: SigningArguments & Partial<EventSigningArguments> = {}
   ): Promise<string> {
-    const credentials = await this.credentialProvider();
+    const credentials = eventStreamCredentials ?? (await this.credentialProvider());
     this.validateResolvedCredentials(credentials);
     const region = signingRegion ?? (await this.regionProvider());
     const { shortDate } = this.formatDate(signingDate);

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -1,5 +1,6 @@
 import type { Message } from "./eventStream";
 import type { HttpRequest } from "./http";
+import type { AwsCredentialIdentity } from "./identity/awsCredentialIdentity";
 
 /**
  * @public
@@ -86,8 +87,25 @@ export interface RequestPresigningArguments extends RequestSigningArguments {
 /**
  * @public
  */
-export interface EventSigningArguments extends SigningArguments {
+export interface EventSigningArguments extends SigningArguments, EventStreamRequestScopedCredentials {
   priorSignature: string;
+}
+
+/**
+ * @public
+ */
+export interface MessageSigningArguments extends SigningArguments, EventStreamRequestScopedCredentials {}
+
+/**
+ * @internal
+ */
+export interface EventStreamRequestScopedCredentials {
+  /**
+   * Optional, static credentials used for the duration of the event-stream request.
+   * If not provided, the signer's internal credential provider would be used, if
+   * the signer is SignatureV4.
+   */
+  eventStreamCredentials?: AwsCredentialIdentity;
 }
 
 /**
@@ -169,6 +187,6 @@ export interface SignedMessage {
  * @public
  */
 export interface MessageSigner {
-  signMessage(message: SignableMessage, args: SigningArguments): Promise<SignedMessage>;
-  sign(event: SignableMessage, options: SigningArguments): Promise<SignedMessage>;
+  signMessage(message: SignableMessage, args: MessageSigningArguments): Promise<SignedMessage>;
+  sign(event: SignableMessage, options: MessageSigningArguments): Promise<SignedMessage>;
 }


### PR DESCRIPTION
*Issue #, if available:*
JS-6779

*Description of changes:*

This adds an optional signature for event and message signing where a static credential can be provided, which has a lifecycle tied to the request.

This allows the client to perform a credential refresh without interrupting the event stream signing process, which requires a static set of credentials.