### PR TITLE
perf(util-endpoints): reduce temporary object allocations

### DIFF
--- a/.changeset/nasty-beers-invite.md
+++ b/.changeset/nasty-beers-invite.md
@@ -2,4 +2,4 @@
 "@smithy/util-endpoints": patch
 ---
 
-Reduce allocations in evaluateCondition(s)
+Reduce temporary object allocations

--- a/.changeset/nasty-beers-invite.md
+++ b/.changeset/nasty-beers-invite.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": patch
+---
+
+Reduce allocations in evaluateCondition

--- a/.changeset/nasty-beers-invite.md
+++ b/.changeset/nasty-beers-invite.md
@@ -2,4 +2,4 @@
 "@smithy/util-endpoints": patch
 ---
 
-Reduce allocations in evaluateCondition
+Reduce allocations in evaluateCondition(s)

--- a/packages/util-endpoints/src/types/shared.ts
+++ b/packages/util-endpoints/src/types/shared.ts
@@ -1,4 +1,4 @@
-import type { EndpointARN, EndpointPartition, Logger } from "@smithy/types";
+import type { EndpointARN, EndpointPartition, EndpointURL, Logger } from "@smithy/types";
 
 export type ReferenceObject = { ref: string };
 
@@ -10,8 +10,11 @@ export type FunctionReturn =
   | number
   | EndpointARN
   | EndpointPartition
+  | EndpointURL
   | { [key: string]: FunctionReturn }
-  | null;
+  | Array<FunctionReturn>
+  | null
+  | undefined;
 
 export type ConditionObject = FunctionObject & { assign?: string };
 

--- a/packages/util-endpoints/src/types/shared.ts
+++ b/packages/util-endpoints/src/types/shared.ts
@@ -13,8 +13,7 @@ export type FunctionReturn =
   | EndpointURL
   | { [key: string]: FunctionReturn }
   | Array<FunctionReturn>
-  | null
-  | undefined;
+  | null;
 
 export type ConditionObject = FunctionObject & { assign?: string };
 

--- a/packages/util-endpoints/src/utils/endpointFunctions.ts
+++ b/packages/util-endpoints/src/utils/endpointFunctions.ts
@@ -12,8 +12,9 @@ import {
   substring,
   uriEncode,
 } from "../lib";
+import type { EndpointFunctions } from "../types";
 
-export const endpointFunctions = {
+export const endpointFunctions: EndpointFunctions = {
   booleanEquals,
   coalesce,
   getAttr,

--- a/packages/util-endpoints/src/utils/evaluateCondition.ts
+++ b/packages/util-endpoints/src/utils/evaluateCondition.ts
@@ -3,16 +3,20 @@ import type { ConditionObject, EvaluateOptions } from "../types";
 import { EndpointError } from "../types";
 import { callFunction } from "./callFunction";
 
-export const evaluateCondition = ({ assign, ...fnArgs }: ConditionObject, options: EvaluateOptions) => {
+export const evaluateCondition = (condition: ConditionObject, options: EvaluateOptions) => {
+  const { assign } = condition;
+
   if (assign && assign in options.referenceRecord) {
     throw new EndpointError(`'${assign}' is already defined in Reference Record.`);
   }
-  const value = callFunction(fnArgs, options);
+  const value = callFunction(condition, options);
 
-  options.logger?.debug?.(`${debugId} evaluateCondition: ${toDebugString(fnArgs)} = ${toDebugString(value)}`);
+  options.logger?.debug?.(`${debugId} evaluateCondition: ${toDebugString(condition)} = ${toDebugString(value)}`);
 
-  return {
-    result: value === "" ? true : !!value,
-    ...(assign != null && { toAssign: { name: assign, value } }),
-  };
+  const result = value === "" ? true : !!value;
+
+  if (assign != null) {
+    return { result, toAssign: { name: assign, value } };
+  }
+  return { result };
 };

--- a/packages/util-endpoints/src/utils/evaluateConditions.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.spec.ts
@@ -50,14 +50,17 @@ describe(evaluateConditions.name, () => {
     const value1 = "value1";
     const value2 = "value2";
 
-    vi.mocked(evaluateCondition).mockReturnValueOnce({
-      result: true,
-      toAssign: { name: mockCn1.assign!, value: value1 },
-    });
-    vi.mocked(evaluateCondition).mockReturnValueOnce({
-      result: true,
-      toAssign: { name: mockCn2.assign!, value: value2 },
-    });
+    const capturedReferenceRecords: Record<string, unknown>[] = [];
+
+    vi.mocked(evaluateCondition)
+      .mockImplementationOnce((_condition, options) => {
+        capturedReferenceRecords.push({ ...options.referenceRecord });
+        return { result: true, toAssign: { name: mockCn1.assign!, value: value1 } };
+      })
+      .mockImplementationOnce((_condition, options) => {
+        capturedReferenceRecords.push({ ...options.referenceRecord });
+        return { result: true, toAssign: { name: mockCn2.assign!, value: value2 } };
+      });
 
     const { result, referenceRecord } = evaluateConditions([mockCn1, mockCn2], { ...mockOptions });
     expect(result).toBe(true);
@@ -65,11 +68,8 @@ describe(evaluateConditions.name, () => {
       [mockCn1.assign!]: value1,
       [mockCn2.assign!]: value2,
     });
-    expect(evaluateCondition).toHaveBeenNthCalledWith(1, mockCn1, mockOptions);
-    expect(evaluateCondition).toHaveBeenNthCalledWith(2, mockCn2, {
-      ...mockOptions,
-      referenceRecord: { [mockCn1.assign!]: value1 },
-    });
+    expect(capturedReferenceRecords[0]).toEqual({});
+    expect(capturedReferenceRecords[1]).toEqual({ [mockCn1.assign!]: value1 });
     expect(mockLogger.debug).nthCalledWith(1, `${debugId} assign: ${mockCn1.assign} := ${toDebugString(value1)}`);
     expect(mockLogger.debug).nthCalledWith(2, `${debugId} assign: ${mockCn2.assign} := ${toDebugString(value2)}`);
   });

--- a/packages/util-endpoints/src/utils/evaluateConditions.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.spec.ts
@@ -73,4 +73,15 @@ describe(evaluateConditions.name, () => {
     expect(mockLogger.debug).nthCalledWith(1, `${debugId} assign: ${mockCn1.assign} := ${toDebugString(value1)}`);
     expect(mockLogger.debug).nthCalledWith(2, `${debugId} assign: ${mockCn2.assign} := ${toDebugString(value2)}`);
   });
+
+  it("returns true without a referenceRecord if no conditions assign values", () => {
+    vi.mocked(evaluateCondition).mockReturnValueOnce({ result: true }).mockReturnValueOnce({ result: true });
+
+    const result = evaluateConditions([mockCn1, mockCn2], mockOptions);
+
+    expect(result).toEqual({ result: true });
+    expect(evaluateCondition).toHaveBeenNthCalledWith(1, mockCn1, mockOptions);
+    expect(evaluateCondition).toHaveBeenNthCalledWith(2, mockCn2, mockOptions);
+    expect(mockLogger.debug).not.toHaveBeenCalled();
+  });
 });

--- a/packages/util-endpoints/src/utils/evaluateConditions.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.ts
@@ -23,5 +23,9 @@ export const evaluateConditions = (conditions: ConditionObject[] = [], options: 
     }
   }
 
+  if (Object.keys(conditionsReferenceRecord).length === 0) {
+    return { result: true };
+  }
+
   return { result: true, referenceRecord: conditionsReferenceRecord };
 };

--- a/packages/util-endpoints/src/utils/evaluateConditions.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.ts
@@ -8,6 +8,7 @@ export const evaluateConditions = (conditions: ConditionObject[] = [], options: 
     ...options,
     referenceRecord: { ...options.referenceRecord },
   };
+  let didAssign = false;
 
   for (const condition of conditions) {
     const { result, toAssign } = evaluateCondition(condition, conditionOptions);
@@ -17,15 +18,16 @@ export const evaluateConditions = (conditions: ConditionObject[] = [], options: 
     }
 
     if (toAssign) {
+      didAssign = true;
       conditionsReferenceRecord[toAssign.name] = toAssign.value;
       conditionOptions.referenceRecord[toAssign.name] = toAssign.value;
       options.logger?.debug?.(`${debugId} assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`);
     }
   }
 
-  if (Object.keys(conditionsReferenceRecord).length === 0) {
-    return { result: true };
+  if (didAssign) {
+    return { result: true, referenceRecord: conditionsReferenceRecord };
   }
 
-  return { result: true, referenceRecord: conditionsReferenceRecord };
+  return { result: true };
 };

--- a/packages/util-endpoints/src/utils/evaluateConditions.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.ts
@@ -4,15 +4,13 @@ import { evaluateCondition } from "./evaluateCondition";
 
 export const evaluateConditions = (conditions: ConditionObject[] = [], options: EvaluateOptions) => {
   const conditionsReferenceRecord: Record<string, FunctionReturn> = {};
+  const conditionOptions: EvaluateOptions = {
+    ...options,
+    referenceRecord: { ...options.referenceRecord },
+  };
 
   for (const condition of conditions) {
-    const { result, toAssign } = evaluateCondition(condition, {
-      ...options,
-      referenceRecord: {
-        ...options.referenceRecord,
-        ...conditionsReferenceRecord,
-      },
-    });
+    const { result, toAssign } = evaluateCondition(condition, conditionOptions);
 
     if (!result) {
       return { result };
@@ -20,6 +18,7 @@ export const evaluateConditions = (conditions: ConditionObject[] = [], options: 
 
     if (toAssign) {
       conditionsReferenceRecord[toAssign.name] = toAssign.value;
+      conditionOptions.referenceRecord[toAssign.name] = toAssign.value;
       options.logger?.debug?.(`${debugId} assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`);
     }
   }

--- a/packages/util-endpoints/src/utils/evaluateEndpointRule.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateEndpointRule.spec.ts
@@ -47,6 +47,15 @@ describe(evaluateEndpointRule.name, () => {
     expect(getEndpointProperties).not.toHaveBeenCalled();
   });
 
+  it("reuses the original options when conditions assign no references", () => {
+    vi.mocked(evaluateConditions).mockReturnValue({ result: true });
+    vi.mocked(getEndpointUrl).mockReturnValue(new URL(mockEndpoint.url));
+
+    evaluateEndpointRule(mockEndpointRule, mockOptions);
+
+    expect(getEndpointUrl).toHaveBeenCalledWith(mockEndpoint.url, mockOptions);
+  });
+
   describe("returns endpoint if conditions are true", () => {
     const mockReferenceRecord = { key: "value" };
     const mockEndpointUrl = new URL(mockEndpoint.url);

--- a/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
@@ -18,10 +18,12 @@ export const evaluateEndpointRule = (
     return;
   }
 
-  const endpointRuleOptions = {
-    ...options,
-    referenceRecord: { ...options.referenceRecord, ...referenceRecord },
-  };
+  const endpointRuleOptions = referenceRecord
+    ? {
+        ...options,
+        referenceRecord: { ...options.referenceRecord, ...referenceRecord },
+      }
+    : options;
 
   const { url, properties, headers } = endpoint;
 

--- a/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
@@ -30,10 +30,10 @@ export const evaluateEndpointRule = (
   options.logger?.debug?.(`${debugId} Resolving endpoint from template: ${toDebugString(endpoint)}`);
 
   const endpointToReturn: EndpointV2 = { url: getEndpointUrl(url, endpointRuleOptions) };
-  if (headers != undefined) {
+  if (headers != null) {
     endpointToReturn.headers = getEndpointHeaders(headers, endpointRuleOptions);
   }
-  if (properties != undefined) {
+  if (properties != null) {
     endpointToReturn.properties = getEndpointProperties(properties, endpointRuleOptions);
   }
 

--- a/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
@@ -27,13 +27,13 @@ export const evaluateEndpointRule = (
 
   options.logger?.debug?.(`${debugId} Resolving endpoint from template: ${toDebugString(endpoint)}`);
 
-  return {
-    ...(headers != undefined && {
-      headers: getEndpointHeaders(headers, endpointRuleOptions),
-    }),
-    ...(properties != undefined && {
-      properties: getEndpointProperties(properties, endpointRuleOptions),
-    }),
-    url: getEndpointUrl(url, endpointRuleOptions),
-  };
+  const endpointToReturn: EndpointV2 = { url: getEndpointUrl(url, endpointRuleOptions) };
+  if (headers != undefined) {
+    endpointToReturn.headers = getEndpointHeaders(headers, endpointRuleOptions);
+  }
+  if (properties != undefined) {
+    endpointToReturn.properties = getEndpointProperties(properties, endpointRuleOptions);
+  }
+
+  return endpointToReturn;
 };

--- a/packages/util-endpoints/src/utils/evaluateErrorRule.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateErrorRule.spec.ts
@@ -33,6 +33,16 @@ describe(evaluateErrorRule.name, () => {
     expect(evaluateExpression).not.toHaveBeenCalled();
   });
 
+  it("reuses the original options if conditions assign no references", () => {
+    const mockErrorMsg = "mockErrorMsg";
+
+    vi.mocked(evaluateConditions).mockReturnValue({ result: true });
+    vi.mocked(evaluateExpression).mockReturnValue(mockErrorMsg);
+
+    expect(() => evaluateErrorRule(mockErrorRule, mockOptions)).toThrowError(new EndpointError(`mockErrorMsg`));
+    expect(evaluateExpression).toHaveBeenCalledWith(mockError, "Error", mockOptions);
+  });
+
   it("throws error if conditions evaluate to true", () => {
     const mockErrorMsg = "mockErrorMsg";
     const mockReferenceRecord = { key: "value" };

--- a/packages/util-endpoints/src/utils/evaluateErrorRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateErrorRule.ts
@@ -11,10 +11,12 @@ export const evaluateErrorRule = (errorRule: ErrorRuleObject, options: EvaluateO
     return;
   }
 
-  throw new EndpointError(
-    evaluateExpression(error, "Error", {
-      ...options,
-      referenceRecord: { ...options.referenceRecord, ...referenceRecord },
-    }) as string
-  );
+  const errorRuleOptions = referenceRecord
+    ? {
+        ...options,
+        referenceRecord: { ...options.referenceRecord, ...referenceRecord },
+      }
+    : options;
+
+  throw new EndpointError(evaluateExpression(error, "Error", errorRuleOptions) as string);
 };

--- a/packages/util-endpoints/src/utils/evaluateExpression.ts
+++ b/packages/util-endpoints/src/utils/evaluateExpression.ts
@@ -29,20 +29,21 @@ export const callFunction = ({ fn, argv }: FunctionObject, options: EvaluateOpti
     }
   }
 
-  // if-statement to avoid split array allocation.
-  if (fn.includes(".")) {
-    const fnSegments = fn.split(".");
-    if (fnSegments[0] in customEndpointFunctions && fnSegments[1] != null) {
-      return (customEndpointFunctions as any)[fnSegments[0]][fnSegments[1]](...evaluatedArgs);
+  const namespaceSeparatorIndex = fn.indexOf(".");
+  if (namespaceSeparatorIndex !== -1) {
+    const namespaceFunctions = customEndpointFunctions[fn.slice(0, namespaceSeparatorIndex)];
+    const customFunction = namespaceFunctions?.[fn.slice(namespaceSeparatorIndex + 1)];
+    if (typeof customFunction === "function") {
+      return customFunction(...evaluatedArgs);
     }
   }
 
-  if (typeof (endpointFunctions as Record<string, Function>)[fn] !== "function") {
-    throw new Error(`function ${fn} not loaded in endpointFunctions.`);
+  const callable = endpointFunctions[fn as keyof typeof endpointFunctions];
+  if (typeof callable === "function") {
+    return callable(...evaluatedArgs);
   }
 
-  const callable = endpointFunctions[fn as keyof typeof endpointFunctions] as (...args: any[]) => any;
-  return callable(...evaluatedArgs);
+  throw new Error(`function ${fn} not loaded in endpointFunctions.`);
 };
 
 export const group = {

--- a/packages/util-endpoints/src/utils/evaluateRules.ts
+++ b/packages/util-endpoints/src/utils/evaluateRules.ts
@@ -35,10 +35,9 @@ export const evaluateTreeRule = (treeRule: TreeRuleObject, options: EvaluateOpti
     return;
   }
 
-  const treeRuleOptions =
-    Object.keys(referenceRecord ?? {}).length > 0
-      ? { ...options, referenceRecord: { ...options.referenceRecord, ...referenceRecord } }
-      : options;
+  const treeRuleOptions = referenceRecord
+    ? { ...options, referenceRecord: { ...options.referenceRecord, ...referenceRecord } }
+    : options;
 
   return group.evaluateRules(rules, treeRuleOptions);
 };

--- a/packages/util-endpoints/src/utils/evaluateRules.ts
+++ b/packages/util-endpoints/src/utils/evaluateRules.ts
@@ -35,10 +35,12 @@ export const evaluateTreeRule = (treeRule: TreeRuleObject, options: EvaluateOpti
     return;
   }
 
-  return group.evaluateRules(rules, {
-    ...options,
-    referenceRecord: { ...options.referenceRecord, ...referenceRecord },
-  });
+  const treeRuleOptions =
+    Object.keys(referenceRecord ?? {}).length > 0
+      ? { ...options, referenceRecord: { ...options.referenceRecord, ...referenceRecord } }
+      : options;
+
+  return group.evaluateRules(rules, treeRuleOptions);
 };
 
 export const group = {

--- a/packages/util-endpoints/src/utils/getEndpointHeaders.ts
+++ b/packages/util-endpoints/src/utils/getEndpointHeaders.ts
@@ -3,16 +3,13 @@ import { EndpointError } from "../types";
 import { evaluateExpression } from "./evaluateExpression";
 
 export const getEndpointHeaders = (headers: EndpointObjectHeaders, options: EvaluateOptions) =>
-  Object.entries(headers ?? {}).reduce(
-    (acc, [headerKey, headerVal]) => ({
-      ...acc,
-      [headerKey]: headerVal.map((headerValEntry) => {
-        const processedExpr = evaluateExpression(headerValEntry, "Header value entry", options);
-        if (typeof processedExpr !== "string") {
-          throw new EndpointError(`Header '${headerKey}' value '${processedExpr}' is not a string`);
-        }
-        return processedExpr;
-      }),
-    }),
-    {}
-  );
+  Object.entries(headers ?? {}).reduce((acc, [headerKey, headerVal]) => {
+    acc[headerKey] = headerVal.map((headerValEntry) => {
+      const processedExpr = evaluateExpression(headerValEntry, "Header value entry", options);
+      if (typeof processedExpr !== "string") {
+        throw new EndpointError(`Header '${headerKey}' value '${processedExpr}' is not a string`);
+      }
+      return processedExpr;
+    });
+    return acc;
+  }, {});

--- a/packages/util-endpoints/src/utils/getEndpointHeaders.ts
+++ b/packages/util-endpoints/src/utils/getEndpointHeaders.ts
@@ -3,13 +3,16 @@ import { EndpointError } from "../types";
 import { evaluateExpression } from "./evaluateExpression";
 
 export const getEndpointHeaders = (headers: EndpointObjectHeaders, options: EvaluateOptions) =>
-  Object.entries(headers ?? {}).reduce((acc, [headerKey, headerVal]) => {
-    acc[headerKey] = headerVal.map((headerValEntry) => {
-      const processedExpr = evaluateExpression(headerValEntry, "Header value entry", options);
-      if (typeof processedExpr !== "string") {
-        throw new EndpointError(`Header '${headerKey}' value '${processedExpr}' is not a string`);
-      }
-      return processedExpr;
-    });
-    return acc;
-  }, {});
+  Object.entries(headers ?? {}).reduce(
+    (acc, [headerKey, headerVal]) => {
+      acc[headerKey] = headerVal.map((headerValEntry) => {
+        const processedExpr = evaluateExpression(headerValEntry, "Header value entry", options);
+        if (typeof processedExpr !== "string") {
+          throw new EndpointError(`Header '${headerKey}' value '${processedExpr}' is not a string`);
+        }
+        return processedExpr;
+      });
+      return acc;
+    },
+    {} as Record<string, string[]>
+  );

--- a/packages/util-endpoints/src/utils/getEndpointProperties.ts
+++ b/packages/util-endpoints/src/utils/getEndpointProperties.ts
@@ -5,13 +5,10 @@ import { EndpointError } from "../types";
 import { evaluateTemplate } from "./evaluateTemplate";
 
 export const getEndpointProperties = (properties: EndpointObjectProperties, options: EvaluateOptions) =>
-  Object.entries(properties).reduce(
-    (acc, [propertyKey, propertyVal]) => ({
-      ...acc,
-      [propertyKey]: group.getEndpointProperty(propertyVal, options),
-    }),
-    {}
-  );
+  Object.entries(properties).reduce((acc, [propertyKey, propertyVal]) => {
+    acc[propertyKey] = group.getEndpointProperty(propertyVal, options);
+    return acc;
+  }, {});
 
 export const getEndpointProperty = (
   property: EndpointObjectProperty,

--- a/packages/util-endpoints/src/utils/getEndpointProperties.ts
+++ b/packages/util-endpoints/src/utils/getEndpointProperties.ts
@@ -5,10 +5,13 @@ import { EndpointError } from "../types";
 import { evaluateTemplate } from "./evaluateTemplate";
 
 export const getEndpointProperties = (properties: EndpointObjectProperties, options: EvaluateOptions) =>
-  Object.entries(properties).reduce((acc, [propertyKey, propertyVal]) => {
-    acc[propertyKey] = group.getEndpointProperty(propertyVal, options);
-    return acc;
-  }, {});
+  Object.entries(properties).reduce(
+    (acc, [propertyKey, propertyVal]) => {
+      acc[propertyKey] = group.getEndpointProperty(propertyVal, options);
+      return acc;
+    },
+    {} as Record<string, EndpointObjectProperty>
+  );
 
 export const getEndpointProperty = (
   property: EndpointObjectProperty,


### PR DESCRIPTION
### Issue
Internal JS-6645

### Description

Remove rest spread destructuring that created a new object on every call, and replace conditional spread in the return with an early return branch to avoid temporary object allocation.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
