### PR TITLE
fix(util-endpoints): handle negative index in getAttr

### DIFF
--- a/.changeset/eight-squids-visit.md
+++ b/.changeset/eight-squids-visit.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": patch
+---
+
+fix getAttr function when using negative index

--- a/packages/util-endpoints/src/lib/getAttr.spec.ts
+++ b/packages/util-endpoints/src/lib/getAttr.spec.ts
@@ -36,6 +36,8 @@ describe(getAttr.name, () => {
     it.each([
       [mockArr[0], "[0]", ["0"]],
       [mockArr[1], "[1]", ["1"]],
+      [mockArr[1], "[-1]", ["-1"]],
+      [mockArr[0], "[-2]", ["-2"]],
     ])("returns '%s' for '%s'", (output, input, pathList) => {
       testSuccess(mockArr, input, output, pathList);
     });

--- a/packages/util-endpoints/src/lib/getAttr.ts
+++ b/packages/util-endpoints/src/lib/getAttr.ts
@@ -11,7 +11,8 @@ export const getAttr = (value: GetAttrValue, path: string): GetAttrValue =>
     if (typeof acc !== "object") {
       throw new EndpointError(`Index '${index}' in '${path}' not found in '${JSON.stringify(value)}'`);
     } else if (Array.isArray(acc)) {
-      return acc[parseInt(index)];
+      const i = parseInt(index);
+      return acc[i < 0 ? acc.length + i : i];
     }
     return acc[index];
   }, value);

--- a/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -1,7 +1,9 @@
-import { existsSync, readdirSync } from "fs";
-import { resolve } from "path";
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, test as it } from "vitest";
 
+import { BinaryDecisionDiagram } from "./bdd/BinaryDecisionDiagram";
+import { decideEndpoint } from "./decideEndpoint";
 import { resolveEndpoint } from "./resolveEndpoint";
 import { EndpointError } from "./types";
 
@@ -44,5 +46,61 @@ describe(resolveEndpoint.name, () => {
         });
       }
     }
+  });
+});
+
+describe(decideEndpoint.name, () => {
+  describe("split, ite, and getAttr with negative index", () => {
+    const r = 100_000_000;
+
+    const conditions = [
+      ["split", [{ ref: "Splittable" }, ".", 0], "parts"],
+      ["getAttr", [{ ref: "parts" }, "[-2]"], "tld"],
+      ["stringEquals", [{ ref: "tld" }, "com"], "isCom"],
+    ];
+
+    const results = [[{ fn: "ite", argv: [{ ref: "isCom" }, "https://api.___.com", "https://api.___.net"] }, {}, {}]];
+
+    const nodes = new Int32Array([
+      0,
+      0,
+      0,
+      // (2, start) - split Splittable by "." with unlimited parts and proceed to node 3.
+      0,
+      3,
+      -1,
+      // (3) - getAttr [-2] and assign to tld, proceed to node 4.
+      1,
+      4,
+      -1,
+      // (4) - compare tld to "com" as isCom and proceed to terminal 0.
+      2,
+      r + 0,
+      r + 0,
+    ]);
+
+    const bdd = BinaryDecisionDiagram.from(nodes, 2, conditions, results);
+
+    it("should resolve endpoint using split + getAttr[-1] + ite", () => {
+      const endpoint = decideEndpoint(bdd, {
+        endpointParams: { Splittable: "___.com.___" },
+      });
+      expect(endpoint).toEqual({
+        url: new URL("https://api.___.com"),
+        properties: {},
+        headers: {},
+      });
+    });
+
+    it("should pick alternate URL when getAttr[-1] yields non-com TLD", () => {
+      const endpoint = decideEndpoint(bdd, {
+        endpointParams: { Splittable: "___.org.___" },
+      });
+      expect(endpoint).toEqual({
+        url: new URL("https://api.___.net"),
+        properties: {},
+        headers: {},
+      });
+    });
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
follows https://github.com/smithy-lang/smithy-typescript/pull/1949

*Description of changes:*

negative index in getAttr are only used in the new BDD endpoint resolver.

see https://smithy.io/2.0/additional-specs/rules-engine/standard-library.html#getattr-function
