### PR TITLE
chore(core): replace Object.entries with single-pass header scan

### DIFF
--- a/.changeset/great-parrots-sleep.md
+++ b/.changeset/great-parrots-sleep.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Replace Object.entries with single-pass header scan

--- a/packages/core/src/submodules/schema/middleware/schemaDeserializationMiddleware.ts
+++ b/packages/core/src/submodules/schema/middleware/schemaDeserializationMiddleware.ts
@@ -75,12 +75,22 @@ export const schemaDeserializationMiddleware =
           // by taking information from the response.
           if (HttpResponse.isInstance(response)) {
             const { headers = {} } = response;
-            const headerEntries = Object.entries(headers);
+
+            let requestId: string | undefined;
+            let extendedRequestId: string | undefined;
+            let cfId: string | undefined;
+
+            for (const k in headers) {
+              if (/^x-[\w-]+-request-?id$/.test(k)) requestId = headers[k];
+              else if (/^x-[\w-]+-id-2$/.test(k)) extendedRequestId = headers[k];
+              else if (/^x-[\w-]+-cf-id$/.test(k)) cfId = headers[k];
+            }
+
             (error as MetadataBearer).$metadata = {
               httpStatusCode: response.statusCode,
-              requestId: findHeader(/^x-[\w-]+-request-?id$/, headerEntries),
-              extendedRequestId: findHeader(/^x-[\w-]+-id-2$/, headerEntries),
-              cfId: findHeader(/^x-[\w-]+-cf-id$/, headerEntries),
+              requestId,
+              extendedRequestId,
+              cfId,
             };
           }
         } catch (e) {
@@ -91,13 +101,3 @@ export const schemaDeserializationMiddleware =
       throw error;
     }
   };
-
-/**
- * @internal
- * @returns header value where key matches regex.
- */
-const findHeader = (pattern: RegExp, headers: [string, string][]): string | undefined => {
-  return (headers.find(([k]) => {
-    return k.match(pattern);
-  }) || [void 0, void 1])[1];
-};


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-6645

*Description of changes:*
* Replaces Object.entries with single-pass header scan
* This was missed in https://github.com/smithy-lang/smithy-typescript/pull/1961 as it wasn't in hot path

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
