### PR TITLE
fix(service-error-classification): add check for clock skew based errors to retry

### DIFF
--- a/.changeset/neat-ravens-clean.md
+++ b/.changeset/neat-ravens-clean.md
@@ -1,0 +1,5 @@
+---
+"@smithy/service-error-classification": patch
+---
+
+retry clock skew errors for freeze/thaw/drift situations

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -57,6 +57,7 @@ export const isThrottlingError = (error: SdkError) =>
 export const isTransientError = (error: SdkError, depth = 0): boolean =>
   isRetryableByTrait(error) ||
   isClockSkewCorrectedError(error) ||
+  (error.name === "InvalidSignatureException" && error.message?.includes("Signature expired")) ||
   TRANSIENT_ERROR_CODES.includes(error.name) ||
   NODEJS_TIMEOUT_ERROR_CODES.includes((error as { code?: string })?.code || "") ||
   NODEJS_NETWORK_ERROR_CODES.includes((error as { code?: string })?.code || "") ||


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/7605

*Description of changes:*
The SDK was not attempting retries upon receiving `InvalidSignatureException` with "Signature expired" (due to clock skew from Lambda freeze/thaw or ECS clock drift). The errorHandler ([code](https://github.com/aws/aws-sdk-js-v3/blob/f83dd4822559eca40d1fcd13bf330259c588bc28/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts#L127)) attempts to detect clock skew by comparing server time to `Date.now()`. In freeze/thaw scenarios, the system clock could have already self-corrected by the time the error response arrives, so ultimately the RetryStrategy in the SDK classifies the error as a non-retryable error.

This change intends to make the error retryable since a subsequent request in this case can succeed.

---

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
