### PR TITLE
feat(util-waiter): emit warning from waiter for sustained 403s

### DIFF
--- a/.changeset/proud-oranges-suffer.md
+++ b/.changeset/proud-oranges-suffer.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-waiter": minor
+---
+
+emit warning from waiter polling when repeated 403s are encountered

--- a/packages/util-waiter/src/poller.spec.ts
+++ b/packages/util-waiter/src/poller.spec.ts
@@ -108,13 +108,13 @@ describe(runPolling.name, () => {
     expect(sleep).toHaveBeenCalled();
     expect(mockAcceptorChecks).toHaveBeenCalledTimes(8);
     expect(sleep).toHaveBeenCalledTimes(7);
-    expect(sleep).toHaveBeenNthCalledWith(1, 2); // min delay. random(2, 2)
+    expect(sleep).toHaveBeenNthCalledWith(1, 2); // min delay
     expect(sleep).toHaveBeenNthCalledWith(2, 3); // random(2, 4)
-    expect(sleep).toHaveBeenNthCalledWith(3, 5); // +random(2, 8)
-    expect(sleep).toHaveBeenNthCalledWith(4, 9); // +random(2, 16)
-    expect(sleep).toHaveBeenNthCalledWith(5, 30); // max delay
-    expect(sleep).toHaveBeenNthCalledWith(6, 30); // max delay
-    expect(sleep).toHaveBeenNthCalledWith(7, 30); // max delay
+    expect(sleep).toHaveBeenNthCalledWith(3, 5); // random(2, 8)
+    expect(sleep).toHaveBeenNthCalledWith(4, 9); // random(2, 16)
+    expect(sleep).toHaveBeenNthCalledWith(5, 30); // past attemptCeiling, maxDelay
+    expect(sleep).toHaveBeenNthCalledWith(6, 30); // past attemptCeiling
+    expect(sleep).toHaveBeenNthCalledWith(7, 30); // past attemptCeiling
   });
 
   it("resolves after the last attempt before reaching maxWaitTime ", async () => {
@@ -137,8 +137,6 @@ describe(runPolling.name, () => {
 
     mockAcceptorChecks = vi.fn().mockResolvedValue(retryState);
     await expect(runPolling(localConfig, input, mockAcceptorChecks)).resolves.toStrictEqual(timeoutState);
-    expect(sleep).toHaveBeenCalled();
-    expect(sleep).toHaveBeenCalledTimes(2);
     nowMock.mockReset();
   });
 
@@ -198,6 +196,85 @@ describe(runPolling.name, () => {
     const result = await runPolling(localConfig, input, mockAcceptorChecks);
     expect(result.state).toBe(WaiterState.TIMEOUT);
     expect(result.final).toBeUndefined();
+    nowMock.mockReset();
+  });
+
+  it("should warn when polling exceeds 60s and 403s are observed", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const reason403 = { $metadata: { httpStatusCode: 403 }, message: "Forbidden" };
+    const retryWith403 = { state: WaiterState.RETRY, reason: reason403 };
+
+    // Simulate time: start at T=0, each Date.now() call advances 20s.
+    // This ensures we cross the 60s warn403Time threshold after a few polls.
+    let now = 1_000_000;
+    const nowMock = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(now) // waitUntil
+      .mockImplementation(() => {
+        const rtn = now;
+        now += 20_000;
+        return rtn;
+      });
+
+    const localConfig = {
+      ...config,
+      minDelay: 2,
+      maxDelay: 2,
+      maxWaitTime: 300,
+      client: { config: {} },
+    } as WaiterOptions<any>;
+
+    mockAcceptorChecks = vi
+      .fn()
+      .mockResolvedValueOnce(retryWith403) // initial check
+      .mockResolvedValueOnce(retryWith403) // poll 1
+      .mockResolvedValueOnce(retryWith403) // poll 2
+      .mockResolvedValueOnce(retryWith403) // poll 3
+      .mockResolvedValueOnce({ state: WaiterState.SUCCESS, reason: { $metadata: { httpStatusCode: 200 } } });
+
+    await runPolling(localConfig, input, mockAcceptorChecks);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("403 status code encountered during waiter polling"));
+
+    warnSpy.mockRestore();
+    nowMock.mockReset();
+  });
+
+  it("should truncate delay to fire a last poll before timeout", async () => {
+    // Use real-ish time: start at T=0, advance 1s per Date.now() call.
+    let now = 1_000_000;
+    const nowMock = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(now) // waitUntil = now + 10_000
+      .mockImplementation(() => {
+        const rtn = now;
+        now += 1_000;
+        return rtn;
+      });
+
+    const localConfig = {
+      ...config,
+      minDelay: 2,
+      maxDelay: 30,
+      maxWaitTime: 10,
+      client: "mockClient",
+    } as WaiterOptions<any>;
+
+    mockAcceptorChecks = vi
+      .fn()
+      .mockResolvedValueOnce(retryState) // initial check
+      .mockResolvedValue({ state: WaiterState.SUCCESS, reason: { ok: true } });
+
+    const result = await runPolling(localConfig, input, mockAcceptorChecks);
+
+    // The backoff function should have truncated the delay so that
+    // sleep was called with a value less than the normal backoff,
+    // allowing one more poll before timeout.
+    expect(sleep).toHaveBeenCalled();
+    const sleepArg = vi.mocked(sleep).mock.calls[0][0];
+    expect(sleepArg).toBeLessThanOrEqual(localConfig.maxDelay);
+    expect(result.state).toBe(WaiterState.SUCCESS);
+
     nowMock.mockReset();
   });
 });

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -4,20 +4,9 @@ import type { WaiterOptions, WaiterResult } from "./waiter";
 import { WaiterState } from "./waiter";
 
 /**
- * Reference: https://smithy.io/2.0/additional-specs/waiters.html#waiter-retries
- * @internal
- */
-const exponentialBackoffWithJitter = (minDelay: number, maxDelay: number, attemptCeiling: number, attempt: number) => {
-  if (attempt > attemptCeiling) return maxDelay;
-  const delay = minDelay * 2 ** (attempt - 1);
-  return randomInRange(minDelay, delay);
-};
-
-const randomInRange = (min: number, max: number) => min + Math.random() * (max - min);
-
-/**
  * Function that runs polling as part of waiters. This will make one inital attempt and then
  * subsequent attempts with an increasing delay.
+ *
  * @param params - options passed to the waiter.
  * @param client - AWS SDK Client
  * @param input - client input
@@ -29,37 +18,32 @@ export const runPolling = async <Client, Input, Reason = any>(
   acceptorChecks: (client: Client, input: Input) => Promise<WaiterResult<Reason>>
 ): Promise<WaiterResult<Reason>> => {
   const observedResponses: Record<string, number> = {};
+  const [minDelayMs, maxDelayMs] = [minDelay * 1000, maxDelay * 1000];
 
-  const { state, reason } = await acceptorChecks(client, input);
-  if (reason) {
-    const message = createMessageFromResponse(reason);
-    observedResponses[message] |= 0;
-    observedResponses[message] += 1;
-  }
-
-  if (state !== WaiterState.RETRY) {
-    return { state, reason, final: reason, observedResponses };
-  }
-
-  let currentAttempt = 1;
+  let currentAttempt = 0;
   const waitUntil = Date.now() + maxWaitTime * 1000;
-  // The max attempt number that the derived delay time tend to increase.
-  // Pre-compute this number to avoid Number type overflow.
-  const attemptCeiling = Math.log(maxDelay / minDelay) / Math.log(2) + 1;
+
+  // warn about 403s if the waiter is still running at this time.
+  const warn403Time = Date.now() + 60_000;
+  let didWarn403 = false;
+
   while (true) {
-    if (abortController?.signal?.aborted || abortSignal?.aborted) {
-      const message = "AbortController signal aborted.";
-      observedResponses[message] |= 0;
-      observedResponses[message] += 1;
-      return { state: WaiterState.ABORTED, observedResponses };
+    if (currentAttempt > 0) {
+      const delayMs = exponentialBackoffWithJitter(minDelayMs, maxDelayMs, currentAttempt, waitUntil);
+
+      if (abortController?.signal?.aborted || abortSignal?.aborted) {
+        const message = "AbortController signal aborted.";
+        observedResponses[message] |= 0;
+        observedResponses[message] += 1;
+        return { state: WaiterState.ABORTED, observedResponses };
+      }
+      if (Date.now() + delayMs > waitUntil) {
+        return { state: WaiterState.TIMEOUT, observedResponses };
+      }
+
+      await sleep(delayMs / 1_000);
     }
-    const delay = exponentialBackoffWithJitter(minDelay, maxDelay, attemptCeiling, currentAttempt);
-    // Resolve the promise explicitly at timeout or aborted. Otherwise this while loop will keep making API call until
-    // `acceptorCheck` returns non-retry status, even with the Promise.race() outside.
-    if (Date.now() + delay * 1000 > waitUntil) {
-      return { state: WaiterState.TIMEOUT, observedResponses };
-    }
-    await sleep(delay);
+
     const { state, reason } = await acceptorChecks(client, input);
 
     if (reason) {
@@ -73,6 +57,41 @@ export const runPolling = async <Client, Input, Reason = any>(
     }
 
     currentAttempt += 1;
+
+    if (!didWarn403 && Date.now() >= warn403Time) {
+      checkWarn403(observedResponses, client);
+      didWarn403 = true;
+    }
+  }
+};
+
+/**
+ * Called after the waiter reaches at least 1 minute of wait time,
+ * checking if the observed responses are predominantly 403s.
+ *
+ * In such a case, warn that 403 was encountered during waiter polling.
+ */
+const checkWarn403 = (observedResponses: Record<string, number> = {}, client: any): void => {
+  const orderedErrors = Object.keys(observedResponses);
+
+  let maxCount = 0;
+  let count403 = 0;
+
+  for (const response of orderedErrors) {
+    const n = observedResponses[response] | 0;
+    maxCount = Math.max(n, maxCount);
+    if (response.startsWith("403:")) {
+      count403 += n;
+    }
+  }
+  const clientLogger = client?.config?.logger;
+  const warningLogger =
+    typeof clientLogger?.warn === "function" && !clientLogger.constructor?.name?.includes?.("NoOpLogger")
+      ? clientLogger
+      : console;
+
+  if (count403 >= 3 || orderedErrors[orderedErrors.length - 1].startsWith("403:")) {
+    warningLogger.warn(`@smithy/util-waiter WARN - 403 status code encountered during waiter polling.`);
   }
 };
 
@@ -83,19 +102,46 @@ export const runPolling = async <Client, Input, Reason = any>(
  * @internal
  */
 const createMessageFromResponse = (reason: any): string => {
+  const status = reason?.$response?.statusCode ?? reason?.$metadata?.httpStatusCode;
+
   if (reason?.$responseBodyText) {
     // is a deserialization error.
-    return `Deserialization error for body: ${reason.$responseBodyText}`;
+    return `${status ? status + ": " : ""}Deserialization error for body: ${reason.$responseBodyText}`;
   }
-  if (reason?.$metadata?.httpStatusCode) {
+  if (status) {
     // has a status code.
-    if (reason.$response || reason.message) {
+    if (reason?.$response || reason?.message) {
       // is an error object.
-      return `${reason.$response?.statusCode ?? reason.$metadata.httpStatusCode ?? "Unknown"}: ${reason.message}`;
+      return `${status ?? "Unknown"}: ${reason?.message}`;
     }
     // is an output object.
-    return `${reason.$metadata.httpStatusCode}: OK`;
+    return `${status}: OK`;
   }
   // is an unknown object.
   return String(reason?.message ?? JSON.stringify(reason, getCircularReplacer()) ?? "Unknown");
 };
+
+/**
+ * Reference: https://smithy.io/2.0/additional-specs/waiters.html#waiter-retries
+ *
+ * @internal
+ */
+const exponentialBackoffWithJitter = (minDelayMs: number, maxDelayMs: number, attempt: number, waitUntil: number) => {
+  const attemptCountCeiling = Math.log(maxDelayMs / minDelayMs) / Math.log(2) + 1;
+  if (attempt > attemptCountCeiling) {
+    return maxDelayMs;
+  }
+
+  const delay = minDelayMs * 2 ** (attempt - 1);
+  const capped = Math.min(delay, maxDelayMs);
+  const waitFor = randomInRange(minDelayMs, capped);
+
+  if (Date.now() + waitFor > waitUntil) {
+    const timeRemaining = waitUntil - Date.now();
+    // fire the last request 500ms before the waiter would time out.
+    return Math.max(0, timeRemaining - 500);
+  }
+  return waitFor;
+};
+
+const randomInRange = (min: number, max: number) => min + Math.random() * (max - min);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/3081
https://github.com/aws/aws-sdk-js-v3/issues/7818

*Description of changes:*

(waitUntil) Waiters, which throw on any non-success result, currently include the encountered errors in the thrown Error message.

For example:
```
Error [TimeoutError]: {"state":"TIMEOUT","observedResponses":{"403: UnknownError":3},"reason":"Waiter has timed out"}
```

This PR addresses long duration waiters, because it may take too long for them to surface the final thrown error to the user.

If 1 minute elapses and there are at least 3 `403` errors, or the latest error is 403, a warning will be pushed to a logger. The logger is selected from the client performing the polling or console.

This warning does not terminate the waiter. The warning will only be emitted once per waiter. The warning text is:

```
@smithy/util-waiter WARN - 403 status code encountered during waiter polling.
```