### PR TITLE
fix(smithy-client): set request options correctly

### DIFF
--- a/.changeset/moody-roses-care.md
+++ b/.changeset/moody-roses-care.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+fix to set requestOptions correctly

--- a/packages/smithy-client/src/command.spec.ts
+++ b/packages/smithy-client/src/command.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test as it } from "vitest";
+import { describe, expect, test as it, vi } from "vitest";
 
 import { Command } from "./command";
 
@@ -55,5 +55,39 @@ describe(Command.name, () => {
 
     // private method exists for compatibility
     expect((myCommand as any).deserialize).toBeDefined();
+  });
+
+  it("should spread requestOptions correctly for event stream commands", async () => {
+    const handleFn = vi.fn().mockResolvedValue({ response: {} });
+
+    class MyEventStreamCommand extends Command.classBuilder<any, any, any, any, any>()
+      .m(function () {
+        return [];
+      })
+      .s("MyClient", "MyOp", { eventStream: true })
+      .n("MyClient", "MyOp")
+      .f()
+      .ser(async (_) => ({ ..._, headers: {}, method: "POST", protocol: "https:", hostname: "localhost", path: "/" }))
+      .de(async (_) => ({ $metadata: {} }))
+      .build() {}
+
+    const cmd = new MyEventStreamCommand({});
+    const handler = cmd.resolveMiddleware(
+      { concat: () => ({ resolve: (fn: any, ctx: any) => fn }) } as any,
+      {
+        logger: {} as any,
+        requestHandler: { handle: handleFn },
+      },
+      { requestTimeout: 5000 }
+    );
+
+    await handler({ input: {} });
+
+    expect(handleFn).toHaveBeenCalledTimes(1);
+    const passedOptions = handleFn.mock.calls[0][1];
+    expect(passedOptions).toEqual({
+      isEventStream: true,
+      requestTimeout: 5000,
+    });
   });
 });

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -96,10 +96,10 @@ export abstract class Command<
     const { requestHandler } = configuration;
     let requestOptions = options ?? {};
     if (smithyContext.eventStream) {
-      requestOptions = Object.assign({
+      requestOptions = {
         isEventStream: true,
-        requestOptions,
-      });
+        ...requestOptions,
+      };
     }
     return stack.resolve(
       (request: FinalizeHandlerArguments<any>) => requestHandler.handle(request.request as HttpRequest, requestOptions),


### PR DESCRIPTION
The conditional assignment of requestOptions in https://github.com/smithy-lang/smithy-typescript/pull/1952 contained a bug that caused the options to be set incorrectly.

To update your application, do not directly take a dependency on `@smithy/smithy-client`. Instead, run `npm up @smithy/smithy-client` or equivalent to bring the new version into your lockfile.
