### PR TITLE
fix(node-http-handler): more graceful http2 session closure logic

### DIFF
--- a/.changeset/lazy-eagles-check.md
+++ b/.changeset/lazy-eagles-check.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+update http2 session closure to prefer session.close() on goaway rather than immediately invoking session.destroy()

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
@@ -71,6 +71,15 @@ export class ClientHttp2SessionRef {
     return this.session;
   }
 
+  /**
+   * Allow open refs to free on their own.
+   */
+  public close(): void {
+    if (!this.session.closed) {
+      this.session.close();
+    }
+  }
+
   public destroy(): void {
     this.refs = 0;
     if (!this.session.destroyed) {

--- a/packages/node-http-handler/src/node-http2-connection-manager.ts
+++ b/packages/node-http-handler/src/node-http2-connection-manager.ts
@@ -60,17 +60,19 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
       });
     }
 
-    const destroySessionCb = () => {
-      session.destroy();
-      this.removeFromPool(url, ref);
+    const graceful = () => {
+      this.removeFromPoolAndClose(url, ref);
     };
-    session.on("goaway", destroySessionCb);
-    session.on("error", destroySessionCb);
-    session.on("frameError", destroySessionCb);
-    session.on("close", () => this.removeFromPool(url, ref));
+    const ensureDestroyed = () => {
+      this.removeFromPoolAndCheckedDestroy(url, ref);
+    };
+    session.on("goaway", graceful);
+    session.on("error", ensureDestroyed);
+    session.on("frameError", ensureDestroyed);
+    session.on("close", ensureDestroyed);
 
     if (connectionConfiguration.requestTimeout) {
-      session.setTimeout(connectionConfiguration.requestTimeout, destroySessionCb);
+      session.setTimeout(connectionConfiguration.requestTimeout, ensureDestroyed);
     }
 
     pool.offerLast(ref);
@@ -102,17 +104,19 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
 
     session.settings({ maxConcurrentStreams: 1 });
 
-    const destroySession = () => {
-      session.destroy();
+    const ensureDestroyed = () => {
+      ref.destroy();
     };
 
-    session.on("goaway", destroySession);
-    session.on("error", destroySession);
-    session.on("frameError", destroySession);
-    session.on("close", destroySession);
+    // note: there is no goaway handler for an isolated session.
+    // the session is already closing after receiving "goaway" and
+    // there is no pool from which to remove it.
+    session.on("error", ensureDestroyed);
+    session.on("frameError", ensureDestroyed);
+    session.on("close", ensureDestroyed);
 
     if (connectionConfiguration.requestTimeout) {
-      session.setTimeout(connectionConfiguration.requestTimeout, destroySession);
+      session.setTimeout(connectionConfiguration.requestTimeout, ensureDestroyed);
     }
 
     ref.retain();
@@ -165,11 +169,17 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
     return pools;
   }
 
-  /**
-   * Remove a session from the pools. Does not destroy it.
-   */
-  private removeFromPool(authority: string, ref: ClientHttp2SessionRef): void {
+  private removeFromPoolAndClose(authority: string, ref: ClientHttp2SessionRef): void {
     this.connectionPools.get(authority)?.remove(ref);
+    // no-op when this function is called as a "goaway" reaction,
+    // but in case the method is called from another path, this is a defensive closure
+    // because we lose the reference to the session.
+    ref.close();
+  }
+
+  private removeFromPoolAndCheckedDestroy(authority: string, ref: ClientHttp2SessionRef): void {
+    this.connectionPools.get(authority)?.remove(ref);
+    ref.destroy();
   }
 
   private getPool(url: string): NodeHttp2ConnectionPool {

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -208,7 +208,7 @@ describe(NodeHttp2Handler.name, () => {
     });
 
     describe("errors", () => {
-      const UNEXPECTEDLY_CLOSED_REGEX = /closed|destroy|cancel|did not get a response/i;
+      const UNEXPECTEDLY_CLOSED_REGEX = /closed|destroy|cancel|did not get a response|failed/i;
       it("handles goaway frames", async () => {
         const mockH2Server3 = mockH2Servers[port3];
         let establishedConnections = 0;
@@ -286,18 +286,15 @@ describe(NodeHttp2Handler.name, () => {
         expectSessionCreatedAndUnreffed(createdSessions[3]);
       });
 
-      it.each([
-        ["destroy" as keyof Http2Session, 1],
-        ["close" as keyof Http2Session, 2],
-      ])("handles servers calling connections %s", async (func: keyof Http2Session, portIndex) => {
-        const port = [port1, port2, port3, port4][portIndex];
+      it("handles servers calling connections destroy", async () => {
+        const port = port2;
         const mockH2Server4 = mockH2Servers[port];
         let establishedConnections = 0;
         let numRequests = 0;
 
         mockH2Server4.on("stream", (request: Http2Stream) => {
           numRequests += 1;
-          (request.session as any)![func]();
+          (request.session as any)!.destroy();
         });
         mockH2Server4.on("connection", () => {
           establishedConnections += 1;
@@ -308,21 +305,21 @@ describe(NodeHttp2Handler.name, () => {
         await rejects(
           nodeH2Handler.handle(req, {}),
           UNEXPECTEDLY_CLOSED_REGEX,
-          "should be rejected promptly due to goaway frame or destroyed connection"
+          "should be rejected promptly due to destroyed connection"
         );
         expect(establishedConnections).toBe(1);
         expect(numRequests).toBe(1);
         await rejects(
           nodeH2Handler.handle(req, {}),
           UNEXPECTEDLY_CLOSED_REGEX,
-          "should be rejected promptly due to goaway frame or destroyed connection"
+          "should be rejected promptly due to destroyed connection"
         );
         expect(establishedConnections).toBe(2);
         expect(numRequests).toBe(2);
         await rejects(
           nodeH2Handler.handle(req, {}),
           UNEXPECTEDLY_CLOSED_REGEX,
-          "should be rejected promptly due to goaway frame or destroyed connection"
+          "should be rejected promptly due to destroyed connection"
         );
         expect(establishedConnections).toBe(3);
         expect(numRequests).toBe(3);
@@ -333,6 +330,30 @@ describe(NodeHttp2Handler.name, () => {
         expectSessionCreatedAndDestroyed(createdSessions[0]);
         expectSessionCreatedAndDestroyed(createdSessions[1]);
         expectSessionCreatedAndDestroyed(createdSessions[2]);
+      });
+
+      it("handles servers calling connections close", async () => {
+        const port = port3;
+        const mockH2Server4 = mockH2Servers[port];
+
+        mockH2Server4.on("stream", (request: Http2Stream) => {
+          // Server gracefully closes the session (sends GOAWAY with NO_ERROR)
+          // and resets the stream so it completes.
+          request.close();
+          (request.session as any)!.close();
+        });
+
+        const req = new HttpRequest({ ...getMockReqOptions(), port });
+
+        // Each request should be rejected because the server closes
+        // without sending a response. Subsequent requests may fail
+        // client-side (frameError on closed session) before reaching
+        // the server.
+        await rejects(nodeH2Handler.handle(req, {}), UNEXPECTEDLY_CLOSED_REGEX);
+        await rejects(nodeH2Handler.handle(req, {}), UNEXPECTEDLY_CLOSED_REGEX);
+        await rejects(nodeH2Handler.handle(req, {}), UNEXPECTEDLY_CLOSED_REGEX);
+
+        mockH2Server4.close();
       });
     });
 


### PR DESCRIPTION
*Issue #, if available:*

follows https://github.com/smithy-lang/smithy-typescript/pull/1962

*Description of changes:*

don't immediately destroy a session when receiving the `goaway` message from the server
