### PR TITLE
fix(util-endpoints): handle null-ish input for getEndpointHeaders

### DIFF
--- a/.changeset/fluffy-tigers-swim.md
+++ b/.changeset/fluffy-tigers-swim.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": patch
+---
+
+handle nullish input for getEndpointHeaders function

--- a/packages/util-endpoints/src/bdd/BinaryDecisionDiagram.ts
+++ b/packages/util-endpoints/src/bdd/BinaryDecisionDiagram.ts
@@ -1,6 +1,6 @@
 import type { EndpointObjectHeaders, ParameterObject } from "@smithy/types";
 
-import type { FunctionArgv } from "../types/shared";
+import type { Expression, FunctionArgv } from "../types/shared";
 
 /**
  * @internal
@@ -10,7 +10,11 @@ type BddCondition = [string, FunctionArgv] | [string, FunctionArgv, string];
 /**
  * @internal
  */
-type BddResult = [-1] | [-1, string] | [string, Record<string, ParameterObject>, EndpointObjectHeaders];
+type BddResult =
+  | [-1]
+  | [-1, Expression]
+  | [string, Record<string, ParameterObject>, EndpointObjectHeaders]
+  | [string, Record<string, ParameterObject>];
 
 /**
  * @internal

--- a/packages/util-endpoints/src/decideEndpoint.spec.ts
+++ b/packages/util-endpoints/src/decideEndpoint.spec.ts
@@ -36,4 +36,20 @@ describe(decideEndpoint.name, () => {
       headers: {},
     });
   });
+
+  it("evaluates templates in error messages", () => {
+    const r = 100_000_000;
+    const bdd = new Int32Array([0, 0, 0, 0, r + 0, -1]);
+    const data = BinaryDecisionDiagram.from(
+      bdd,
+      2,
+      [["isSet", [{ ref: "Region" }]]],
+      [[-1, "Invalid region: {Region}"]]
+    );
+    expect(() =>
+      decideEndpoint(data, {
+        endpointParams: { Region: "us-west-2" },
+      })
+    ).toThrow("Invalid region: us-west-2");
+  });
 });

--- a/packages/util-endpoints/src/decideEndpoint.ts
+++ b/packages/util-endpoints/src/decideEndpoint.ts
@@ -4,6 +4,7 @@ import type { BinaryDecisionDiagram } from "./bdd/BinaryDecisionDiagram";
 import type { EndpointResolverOptions } from "./types";
 import { EndpointError } from "./types";
 import { evaluateCondition } from "./utils/evaluateCondition";
+import { evaluateExpression } from "./utils/evaluateExpression";
 import { getEndpointHeaders } from "./utils/getEndpointHeaders";
 import { getEndpointProperties } from "./utils/getEndpointProperties";
 import { getEndpointUrl } from "./utils/getEndpointUrl";
@@ -40,15 +41,15 @@ export const decideEndpoint = (bdd: BinaryDecisionDiagram, options: EndpointReso
   if (ref >= RESULT) {
     const result = results[ref - RESULT];
     if (result[0] === -1) {
-      const [, errorMessage] = result;
-      throw new EndpointError(errorMessage!);
+      const [, errorExpression] = result;
+      throw new EndpointError(evaluateExpression(errorExpression!, "Error", closure) as string);
     }
     const [url, properties, headers] = result;
 
     return {
       url: getEndpointUrl(url, closure),
       properties: getEndpointProperties(properties, closure),
-      headers: getEndpointHeaders(headers, closure),
+      headers: getEndpointHeaders(headers ?? {}, closure),
     };
   }
 

--- a/packages/util-endpoints/src/utils/getEndpointHeaders.spec.ts
+++ b/packages/util-endpoints/src/utils/getEndpointHeaders.spec.ts
@@ -16,6 +16,7 @@ describe(getEndpointHeaders.name, () => {
   });
 
   it("should return an empty object if empty headers are provided", () => {
+    expect(getEndpointHeaders(null as any, mockOptions)).toEqual({});
     expect(getEndpointHeaders({}, mockOptions)).toEqual({});
     expect(evaluateExpression).not.toHaveBeenCalled();
   });

--- a/packages/util-endpoints/src/utils/getEndpointHeaders.ts
+++ b/packages/util-endpoints/src/utils/getEndpointHeaders.ts
@@ -3,7 +3,7 @@ import { EndpointError } from "../types";
 import { evaluateExpression } from "./evaluateExpression";
 
 export const getEndpointHeaders = (headers: EndpointObjectHeaders, options: EvaluateOptions) =>
-  Object.entries(headers).reduce(
+  Object.entries(headers ?? {}).reduce(
     (acc, [headerKey, headerVal]) => ({
       ...acc,
       [headerKey]: headerVal.map((headerValEntry) => {


### PR DESCRIPTION
*Issue #, if available:*

In https://github.com/smithy-lang/smithy-typescript/pull/1948, bdd result nodes with no headers will use undefined for the headers to save space. 

This defends against that case.
