### PR TITLE
fix(node-http-handler): connection pools and http2 session concurrency

### DIFF
--- a/.changeset/grumpy-guests-remain.md
+++ b/.changeset/grumpy-guests-remain.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": minor
+---
+
+adds ref-counting logic for http2 sessions in the client connection pool.

--- a/.changeset/wicked-items-taste.md
+++ b/.changeset/wicked-items-taste.md
@@ -1,0 +1,5 @@
+---
+"@smithy/service-error-classification": minor
+---
+
+include http refused stream as transient error for Node.js

--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -248,7 +248,8 @@
     "isRetryableByTrait": "function, since <=4.2.5",
     "isServerError": "function, since <=4.2.5",
     "isThrottlingError": "function, since <=4.2.5",
-    "isTransientError": "function, since <=4.2.5"
+    "isTransientError": "function, since <=4.2.5",
+    "isNodeJsHttp2TransientError": "function, since 4.2.14"
   },
   "@smithy/shared-ini-file-loader": {
     "getSSOTokenFromFile": "function, since <=4.4.0",

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
@@ -1,0 +1,95 @@
+import type { ClientHttp2Session } from "node:http2";
+import { describe, expect, test as it, vi } from "vitest";
+
+import { ClientHttp2SessionRef } from "./ClientHttp2SessionRef";
+
+const createMockSession = (destroyed = false) => {
+  const session = {
+    ref: vi.fn(),
+    unref: vi.fn(),
+    destroy: vi.fn(() => {
+      (session as any).destroyed = true;
+    }),
+    destroyed,
+  } as unknown as ClientHttp2Session;
+  return session;
+};
+
+describe(ClientHttp2SessionRef.name, () => {
+  it("calls unref on the session at the start of object lifecycle", () => {
+    const session = createMockSession();
+    new ClientHttp2SessionRef(session);
+    expect(session.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("retain() calls ref on the session", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    ref.retain();
+    expect(session.ref).toHaveBeenCalledTimes(1);
+  });
+
+  it("retain() throws if session is destroyed", () => {
+    const session = createMockSession(true);
+    const ref = new ClientHttp2SessionRef(session);
+    expect(() => ref.retain()).toThrow("cannot acquire reference to destroyed session");
+  });
+
+  it("deref() returns the session without ref-counting", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    expect(ref.deref()).toBe(session);
+    expect(session.ref).not.toHaveBeenCalled();
+  });
+
+  it("free() calls unref when refcount reaches zero", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    ref.retain();
+    // 1 from constructor
+    expect(session.unref).toHaveBeenCalledTimes(1);
+    ref.free();
+    // 1 from constructor + 1 from free reaching zero
+    expect(session.unref).toHaveBeenCalledTimes(2);
+  });
+
+  it("free() does not call unref when refcount is still positive", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    ref.retain();
+    ref.retain();
+    ref.free(); // refcount 2 -> 1
+    // only constructor unref
+    expect(session.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("free() throws when refcount goes below zero", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    expect(() => ref.free()).toThrow("refcount at zero, cannot decrement");
+  });
+
+  it("free() is a no-op on destroyed session", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    ref.retain();
+    ref.destroy();
+    // should not throw
+    ref.free();
+  });
+
+  it("destroy() destroys the session and resets refcount", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    ref.retain();
+    ref.destroy();
+    expect(session.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroy() is safe to call on already-destroyed session", () => {
+    const session = createMockSession(true);
+    const ref = new ClientHttp2SessionRef(session);
+    ref.destroy();
+    expect(session.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
@@ -1,0 +1,87 @@
+import type { ClientHttp2Session } from "node:http2";
+
+const ids = new Uint16Array(1);
+
+/**
+ * Shared access ref counter for ClientHttp2Session, where owners are
+ * in-flight requests.
+ *
+ * @internal
+ * @since 4.6.0
+ */
+export class ClientHttp2SessionRef {
+  // debug information
+  public readonly id = ids[0]++;
+  /**
+   * Total calls to retain for this session.
+   */
+  public total = 0;
+  /**
+   * Max ref count observed.
+   */
+  public max = 0;
+
+  private readonly session: ClientHttp2Session;
+  private refs = 0;
+
+  public constructor(session: ClientHttp2Session) {
+    // The session starts in unref state.
+    // The start of the request (call to retain) will bring it into ref state.
+    session.unref();
+    this.session = session;
+  }
+
+  /**
+   * Signal that the session is entering a request span and has an additional owning request.
+   * This must be called when beginning a request using the session.
+   */
+  public retain(): void {
+    if (this.session.destroyed) {
+      throw new Error("@smithy/node-http-handler - cannot acquire reference to destroyed session.");
+    }
+    this.refs += 1;
+    this.total += 1;
+
+    this.max = Math.max(this.refs, this.max);
+    this.session.ref();
+  }
+
+  /**
+   * Release reference to session, to be called when it exits request span, indicating one fewer owning request.
+   * When reaching zero, the session is unref'd.
+   * This must be called when concluding a request using the session.
+   */
+  public free(): void {
+    if (this.session.destroyed) {
+      return;
+    }
+    this.refs -= 1;
+    if (this.refs === 0) {
+      this.session.unref();
+    }
+    if (this.refs < 0) {
+      throw new Error("@smithy/node-http-handler - ClientHttp2Session refcount at zero, cannot decrement.");
+    }
+  }
+
+  /**
+   * Access the session (don't call ref/unref on it).
+   */
+  public deref(): ClientHttp2Session {
+    return this.session;
+  }
+
+  public destroy(): void {
+    this.refs = 0;
+    if (!this.session.destroyed) {
+      this.session.destroy();
+    }
+  }
+
+  /**
+   * @returns the current number of active references (in-flight requests).
+   */
+  public useCount(): number {
+    return this.refs;
+  }
+}

--- a/packages/node-http-handler/src/node-http2-connection-manager.ts
+++ b/packages/node-http-handler/src/node-http2-connection-manager.ts
@@ -1,15 +1,25 @@
-import type { RequestContext } from "@smithy/types";
-import type { ConnectConfiguration } from "@smithy/types";
-import type { ConnectionManager, ConnectionManagerConfiguration } from "@smithy/types";
-import type { ClientHttp2Session } from "node:http2";
+import type {
+  ConnectConfiguration,
+  ConnectionManager,
+  ConnectionManagerConfiguration,
+  RequestContext,
+} from "@smithy/types";
 import http2 from "node:http2";
 
+import { ClientHttp2SessionRef } from "./http2/ClientHttp2SessionRef";
 import { NodeHttp2ConnectionPool } from "./node-http2-connection-pool";
 
 /**
- * @public
+ * This class previously implemented the ConnectionManager<ClientHttp2Session> interface,
+ * but this class isn't exported from this package, except as a private property of NodeHttp2Handler.
+ *
+ * @since 4.6.0
+ * @internal
  */
-export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2Session> {
+export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2SessionRef> {
+  private config: ConnectionManagerConfiguration;
+  private readonly connectionPools: Map<string, NodeHttp2ConnectionPool> = new Map<string, NodeHttp2ConnectionPool>();
+
   constructor(config: ConnectionManagerConfiguration) {
     this.config = config;
 
@@ -18,26 +28,24 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
     }
   }
 
-  private config: ConnectionManagerConfiguration;
-
-  private readonly sessionCache: Map<string, NodeHttp2ConnectionPool> = new Map<string, NodeHttp2ConnectionPool>();
-
-  public lease(requestContext: RequestContext, connectionConfiguration: ConnectConfiguration): ClientHttp2Session {
+  /**
+   * Acquire a session for making a request.
+   */
+  public lease(requestContext: RequestContext, connectionConfiguration: ConnectConfiguration): ClientHttp2SessionRef {
     const url = this.getUrlString(requestContext);
 
-    const existingPool = this.sessionCache.get(url);
+    const pool = this.getPool(url);
 
-    if (existingPool) {
-      // This poll call needs to happen regardless of whether existingSession is returned.
-      // polling, and thereby dropping references to the session, allows it to be closed by garbage collection.
-      const existingSession = existingPool.poll();
-
-      if (existingSession && !this.config.disableConcurrency && !connectionConfiguration.isEventStream) {
-        return existingSession;
+    if (!this.config.disableConcurrency && !connectionConfiguration.isEventStream) {
+      const available = pool.poll();
+      if (available) {
+        available.retain();
+        return available;
       }
     }
 
-    const session = http2.connect(url);
+    const ref = new ClientHttp2SessionRef(http2.connect(url));
+    const session = ref.deref();
 
     if (this.config.maxConcurrency) {
       session.settings({ maxConcurrentStreams: this.config.maxConcurrency }, (err) => {
@@ -52,66 +60,73 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
       });
     }
 
-    // AWS SDK does not expect server push streams, don't keep node alive without a request.
-    session.unref();
-
     const destroySessionCb = () => {
       session.destroy();
-      this.deleteSession(url, session);
+      this.removeFromPool(url, ref);
     };
     session.on("goaway", destroySessionCb);
     session.on("error", destroySessionCb);
     session.on("frameError", destroySessionCb);
-    session.on("close", () => this.deleteSession(url, session));
+    session.on("close", () => this.removeFromPool(url, ref));
 
     if (connectionConfiguration.requestTimeout) {
       session.setTimeout(connectionConfiguration.requestTimeout, destroySessionCb);
     }
 
-    const connectionPool = this.sessionCache.get(url) || new NodeHttp2ConnectionPool();
-
-    connectionPool.offerLast(session);
-
-    this.sessionCache.set(url, connectionPool);
-
-    return session;
+    pool.offerLast(ref);
+    ref.retain();
+    return ref;
   }
 
   /**
-   * Delete a session from the connection pool.
-   * @param authority The authority of the session to delete.
-   * @param session The session to delete.
+   * Signal that a request using this session has completed.
+   *
+   * The session remains in its pool for reuse.
+   * This method is not called for isolated sessions.
    */
-  public deleteSession(authority: string, session: ClientHttp2Session): void {
-    const existingConnectionPool = this.sessionCache.get(authority);
-
-    if (!existingConnectionPool) {
-      return;
-    }
-
-    if (!existingConnectionPool.contains(session)) {
-      return;
-    }
-
-    existingConnectionPool.remove(session);
-
-    this.sessionCache.set(authority, existingConnectionPool);
+  public release(_requestContext: RequestContext, ref: ClientHttp2SessionRef): void {
+    ref.free();
   }
 
-  public release(requestContext: RequestContext, session: ClientHttp2Session): void {
-    const cacheKey = this.getUrlString(requestContext);
-    this.sessionCache.get(cacheKey)?.offerLast(session);
+  /**
+   * Create an isolated session that isn't part of the connection pools.
+   * For use in event-streams or when concurrency is turned off.
+   */
+  public createIsolatedSession(
+    requestContext: RequestContext,
+    connectionConfiguration: ConnectConfiguration
+  ): ClientHttp2SessionRef {
+    const url = this.getUrlString(requestContext);
+    const ref = new ClientHttp2SessionRef(http2.connect(url));
+    const session = ref.deref();
+
+    session.settings({ maxConcurrentStreams: 1 });
+
+    const destroySession = () => {
+      session.destroy();
+    };
+
+    session.on("goaway", destroySession);
+    session.on("error", destroySession);
+    session.on("frameError", destroySession);
+    session.on("close", destroySession);
+
+    if (connectionConfiguration.requestTimeout) {
+      session.setTimeout(connectionConfiguration.requestTimeout, destroySession);
+    }
+
+    ref.retain();
+    return ref;
   }
 
   public destroy(): void {
-    for (const [key, connectionPool] of this.sessionCache) {
-      for (const session of connectionPool) {
-        if (!session.destroyed) {
-          session.destroy();
-        }
-        connectionPool.remove(session);
+    for (const [url, connectionPool] of this.connectionPools) {
+      // copy pool array to avoid potential synchronous mutation from
+      // call to session.destroy().
+      for (const session of [...connectionPool]) {
+        session.destroy();
       }
-      this.sessionCache.delete(key);
+      this.connectionPools.delete(url);
     }
   }
 
@@ -120,10 +135,52 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
       throw new RangeError("maxConcurrentStreams must be greater than zero.");
     }
     this.config.maxConcurrency = maxConcurrentStreams;
+    for (const pool of this.connectionPools.values()) {
+      pool.setMaxConcurrency(maxConcurrentStreams);
+    }
   }
 
   public setDisableConcurrentStreams(disableConcurrentStreams: boolean) {
     this.config.disableConcurrency = disableConcurrentStreams;
+  }
+
+  /**
+   * @internal
+   * @returns a snapshot of the state of all connection pools and their sessions.
+   */
+  public debug() {
+    const pools: Record<string, any> = {};
+    for (const [url, pool] of this.connectionPools) {
+      const sessions = [];
+      for (const ref of pool) {
+        sessions.push({
+          id: ref.id,
+          active: ref.useCount(),
+          maxConcurrent: ref.max,
+          totalRequests: ref.total,
+        });
+      }
+      pools[url] = { sessions };
+    }
+    return pools;
+  }
+
+  /**
+   * Remove a session from the pools. Does not destroy it.
+   */
+  private removeFromPool(authority: string, ref: ClientHttp2SessionRef): void {
+    this.connectionPools.get(authority)?.remove(ref);
+  }
+
+  private getPool(url: string): NodeHttp2ConnectionPool {
+    if (!this.connectionPools.has(url)) {
+      const pool = new NodeHttp2ConnectionPool();
+      if (this.config.maxConcurrency) {
+        pool.setMaxConcurrency(this.config.maxConcurrency);
+      }
+      this.connectionPools.set(url, pool);
+    }
+    return this.connectionPools.get(url)!;
   }
 
   private getUrlString(request: RequestContext): string {

--- a/packages/node-http-handler/src/node-http2-connection-pool.ts
+++ b/packages/node-http-handler/src/node-http2-connection-pool.ts
@@ -1,42 +1,79 @@
 import type { ConnectionPool } from "@smithy/types";
 import type { ClientHttp2Session } from "node:http2";
 
-export class NodeHttp2ConnectionPool implements ConnectionPool<ClientHttp2Session> {
-  private sessions: ClientHttp2Session[] = [];
+import { ClientHttp2SessionRef } from "./http2/ClientHttp2SessionRef";
+
+/**
+ * These are keyed by URL, therefore all sessions within this class' state
+ * are for the same URL.
+ *
+ * Sessions remain in the pool for their entire lifetime (until destroyed or
+ * removed). The pool tracks capacity via each session's ref count.
+ *
+ * Interface implementation changed from ConnectionPool<ClientHttp2Session>.
+ * @since 4.6.0
+ * @internal
+ */
+export class NodeHttp2ConnectionPool implements ConnectionPool<ClientHttp2SessionRef> {
+  private readonly sessions: ClientHttp2SessionRef[] = [];
+  private maxConcurrency = 0;
 
   constructor(sessions?: ClientHttp2Session[]) {
-    this.sessions = sessions ?? [];
+    this.sessions = (sessions ?? []).map((session: ClientHttp2Session) => new ClientHttp2SessionRef(session));
   }
 
-  public poll(): ClientHttp2Session | void {
-    if (this.sessions.length > 0) {
-      return this.sessions.shift();
+  /**
+   * Find a session with available capacity (refs < maxConcurrency).
+   * Returns undefined if all sessions are at capacity or the pool is empty.
+   */
+  public poll(): ClientHttp2SessionRef | undefined {
+    let cleanup = false;
+    for (const session of this.sessions) {
+      if (session.deref().destroyed) {
+        cleanup = true;
+        continue;
+      }
+      if (!this.maxConcurrency || session.useCount() < this.maxConcurrency) {
+        return session;
+      }
+    }
+    if (cleanup) {
+      for (const session of this.sessions) {
+        if (session.deref().destroyed) {
+          this.remove(session);
+        }
+      }
     }
   }
 
-  public offerLast(session: ClientHttp2Session): void {
-    this.sessions.push(session);
+  /**
+   * Add a session to the pool.
+   */
+  public offerLast(ref: ClientHttp2SessionRef): void {
+    this.sessions.push(ref);
   }
 
-  public contains(session: ClientHttp2Session): boolean {
-    return this.sessions.includes(session);
-  }
-
-  public remove(session: ClientHttp2Session): void {
-    this.sessions = this.sessions.filter((s) => s !== session);
+  public remove(ref: ClientHttp2SessionRef): void {
+    const ix = this.sessions.indexOf(ref);
+    if (ix > -1) {
+      this.sessions.splice(ix, 1);
+    }
   }
 
   public [Symbol.iterator]() {
     return this.sessions[Symbol.iterator]();
   }
 
-  public destroy(connection: ClientHttp2Session): void {
-    for (const session of this.sessions) {
-      if (session === connection) {
-        if (!session.destroyed) {
-          session.destroy();
-        }
-      }
-    }
+  public setMaxConcurrency(maxConcurrency: number): void {
+    this.maxConcurrency = maxConcurrency;
+  }
+
+  /**
+   * This is unused, but part of the interface.
+   * @deprecated
+   */
+  public destroy(ref: ClientHttp2SessionRef): void {
+    this.remove(ref);
+    ref.destroy();
   }
 }

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -10,11 +10,24 @@ import { Duplex } from "node:stream";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
+import type { ClientHttp2SessionRef } from "./http2/ClientHttp2SessionRef";
+import type { NodeHttp2ConnectionManager } from "./node-http2-connection-manager";
 import { NodeHttp2ConnectionPool } from "./node-http2-connection-pool";
 import type { NodeHttp2HandlerOptions } from "./node-http2-handler";
 import { NodeHttp2Handler } from "./node-http2-handler";
 import { createMockHttp2Server, createResponseFunction, createResponseFunctionWithDelay } from "./server.mock";
 import { timing } from "./timing";
+
+const getConnectionManager = (handler: NodeHttp2Handler) =>
+  (handler as any).connectionManager as NodeHttp2ConnectionManager;
+
+const getConnectionPools = (handler: NodeHttp2Handler) =>
+  (getConnectionManager(handler) as any).connectionPools as Map<string, NodeHttp2ConnectionPool>;
+
+const getSessions = (handler: NodeHttp2Handler, authority: string) =>
+  (getConnectionPools(handler).get(authority) as any).sessions as ClientHttp2SessionRef[];
+
+const getFirstSession = (handler: NodeHttp2Handler, authority: string) => getSessions(handler, authority)[0];
 
 describe(NodeHttp2Handler.name, () => {
   let nodeH2Handler: NodeHttp2Handler;
@@ -102,15 +115,25 @@ describe(NodeHttp2Handler.name, () => {
     };
 
     // Keeping node alive while request is open.
+    // With ref-counting: constructor calls unref once, each get() calls ref once.
     const expectSessionCreatedAndReferred = (session: ClientHttp2Session, requestCount = 1) => {
       expect(session.ref).toHaveBeenCalledTimes(requestCount);
-      expect(session.unref).toHaveBeenCalledTimes(1);
+      expect(session.unref).toHaveBeenCalledTimes(1); // initial unref in constructor
     };
 
-    // No longer keeping node alive
+    // No longer keeping node alive.
+    // With ref-counting: constructor calls unref once, each get() calls ref once,
+    // free() calls unref when refcount reaches zero.
     const expectSessionCreatedAndUnreffed = (session: ClientHttp2Session, requestCount = 1) => {
       expect(session.ref).toHaveBeenCalledTimes(requestCount);
-      expect(session.unref).toHaveBeenCalledTimes(requestCount + 1);
+      // 1 (constructor) + 1 (final free reaching zero)
+      expect(session.unref).toHaveBeenCalledTimes(2);
+    };
+
+    // Session was destroyed (e.g. goaway/error), free() is a no-op on destroyed sessions.
+    const expectSessionCreatedAndDestroyed = (session: ClientHttp2Session, requestCount = 1) => {
+      expect(session.ref).toHaveBeenCalledTimes(requestCount);
+      expect(session.unref).toHaveBeenCalledTimes(1); // only constructor unref
     };
 
     afterEach(() => {
@@ -230,9 +253,9 @@ describe(NodeHttp2Handler.name, () => {
 
         // Not keeping node alive
         expect(createdSessions).toHaveLength(3);
-        expectSessionCreatedAndUnreffed(createdSessions[0]);
-        expectSessionCreatedAndUnreffed(createdSessions[1]);
-        expectSessionCreatedAndUnreffed(createdSessions[2]);
+        expectSessionCreatedAndDestroyed(createdSessions[0]);
+        expectSessionCreatedAndDestroyed(createdSessions[1]);
+        expectSessionCreatedAndDestroyed(createdSessions[2]);
 
         // should be able to recover from goaway after reconnecting to a server
         // that doesn't send goaway, and reuse the TCP connection (Http2Session)
@@ -307,33 +330,30 @@ describe(NodeHttp2Handler.name, () => {
 
         // Not keeping node alive
         expect(createdSessions).toHaveLength(3);
-        expectSessionCreatedAndUnreffed(createdSessions[0]);
-        expectSessionCreatedAndUnreffed(createdSessions[1]);
-        expectSessionCreatedAndUnreffed(createdSessions[2]);
+        expectSessionCreatedAndDestroyed(createdSessions[0]);
+        expectSessionCreatedAndDestroyed(createdSessions[1]);
+        expectSessionCreatedAndDestroyed(createdSessions[2]);
       });
     });
 
     describe("destroy", () => {
-      it("destroys session and clears sessionCache", async () => {
+      it("destroys session and clears connectionPools", async () => {
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
-        // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
+        const sessionRef = getFirstSession(nodeH2Handler, authority);
+        const session: ClientHttp2Session = sessionRef.deref();
 
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.size).toBe(1);
+        expect(getConnectionPools(nodeH2Handler).size).toBe(1);
         expect(session.destroyed).toBe(false);
         nodeH2Handler.destroy();
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.size).toBe(0);
+        expect(getConnectionPools(nodeH2Handler).size).toBe(0);
         expect(session.destroyed).toBe(true);
       });
     });
 
     describe("abortSignal", () => {
       it("will not create session if request already aborted", async () => {
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.size).toBe(0);
+        expect(getConnectionPools(nodeH2Handler).size).toBe(0);
         await expect(
           nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
             abortSignal: {
@@ -342,16 +362,14 @@ describe(NodeHttp2Handler.name, () => {
             },
           })
         ).rejects.toHaveProperty("name", "AbortError");
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.size).toBe(0);
+        expect(getConnectionPools(nodeH2Handler).size).toBe(0);
       });
 
       it("will not create request on session if request already aborted", async () => {
         // Create a session by sending a request.
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
-        // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
+        const session: ClientHttp2Session = getFirstSession(nodeH2Handler, authority).deref();
         const requestSpy = vi.spyOn(session, "request");
 
         await expect(
@@ -454,15 +472,12 @@ describe(NodeHttp2Handler.name, () => {
         nodeH2Handler = new NodeHttp2Handler(options);
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), { requestTimeout: sessionTimeout });
 
-        // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
+        const session: ClientHttp2Session = getFirstSession(nodeH2Handler, authority).deref();
         expect(session.destroyed).toBe(false);
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.get(authority).sessions.length).toStrictEqual(1);
+        expect(getSessions(nodeH2Handler, authority).length).toStrictEqual(1);
         await promisify(setTimeout)(sessionTimeout + 100);
         expect(session.destroyed).toBe(true);
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.get(authority).sessions.length).toStrictEqual(0);
+        expect(getSessions(nodeH2Handler, authority).length).toStrictEqual(0);
       });
 
       it.each([
@@ -473,10 +488,14 @@ describe(NodeHttp2Handler.name, () => {
 
         nodeH2Handler = new NodeHttp2Handler(options);
 
+        const connectReal = http2.connect;
+        vi.spyOn(http2, "connect").mockImplementation((...args: any[]) => {
+          session = connectReal(args[0], args[1]);
+          return session;
+        });
+
         mockH2Server.removeAllListeners("request");
         mockH2Server.on("request", (request: any, response: any) => {
-          // @ts-ignore: access private property
-          session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
           createResponseFunction(mockResponse)(request, response);
         });
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
@@ -500,8 +519,7 @@ describe(NodeHttp2Handler.name, () => {
 
       await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
-      // @ts-ignore: access private property
-      const session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
+      const session = getFirstSession(nodeH2Handler, authority).deref();
 
       if (options.maxConcurrentStreams) {
         expect(session.localSettings.maxConcurrentStreams).toBe(options.maxConcurrentStreams);
@@ -530,15 +548,13 @@ describe(NodeHttp2Handler.name, () => {
     nodeH2Handler = new NodeHttp2Handler();
     // Create a session by sending a request.
     await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-    // @ts-ignore: access private property
-    const session: ClientHttp2Session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
+    const session: ClientHttp2Session = getFirstSession(nodeH2Handler, authority).deref();
     const fakeStream = new Duplex() as ClientHttp2Stream;
     const fakeRstCode = 1;
     // @ts-ignore: fake result code
     (fakeStream as Mutable<typeof fakeStream>).rstCode = fakeRstCode;
     vi.spyOn(session, "request").mockImplementation(() => fakeStream);
-    // @ts-ignore: access private property
-    nodeH2Handler.connectionManager.sessionCache.set(authority, new NodeHttp2ConnectionPool([session]));
+    getConnectionPools(nodeH2Handler).set(authority, new NodeHttp2ConnectionPool([session]));
     // Delay response so that onabort is called earlier
     timing.setTimeout(() => {
       fakeStream.emit("aborted");
@@ -554,12 +570,10 @@ describe(NodeHttp2Handler.name, () => {
     nodeH2Handler = new NodeHttp2Handler();
     // Create a session by sending a request.
     await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-    // @ts-ignore: access private property
-    const session: ClientHttp2Session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
+    const session: ClientHttp2Session = getFirstSession(nodeH2Handler, authority).deref();
     const fakeStream = new Duplex() as ClientHttp2Stream;
     vi.spyOn(session, "request").mockImplementation(() => fakeStream);
-    // @ts-ignore: access private property
-    nodeH2Handler.connectionManager.sessionCache.set(authority, new NodeHttp2ConnectionPool([session]));
+    getConnectionPools(nodeH2Handler).set(authority, new NodeHttp2ConnectionPool([session]));
     // Delay response so that onabort is called earlier
     timing.setTimeout(() => {
       fakeStream.emit("frameError", "TYPE", "CODE", "ID");
@@ -666,20 +680,24 @@ describe(NodeHttp2Handler.name, () => {
     });
 
     describe("destroy", () => {
-      it("destroys session and empties sessionCache", async () => {
+      it("destroys session and empties connectionPools", async () => {
+        const connectReal = http2.connect;
+        let createdSession: ClientHttp2Session | undefined;
+        vi.spyOn(http2, "connect").mockImplementation((...args: any[]) => {
+          const session = connectReal(args[0], args[1]);
+          createdSession = session;
+          return session;
+        });
+
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
-        // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connectionManager.sessionCache.get(authority).sessions[0];
-
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.size).toBe(1);
-        expect(session.destroyed).toBe(false);
+        // Isolated sessions (disableConcurrentStreams) are not in the pool.
+        expect(createdSession).toBeDefined();
+        expect(createdSession!.destroyed).toBe(false);
 
         nodeH2Handler.destroy();
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionManager.sessionCache.size).toBe(0);
-        expect(session.destroyed).toBe(true);
+        // Pool should be empty (isolated sessions were never added).
+        expect(getConnectionPools(nodeH2Handler).size).toBe(0);
       });
     });
   });
@@ -761,5 +779,103 @@ describe(NodeHttp2Handler.name, () => {
   it("httpHandlerConfigs returns empty object if handle is not called", async () => {
     const nodeHttpHandler = new NodeHttp2Handler();
     expect(nodeHttpHandler.httpHandlerConfigs()).toEqual({});
+  });
+
+  describe("ref-counting for http2 sessions", () => {
+    let createdSessions: ClientHttp2Session[];
+    const connectReal = http2.connect;
+
+    beforeEach(() => {
+      createdSessions = [];
+      vi.spyOn(http2, "connect").mockImplementation((...args: any[]) => {
+        const session = connectReal(args[0], args[1]);
+        vi.spyOn(session, "ref");
+        vi.spyOn(session, "unref");
+        createdSessions.push(session);
+        return session;
+      });
+    });
+
+    it("acquires ref on request start and releases on stream close", async () => {
+      const handler = new NodeHttp2Handler();
+      const { response } = await handler.handle(new HttpRequest(getMockReqOptions()), {});
+      const session = createdSessions[0];
+
+      // constructor unref + get() ref = session is ref'd (keeping node alive)
+      expect(session.unref).toHaveBeenCalledTimes(1);
+      expect(session.ref).toHaveBeenCalledTimes(1);
+
+      // close the response stream to trigger req "close" -> ref.free()
+      const body = response.body as ClientHttp2Stream;
+      const closePromise = new Promise((resolve) => body.once("close", resolve));
+      body.destroy();
+      await closePromise;
+
+      // free() reached zero -> unref called again
+      expect(session.unref).toHaveBeenCalledTimes(2);
+      handler.destroy();
+    });
+
+    it("maintains positive refcount across concurrent requests on same session", async () => {
+      const handler = new NodeHttp2Handler();
+      const { response: r1 } = await handler.handle(new HttpRequest(getMockReqOptions()), {});
+      const { response: r2 } = await handler.handle(new HttpRequest(getMockReqOptions()), {});
+      const session = createdSessions[0];
+
+      // 1 session, 2 get() calls
+      expect(createdSessions).toHaveLength(1);
+      expect(session.ref).toHaveBeenCalledTimes(2);
+      // only constructor unref so far (refcount is 2, not zero)
+      expect(session.unref).toHaveBeenCalledTimes(1);
+
+      // close first stream — refcount drops to 1, no unref
+      const body1 = r1.body as ClientHttp2Stream;
+      const close1 = new Promise((resolve) => body1.once("close", resolve));
+      body1.destroy();
+      await close1;
+      expect(session.unref).toHaveBeenCalledTimes(1); // still 1
+
+      // close second stream — refcount drops to 0, unref called
+      const body2 = r2.body as ClientHttp2Stream;
+      const close2 = new Promise((resolve) => body2.once("close", resolve));
+      body2.destroy();
+      await close2;
+      expect(session.unref).toHaveBeenCalledTimes(2);
+      handler.destroy();
+    });
+
+    it("opens additional sessions when maxConcurrentStreams is reached", async () => {
+      const maxConcurrentStreams = 3;
+      const totalRequests = 10;
+      const handler = new NodeHttp2Handler({ maxConcurrentStreams });
+
+      // Fire all requests concurrently.
+      const responses = await Promise.all(
+        Array.from({ length: totalRequests }, () => handler.handle(new HttpRequest(getMockReqOptions()), {}))
+      );
+
+      // 10 requests at concurrency 3 = ceil(10/3) = 4 sessions.
+      expect(createdSessions).toHaveLength(4);
+
+      const pools = getConnectionManager(handler).debug();
+      const sessions = pools[authority].sessions;
+      const inFlightCounts = sessions.map((s: any) => s.active).sort();
+      expect(inFlightCounts).toEqual([1, 3, 3, 3]);
+
+      // Close all streams.
+      for (const { response } of responses) {
+        const body = response.body as ClientHttp2Stream;
+        const close = new Promise((resolve) => body.once("close", resolve));
+        body.destroy();
+        await close;
+      }
+
+      const poolsAfter = getConnectionManager(handler).debug();
+      for (const s of poolsAfter[authority].sessions) {
+        expect(s.active).toBe(0);
+      }
+
+      handler.destroy();
+    });
   });
 });

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -1,8 +1,7 @@
 import type { HttpHandler, HttpRequest } from "@smithy/protocol-http";
 import { HttpResponse } from "@smithy/protocol-http";
 import { buildQueryString } from "@smithy/querystring-builder";
-import type { ConnectConfiguration, HttpHandlerOptions, Provider, RequestContext } from "@smithy/types";
-import type { ClientHttp2Session } from "node:http2";
+import type { HttpHandlerOptions, Provider, RequestContext } from "@smithy/types";
 import { constants } from "node:http2";
 
 import { buildAbortError } from "./build-abort-error";
@@ -109,13 +108,16 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
   ): Promise<{ response: HttpResponse }> {
     if (!this.config) {
       this.config = await this.configProvider;
-      this.connectionManager.setDisableConcurrentStreams(this.config.disableConcurrentStreams ?? false);
-      if (this.config.maxConcurrentStreams) {
-        this.connectionManager.setMaxConcurrentStreams(this.config.maxConcurrentStreams);
+      const { disableConcurrentStreams, maxConcurrentStreams } = this.config;
+
+      this.connectionManager.setDisableConcurrentStreams(disableConcurrentStreams ?? false);
+      if (maxConcurrentStreams) {
+        this.connectionManager.setMaxConcurrentStreams(maxConcurrentStreams);
       }
     }
 
     const { requestTimeout: configRequestTimeout, disableConcurrentStreams } = this.config;
+    const useIsolatedSession = disableConcurrentStreams || isEventStream;
     const effectiveRequestTimeout = requestTimeout ?? configRequestTimeout;
 
     return new Promise((_resolve, _reject) => {
@@ -150,14 +152,20 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
       }
       const authority = `${protocol}//${auth}${hostname}${port ? `:${port}` : ""}`;
       const requestContext = { destination: new URL(authority) } as RequestContext;
-      const session = this.connectionManager.lease(requestContext, {
+
+      const connectConfig = {
         requestTimeout: this.config?.sessionTimeout,
         isEventStream,
-      });
+      };
+      const ref = useIsolatedSession
+        ? this.connectionManager.createIsolatedSession(requestContext, connectConfig)
+        : this.connectionManager.lease(requestContext, connectConfig);
+
+      const session = ref.deref();
 
       const rejectWithDestroy = (err: Error) => {
-        if (disableConcurrentStreams) {
-          this.destroySession(session);
+        if (useIsolatedSession) {
+          ref.destroy();
         }
         fulfilled = true;
         reject(err);
@@ -172,34 +180,15 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
         path += `#${request.fragment}`;
       }
       // create the http2 request
-      const req = session.request({
+      const clientHttp2Stream = session.request({
         ...request.headers,
         [constants.HTTP2_HEADER_PATH]: path,
         [constants.HTTP2_HEADER_METHOD]: method,
       });
 
-      // Keep node alive while request is in progress. Matched with unref() in close event.
-      session.ref();
-
-      req.on("response", (headers) => {
-        const httpResponse = new HttpResponse({
-          statusCode: headers[":status"] ?? -1,
-          headers: getTransformedHeaders(headers),
-          body: req,
-        });
-        fulfilled = true;
-        resolve({ response: httpResponse });
-        if (disableConcurrentStreams) {
-          // Gracefully closes the Http2Session, allowing any existing streams to complete
-          // on their own and preventing new Http2Stream instances from being created.
-          session.close();
-          this.connectionManager.deleteSession(authority, session);
-        }
-      });
-
       if (effectiveRequestTimeout) {
-        req.setTimeout(effectiveRequestTimeout, () => {
-          req.close();
+        clientHttp2Stream.setTimeout(effectiveRequestTimeout, () => {
+          clientHttp2Stream.close();
           const timeoutError = new Error(`Stream timed out because of no activity for ${effectiveRequestTimeout} ms`);
           timeoutError.name = "TimeoutError";
           rejectWithDestroy(timeoutError);
@@ -208,7 +197,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
 
       if (abortSignal) {
         const onAbort = () => {
-          req.close();
+          clientHttp2Stream.close();
           const abortError = buildAbortError(abortSignal);
           rejectWithDestroy(abortError);
         };
@@ -216,7 +205,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
           // preferred.
           const signal = abortSignal as AbortSignal;
           signal.addEventListener("abort", onAbort, { once: true });
-          req.once("close", () => signal.removeEventListener("abort", onAbort));
+          clientHttp2Stream.once("close", () => signal.removeEventListener("abort", onAbort));
         } else {
           // backwards compatibility
           abortSignal.onabort = onAbort;
@@ -224,30 +213,49 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
       }
 
       // Set up handlers for errors
-      req.on("frameError", (type: number, code: number, id: number) => {
+      clientHttp2Stream.on("frameError", (type: number, code: number, id: number) => {
         rejectWithDestroy(new Error(`Frame type id ${type} in stream id ${id} has failed with code ${code}.`));
       });
-      req.on("error", rejectWithDestroy);
-      req.on("aborted", () => {
+      clientHttp2Stream.on("error", rejectWithDestroy);
+      clientHttp2Stream.on("aborted", () => {
         rejectWithDestroy(
-          new Error(`HTTP/2 stream is abnormally aborted in mid-communication with result code ${req.rstCode}.`)
+          new Error(
+            `HTTP/2 stream is abnormally aborted in mid-communication with result code ${clientHttp2Stream.rstCode}.`
+          )
         );
+      });
+
+      clientHttp2Stream.on("response", (headers) => {
+        const httpResponse = new HttpResponse({
+          statusCode: headers[":status"] ?? -1,
+          headers: getTransformedHeaders(headers),
+          body: clientHttp2Stream,
+        });
+        fulfilled = true;
+        resolve({ response: httpResponse });
+
+        if (useIsolatedSession) {
+          // Gracefully closes the Http2Session, allowing any existing streams to complete
+          // on their own and preventing new Http2Stream instances from being created.
+          session.close();
+        }
       });
 
       // The HTTP/2 error code used when closing the stream can be retrieved using the
       // http2stream.rstCode property. If the code is any value other than NGHTTP2_NO_ERROR (0),
       // an 'error' event will have also been emitted.
-      req.on("close", () => {
-        session.unref();
-        if (disableConcurrentStreams) {
-          session.destroy();
+      clientHttp2Stream.on("close", () => {
+        if (useIsolatedSession) {
+          ref.destroy();
+        } else {
+          this.connectionManager.release(requestContext, ref);
         }
         if (!fulfilled) {
           rejectWithDestroy(new Error("Unexpected error: http2 request did not get a response"));
         }
       });
 
-      writeRequestBodyPromise = writeRequestBody(req, request, effectiveRequestTimeout);
+      writeRequestBodyPromise = writeRequestBody(clientHttp2Stream, request, effectiveRequestTimeout);
     });
   }
 
@@ -263,15 +271,5 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
 
   public httpHandlerConfigs(): NodeHttp2HandlerOptions {
     return this.config ?? {};
-  }
-
-  /**
-   * Destroys a session.
-   * @param session - the session to destroy.
-   */
-  private destroySession(session: ClientHttp2Session): void {
-    if (!session.destroyed) {
-      session.destroy();
-    }
   }
 }

--- a/packages/service-error-classification/src/index.spec.ts
+++ b/packages/service-error-classification/src/index.spec.ts
@@ -9,7 +9,14 @@ import {
   TRANSIENT_ERROR_CODES,
   TRANSIENT_ERROR_STATUS_CODES,
 } from "./constants";
-import { isClockSkewError, isRetryableByTrait, isServerError, isThrottlingError, isTransientError } from "./index";
+import {
+  isClockSkewError,
+  isNodeJsHttp2TransientError,
+  isRetryableByTrait,
+  isServerError,
+  isThrottlingError,
+  isTransientError,
+} from "./index";
 
 const checkForErrorType = (
   isErrorTypeFunc: (error: SdkError) => boolean,
@@ -169,5 +176,39 @@ describe("isServerError", () => {
     it(`should declare error with the HTTP Status Code "${httpStatusCode}" to not be be a Server error`, () => {
       checkForErrorType(isServerError, { httpStatusCode }, false);
     });
+  });
+});
+
+describe("isNodeJsHttp2TransientError", () => {
+  it("should return true for ERR_HTTP2_STREAM_ERROR with NGHTTP2_REFUSED_STREAM", () => {
+    const error = Object.assign(new Error("Stream closed with error code NGHTTP2_REFUSED_STREAM"), {
+      code: "ERR_HTTP2_STREAM_ERROR",
+    });
+    expect(isNodeJsHttp2TransientError(error)).toBe(true);
+  });
+
+  it("should return false for unrelated errors", () => {
+    const error = Object.assign(new Error("something else"), { code: "ECONNRESET" });
+    expect(isNodeJsHttp2TransientError(error)).toBe(false);
+  });
+
+  it("should classify ERR_HTTP2_STREAM_ERROR with NGHTTP2_REFUSED_STREAM as transient via isTransientError", () => {
+    const error = Object.assign(new Error("Stream closed with error code NGHTTP2_REFUSED_STREAM"), {
+      code: "ERR_HTTP2_STREAM_ERROR",
+      $metadata: {},
+    });
+    expect(isTransientError(error as SdkError)).toBe(true);
+  });
+
+  it("should classify ERR_HTTP2_STREAM_ERROR with NGHTTP2_REFUSED_STREAM in cause as transient", () => {
+    const cause = Object.assign(new Error("Stream closed with error code NGHTTP2_REFUSED_STREAM"), {
+      code: "ERR_HTTP2_STREAM_ERROR",
+      $metadata: {},
+    });
+    const error = Object.assign(new Error("request failed"), {
+      $metadata: {},
+      cause,
+    });
+    expect(isTransientError(error as SdkError)).toBe(true);
   });
 });

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -62,6 +62,7 @@ export const isTransientError = (error: SdkError, depth = 0): boolean =>
   NODEJS_NETWORK_ERROR_CODES.includes((error as { code?: string })?.code || "") ||
   TRANSIENT_ERROR_STATUS_CODES.includes(error.$metadata?.httpStatusCode || 0) ||
   isBrowserNetworkError(error) ||
+  isNodeJsHttp2TransientError(error) ||
   (error.cause !== undefined && depth <= 10 && isTransientError(error.cause, depth + 1));
 
 export const isServerError = (error: SdkError) => {
@@ -74,3 +75,10 @@ export const isServerError = (error: SdkError) => {
   }
   return false;
 };
+
+/**
+ * @internal
+ */
+export function isNodeJsHttp2TransientError(error: Error & { code?: string }): boolean {
+  return error.code === "ERR_HTTP2_STREAM_ERROR" && error.message.includes("NGHTTP2_REFUSED_STREAM");
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/7936

- https://github.com/aws/aws-sdk-js-v3/issues/3809
- https://github.com/aws/aws-sdk-js-v3/pull/3810

*Description of changes:*

HTTP2 connection pool fixes to make it usable. 
