### PR TITLE
perf(util-endpoints): resolve defaults and required params in one pass

### DIFF
--- a/.changeset/smart-roses-lay.md
+++ b/.changeset/smart-roses-lay.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": patch
+---
+
+Resolve defaults and required params in one pass

--- a/packages/util-endpoints/src/resolveEndpoint.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.ts
@@ -14,24 +14,17 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
 
   options.logger?.debug?.(`${debugId} Initial EndpointParams: ${toDebugString(endpointParams)}`);
 
-  // @ts-ignore Type 'undefined' is not assignable to type 'string | boolean' (2322)
-  const paramsWithDefault: [string, string | boolean][] = Object.entries(parameters)
-    .filter(([, v]) => v.default != null)
-    .map(([k, v]) => [k, v.default]);
+  for (const paramKey in parameters) {
+    const parameter = parameters[paramKey];
+    const endpointParam = endpointParams[paramKey];
 
-  if (paramsWithDefault.length > 0) {
-    for (const [paramKey, paramDefaultValue] of paramsWithDefault) {
-      endpointParams[paramKey] = endpointParams[paramKey] ?? paramDefaultValue;
+    if (endpointParam == null && parameter.default != null) {
+      endpointParams[paramKey] = parameter.default;
+      continue;
     }
-  }
 
-  const requiredParams = Object.entries(parameters)
-    .filter(([, v]) => v.required)
-    .map(([k]) => k);
-
-  for (const requiredParam of requiredParams) {
-    if (endpointParams[requiredParam] == null) {
-      throw new EndpointError(`Missing required parameter: '${requiredParam}'`);
+    if (parameter.required && endpointParam == null) {
+      throw new EndpointError(`Missing required parameter: '${paramKey}'`);
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6645

*Description of changes:*

Resolves defaults and required params in one pass in resolveEndpoint

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
