### PR TITLE
feat(codegen): aggregate service clients now have specific types for waiter results

### DIFF
--- a/private/my-local-model-schema/src/XYZService.ts
+++ b/private/my-local-model-schema/src/XYZService.ts
@@ -28,9 +28,13 @@ import {
   type TradeEventStreamCommandOutput,
   TradeEventStreamCommand,
 } from "./commands/TradeEventStreamCommand";
+import type { HaltError } from "./models/errors";
+import type { XYZServiceSyntheticServiceException } from "./models/XYZServiceSyntheticServiceException";
 import { paginatecamelCaseOperation as paginateCamelCaseOperation } from "./pagination/camelCaseOperationPaginator";
 import { paginateGetNumbers } from "./pagination/GetNumbersPaginator";
 import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
+import { waitUntilNumbersMisaligned } from "./waiters/waitForNumbersMisaligned";
+import { waitUntilNumbersWhatDoTheyDoAnyway } from "./waiters/waitForNumbersWhatDoTheyDoAnyway";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
@@ -45,6 +49,8 @@ const paginators = {
 };
 const waiters = {
   waitUntilNumbersAligned,
+  waitUntilNumbersMisaligned,
+  waitUntilNumbersWhatDoTheyDoAnyway,
 };
 
 export interface XYZService {
@@ -149,7 +155,27 @@ export interface XYZService {
   waitUntilNumbersAligned(
     args: GetNumbersCommandInput,
     waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
-  ): Promise<WaiterResult>;
+  ): Promise<WaiterResult<GetNumbersCommandOutput>>;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param waiterConfig - `maxWaitTime` in seconds or waiter config object.
+   */
+  waitUntilNumbersMisaligned(
+    args: GetNumbersCommandInput,
+    waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
+  ): Promise<WaiterResult<HaltError>>;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param waiterConfig - `maxWaitTime` in seconds or waiter config object.
+   */
+  waitUntilNumbersWhatDoTheyDoAnyway(
+    args: GetNumbersCommandInput,
+    waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
+  ): Promise<WaiterResult<GetNumbersCommandOutput | HaltError>>;
 }
 
 /**

--- a/private/my-local-model-schema/src/waiters/index.ts
+++ b/private/my-local-model-schema/src/waiters/index.ts
@@ -1,2 +1,4 @@
 // smithy-typescript generated code
 export * from "./waitForNumbersAligned";
+export * from "./waitForNumbersMisaligned";
+export * from "./waitForNumbersWhatDoTheyDoAnyway";

--- a/private/my-local-model-schema/src/waiters/waitForNumbersMisaligned.ts
+++ b/private/my-local-model-schema/src/waiters/waitForNumbersMisaligned.ts
@@ -12,6 +12,7 @@ import {
   type GetNumbersCommandOutput,
   GetNumbersCommand,
 } from "../commands/GetNumbersCommand";
+import type { HaltError } from "../models/errors";
 import type { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 import type { XYZServiceClient } from "../XYZServiceClient";
 
@@ -20,23 +21,20 @@ const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInpu
   try {
     let result: GetNumbersCommandOutput & any = await client.send(new GetNumbersCommand(input));
     reason = result;
-    return { state: WaiterState.SUCCESS, reason };
+    return { state: WaiterState.RETRY, reason };
   } catch (exception) {
     reason = exception;
-    if (exception.name === "MysteryThrottlingError") {
-      return { state: WaiterState.RETRY, reason };
-    }
     if (exception.name === "HaltError") {
-      return { state: WaiterState.FAILURE, reason };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
   return { state: WaiterState.RETRY, reason };
 };
 /**
- * wait until the numbers align
- *  @deprecated Use waitUntilNumbersAligned instead. waitForNumbersAligned does not throw error in non-success cases.
+ * wait until the numbers don't align
+ *  @deprecated Use waitUntilNumbersMisaligned instead. waitForNumbersMisaligned does not throw error in non-success cases.
  */
-export const waitForNumbersAligned = async (
+export const waitForNumbersMisaligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
 ): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
@@ -44,15 +42,15 @@ export const waitForNumbersAligned = async (
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
 };
 /**
- * wait until the numbers align
+ * wait until the numbers don't align
  *  @param params - Waiter configuration options.
  *  @param input - The input to GetNumbersCommand for polling.
  */
-export const waitUntilNumbersAligned = async (
+export const waitUntilNumbersMisaligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult<GetNumbersCommandOutput>> => {
+): Promise<WaiterResult<HaltError>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
-  return checkExceptions(result) as WaiterResult<GetNumbersCommandOutput>;
+  return checkExceptions(result) as WaiterResult<HaltError>;
 };

--- a/private/my-local-model-schema/src/waiters/waitForNumbersWhatDoTheyDoAnyway.ts
+++ b/private/my-local-model-schema/src/waiters/waitForNumbersWhatDoTheyDoAnyway.ts
@@ -12,6 +12,7 @@ import {
   type GetNumbersCommandOutput,
   GetNumbersCommand,
 } from "../commands/GetNumbersCommand";
+import type { HaltError } from "../models/errors";
 import type { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 import type { XYZServiceClient } from "../XYZServiceClient";
 
@@ -23,20 +24,17 @@ const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInpu
     return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
     reason = exception;
-    if (exception.name === "MysteryThrottlingError") {
-      return { state: WaiterState.RETRY, reason };
-    }
     if (exception.name === "HaltError") {
-      return { state: WaiterState.FAILURE, reason };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
   return { state: WaiterState.RETRY, reason };
 };
 /**
- * wait until the numbers align
- *  @deprecated Use waitUntilNumbersAligned instead. waitForNumbersAligned does not throw error in non-success cases.
+ * wait until the numbers align or don't align
+ *  @deprecated Use waitUntilNumbersWhatDoTheyDoAnyway instead. waitForNumbersWhatDoTheyDoAnyway does not throw error in non-success cases.
  */
-export const waitForNumbersAligned = async (
+export const waitForNumbersWhatDoTheyDoAnyway = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
 ): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
@@ -44,15 +42,15 @@ export const waitForNumbersAligned = async (
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
 };
 /**
- * wait until the numbers align
+ * wait until the numbers align or don't align
  *  @param params - Waiter configuration options.
  *  @param input - The input to GetNumbersCommand for polling.
  */
-export const waitUntilNumbersAligned = async (
+export const waitUntilNumbersWhatDoTheyDoAnyway = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult<GetNumbersCommandOutput>> => {
+): Promise<WaiterResult<GetNumbersCommandOutput | HaltError>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
-  return checkExceptions(result) as WaiterResult<GetNumbersCommandOutput>;
+  return checkExceptions(result) as WaiterResult<GetNumbersCommandOutput | HaltError>;
 };

--- a/private/my-local-model-schema/test/index-objects.spec.mjs
+++ b/private/my-local-model-schema/test/index-objects.spec.mjs
@@ -31,7 +31,11 @@ import {
   TradeEventStreamRequest$,
   TradeEventStreamResponse$,
   waitForNumbersAligned,
+  waitForNumbersMisaligned,
+  waitForNumbersWhatDoTheyDoAnyway,
   waitUntilNumbersAligned,
+  waitUntilNumbersMisaligned,
+  waitUntilNumbersWhatDoTheyDoAnyway,
   XYZService,
   XYZServiceClient,
   XYZServiceServiceException,
@@ -79,7 +83,11 @@ assert(typeof XYZServiceServiceException$ === "object");
 assert(XYZServiceSyntheticServiceException.prototype instanceof Error);
 // waiters
 assert(typeof waitForNumbersAligned === "function");
+assert(typeof waitForNumbersMisaligned === "function");
+assert(typeof waitForNumbersWhatDoTheyDoAnyway === "function");
 assert(typeof waitUntilNumbersAligned === "function");
+assert(typeof waitUntilNumbersMisaligned === "function");
+assert(typeof waitUntilNumbersWhatDoTheyDoAnyway === "function");
 // paginators
 assert(typeof paginateGetNumbers === "function");
 assert(typeof paginatecamelCaseOperation === "function");

--- a/private/my-local-model-schema/test/index-types.ts
+++ b/private/my-local-model-schema/test/index-types.ts
@@ -33,7 +33,11 @@ export type {
   XYZServiceServiceException,
   XYZServiceSyntheticServiceException,
   waitForNumbersAligned,
+  waitForNumbersMisaligned,
+  waitForNumbersWhatDoTheyDoAnyway,
   waitUntilNumbersAligned,
+  waitUntilNumbersMisaligned,
+  waitUntilNumbersWhatDoTheyDoAnyway,
   paginateGetNumbers,
   paginatecamelCaseOperation,
 } from "../dist-types/index.d";

--- a/private/my-local-model/src/XYZService.ts
+++ b/private/my-local-model/src/XYZService.ts
@@ -28,9 +28,13 @@ import {
   type TradeEventStreamCommandOutput,
   TradeEventStreamCommand,
 } from "./commands/TradeEventStreamCommand";
+import type { HaltError } from "./models/errors";
+import type { XYZServiceSyntheticServiceException } from "./models/XYZServiceSyntheticServiceException";
 import { paginatecamelCaseOperation as paginateCamelCaseOperation } from "./pagination/camelCaseOperationPaginator";
 import { paginateGetNumbers } from "./pagination/GetNumbersPaginator";
 import { waitUntilNumbersAligned } from "./waiters/waitForNumbersAligned";
+import { waitUntilNumbersMisaligned } from "./waiters/waitForNumbersMisaligned";
+import { waitUntilNumbersWhatDoTheyDoAnyway } from "./waiters/waitForNumbersWhatDoTheyDoAnyway";
 import { XYZServiceClient } from "./XYZServiceClient";
 
 const commands = {
@@ -45,6 +49,8 @@ const paginators = {
 };
 const waiters = {
   waitUntilNumbersAligned,
+  waitUntilNumbersMisaligned,
+  waitUntilNumbersWhatDoTheyDoAnyway,
 };
 
 export interface XYZService {
@@ -149,7 +155,27 @@ export interface XYZService {
   waitUntilNumbersAligned(
     args: GetNumbersCommandInput,
     waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
-  ): Promise<WaiterResult>;
+  ): Promise<WaiterResult<GetNumbersCommandOutput>>;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param waiterConfig - `maxWaitTime` in seconds or waiter config object.
+   */
+  waitUntilNumbersMisaligned(
+    args: GetNumbersCommandInput,
+    waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
+  ): Promise<WaiterResult<HaltError>>;
+
+  /**
+   * @see {@link GetNumbersCommand}
+   * @param args - command input.
+   * @param waiterConfig - `maxWaitTime` in seconds or waiter config object.
+   */
+  waitUntilNumbersWhatDoTheyDoAnyway(
+    args: GetNumbersCommandInput,
+    waiterConfig: number | Omit<WaiterConfiguration<XYZService>, "client">
+  ): Promise<WaiterResult<GetNumbersCommandOutput | HaltError>>;
 }
 
 /**

--- a/private/my-local-model/src/waiters/index.ts
+++ b/private/my-local-model/src/waiters/index.ts
@@ -1,2 +1,4 @@
 // smithy-typescript generated code
 export * from "./waitForNumbersAligned";
+export * from "./waitForNumbersMisaligned";
+export * from "./waitForNumbersWhatDoTheyDoAnyway";

--- a/private/my-local-model/src/waiters/waitForNumbersAligned.ts
+++ b/private/my-local-model/src/waiters/waitForNumbersAligned.ts
@@ -51,8 +51,8 @@ export const waitForNumbersAligned = async (
 export const waitUntilNumbersAligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
+): Promise<WaiterResult<GetNumbersCommandOutput>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
-  return checkExceptions(result);
+  return checkExceptions(result) as WaiterResult<GetNumbersCommandOutput>;
 };

--- a/private/my-local-model/src/waiters/waitForNumbersMisaligned.ts
+++ b/private/my-local-model/src/waiters/waitForNumbersMisaligned.ts
@@ -12,6 +12,7 @@ import {
   type GetNumbersCommandOutput,
   GetNumbersCommand,
 } from "../commands/GetNumbersCommand";
+import type { HaltError } from "../models/errors";
 import type { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 import type { XYZServiceClient } from "../XYZServiceClient";
 
@@ -20,23 +21,20 @@ const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInpu
   try {
     let result: GetNumbersCommandOutput & any = await client.send(new GetNumbersCommand(input));
     reason = result;
-    return { state: WaiterState.SUCCESS, reason };
+    return { state: WaiterState.RETRY, reason };
   } catch (exception) {
     reason = exception;
-    if (exception.name === "MysteryThrottlingError") {
-      return { state: WaiterState.RETRY, reason };
-    }
     if (exception.name === "HaltError") {
-      return { state: WaiterState.FAILURE, reason };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
   return { state: WaiterState.RETRY, reason };
 };
 /**
- * wait until the numbers align
- *  @deprecated Use waitUntilNumbersAligned instead. waitForNumbersAligned does not throw error in non-success cases.
+ * wait until the numbers don't align
+ *  @deprecated Use waitUntilNumbersMisaligned instead. waitForNumbersMisaligned does not throw error in non-success cases.
  */
-export const waitForNumbersAligned = async (
+export const waitForNumbersMisaligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
 ): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
@@ -44,15 +42,15 @@ export const waitForNumbersAligned = async (
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
 };
 /**
- * wait until the numbers align
+ * wait until the numbers don't align
  *  @param params - Waiter configuration options.
  *  @param input - The input to GetNumbersCommand for polling.
  */
-export const waitUntilNumbersAligned = async (
+export const waitUntilNumbersMisaligned = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult<GetNumbersCommandOutput>> => {
+): Promise<WaiterResult<HaltError>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
-  return checkExceptions(result) as WaiterResult<GetNumbersCommandOutput>;
+  return checkExceptions(result) as WaiterResult<HaltError>;
 };

--- a/private/my-local-model/src/waiters/waitForNumbersWhatDoTheyDoAnyway.ts
+++ b/private/my-local-model/src/waiters/waitForNumbersWhatDoTheyDoAnyway.ts
@@ -12,6 +12,7 @@ import {
   type GetNumbersCommandOutput,
   GetNumbersCommand,
 } from "../commands/GetNumbersCommand";
+import type { HaltError } from "../models/errors";
 import type { XYZServiceSyntheticServiceException } from "../models/XYZServiceSyntheticServiceException";
 import type { XYZServiceClient } from "../XYZServiceClient";
 
@@ -23,20 +24,17 @@ const checkState = async (client: XYZServiceClient, input: GetNumbersCommandInpu
     return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
     reason = exception;
-    if (exception.name === "MysteryThrottlingError") {
-      return { state: WaiterState.RETRY, reason };
-    }
     if (exception.name === "HaltError") {
-      return { state: WaiterState.FAILURE, reason };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
   return { state: WaiterState.RETRY, reason };
 };
 /**
- * wait until the numbers align
- *  @deprecated Use waitUntilNumbersAligned instead. waitForNumbersAligned does not throw error in non-success cases.
+ * wait until the numbers align or don't align
+ *  @deprecated Use waitUntilNumbersWhatDoTheyDoAnyway instead. waitForNumbersWhatDoTheyDoAnyway does not throw error in non-success cases.
  */
-export const waitForNumbersAligned = async (
+export const waitForNumbersWhatDoTheyDoAnyway = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
 ): Promise<WaiterResult<GetNumbersCommandOutput | XYZServiceSyntheticServiceException>> => {
@@ -44,15 +42,15 @@ export const waitForNumbersAligned = async (
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
 };
 /**
- * wait until the numbers align
+ * wait until the numbers align or don't align
  *  @param params - Waiter configuration options.
  *  @param input - The input to GetNumbersCommand for polling.
  */
-export const waitUntilNumbersAligned = async (
+export const waitUntilNumbersWhatDoTheyDoAnyway = async (
   params: WaiterConfiguration<XYZServiceClient>,
   input: GetNumbersCommandInput
-): Promise<WaiterResult<GetNumbersCommandOutput>> => {
+): Promise<WaiterResult<GetNumbersCommandOutput | HaltError>> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
-  return checkExceptions(result) as WaiterResult<GetNumbersCommandOutput>;
+  return checkExceptions(result) as WaiterResult<GetNumbersCommandOutput | HaltError>;
 };

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
@@ -223,9 +223,22 @@ final class ServiceAggregatedClientGenerator implements Runnable {
 
                     Symbol operationSymbol = symbolProvider.toSymbol(operation);
                     Symbol input = operationSymbol.expectProperty("inputType", Symbol.class);
-
-                    // TODO: use this to change WaiterResult to WaiterResult<OutputType>.
                     Symbol output = operationSymbol.expectProperty("outputType", Symbol.class);
+
+                    String serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
+                    String syntheticBaseExceptionName =
+                        CodegenUtils.getSyntheticBaseExceptionName(serviceName, model);
+                    writer.addRelativeTypeImport(
+                        syntheticBaseExceptionName,
+                        null,
+                        Paths.get(
+                            ".",
+                            CodegenUtils.SOURCE_FOLDER,
+                            "models",
+                            syntheticBaseExceptionName
+                        )
+                    );
+                    String waiterResultType = output.getName() + " | " + syntheticBaseExceptionName;
 
                     waitableTrait
                         .getWaiters()
@@ -234,6 +247,16 @@ final class ServiceAggregatedClientGenerator implements Runnable {
 
                             writer.addTypeImport("WaiterConfiguration", null, TypeScriptDependency.SMITHY_TYPES);
                             writer.addTypeImport("WaiterResult", null, TypeScriptDependency.AWS_SDK_UTIL_WAITERS);
+
+                            String waitUntilResultType = WaiterGenerator.computeWaitUntilResultType(
+                                waiter,
+                                output.getName(),
+                                syntheticBaseExceptionName,
+                                settings,
+                                model,
+                                symbolProvider,
+                                writer
+                            );
 
                             writer.writeDocs(
                                 """
@@ -247,11 +270,12 @@ final class ServiceAggregatedClientGenerator implements Runnable {
                                 $1L(
                                   args: $2T,
                                   waiterConfig: number | Omit<$3L, "client">
-                                ): Promise<WaiterResult>;
+                                ): Promise<WaiterResult<$4L>>;
                                 """,
                                 waiterLocalName,
                                 input,
-                                "WaiterConfiguration<" + aggregateClientName + ">"
+                                "WaiterConfiguration<" + aggregateClientName + ">",
+                                waitUntilResultType
                             );
                         });
                 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
@@ -17,6 +17,8 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.knowledge.ServiceClosure;
 import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.waiters.Acceptor;
 import software.amazon.smithy.waiters.AcceptorState;
@@ -40,6 +42,7 @@ class WaiterGenerator implements Runnable {
     private final Symbol inputSymbol;
     private final Symbol outputSymbol;
     private final String waiterResultType;
+    private final String waitUntilResultType;
 
     WaiterGenerator(
         String waiterName,
@@ -71,6 +74,15 @@ class WaiterGenerator implements Runnable {
             Path.of(".", "src", "models", syntheticBaseExceptionName)
         );
         waiterResultType = outputSymbol.getName() + " | " + syntheticBaseExceptionName;
+        waitUntilResultType = computeWaitUntilResultType(
+            waiter,
+            outputSymbol.getName(),
+            syntheticBaseExceptionName,
+            settings,
+            model,
+            symbolProvider,
+            writer
+        );
     }
 
     @Override
@@ -142,7 +154,7 @@ class WaiterGenerator implements Runnable {
             waiterName,
             serviceSymbol,
             inputSymbol,
-            waiterResultType,
+            waitUntilResultType,
             () -> {
                 writer.write(
                     "const serviceDefaults = { minDelay: $L, maxDelay: $L };",
@@ -152,7 +164,9 @@ class WaiterGenerator implements Runnable {
                 writer.write(
                     "const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);"
                 );
-                writer.write("return checkExceptions(result);");
+                // as WaiterResult<Narrowed> is needed because createWaiter is the union type
+                // whereas checkExceptions narrows to only the success type.
+                writer.write("return checkExceptions(result) as WaiterResult<$L>;", waitUntilResultType);
             }
         );
     }
@@ -274,6 +288,85 @@ class WaiterGenerator implements Runnable {
 
     private static String getModulePath(String fileLocation) {
         return fileLocation.substring(fileLocation.lastIndexOf("/") + 1, fileLocation.length()).replace(".ts", "");
+    }
+
+    /**
+     * Determines the narrowest result type for waitUntil based on which acceptors
+     * produce a SUCCESS state.
+     *
+     * - If success only comes from successful responses: OutputType only.
+     * - If success only comes from errors: the specific modeled exception if there
+     *   is exactly one ErrorType success acceptor matching a modeled error, otherwise
+     *   the synthetic base exception.
+     * - If success can come from both: OutputType | exception type.
+     */
+    static String computeWaitUntilResultType(
+        Waiter waiter,
+        String outputTypeName,
+        String exceptionTypeName,
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
+    ) {
+        boolean waiterSuccessTerminalOnSuccessfulResponse = false;
+        boolean waiterSuccessTerminalOnErrorResponse = false;
+        Set<String> successErrorTypeNames = new TreeSet<>();
+
+        for (Acceptor acceptor : waiter.getAcceptors()) {
+            if (acceptor.getState() != AcceptorState.SUCCESS) {
+                continue;
+            }
+            Matcher<?> matcher = acceptor.getMatcher();
+            if (matcher instanceof Matcher.SuccessMember successMember) {
+                if (successMember.getValue()) {
+                    waiterSuccessTerminalOnSuccessfulResponse = true;
+                } else {
+                    waiterSuccessTerminalOnErrorResponse = true;
+                }
+            } else if (matcher instanceof Matcher.ErrorTypeMember errorTypeMember) {
+                waiterSuccessTerminalOnErrorResponse = true;
+                successErrorTypeNames.add(errorTypeMember.getValue());
+            } else if (
+                matcher instanceof Matcher.OutputMember
+                    || matcher instanceof Matcher.InputOutputMember
+            ) {
+                waiterSuccessTerminalOnSuccessfulResponse = true;
+            }
+        }
+
+        String resolvedExceptionType = exceptionTypeName;
+        if (successErrorTypeNames.size() == 1) {
+            String errorName = successErrorTypeNames.iterator().next();
+            boolean errorTypeQualifiedName = errorName.contains("#");
+
+            // Check if this error is a modeled error shape on the operation.
+            resolvedExceptionType = ServiceClosure.of(model, settings.getService(model))
+                .getErrorShapes()
+                .stream()
+                .filter(
+                    shape -> errorTypeQualifiedName ? ShapeId.from(errorName).equals(shape.getId())
+                        : shape.getId().getName().equals(errorName)
+                )
+                .findFirst()
+                .map(shape -> {
+                    String typeName = symbolProvider.toSymbol(shape).getName();
+                    writer.addRelativeTypeImport(
+                        typeName,
+                        null,
+                        Path.of(".", "src", "models", "errors")
+                    );
+                    return typeName;
+                })
+                .orElse(exceptionTypeName);
+        }
+
+        if (waiterSuccessTerminalOnSuccessfulResponse && waiterSuccessTerminalOnErrorResponse) {
+            return outputTypeName + " | " + resolvedExceptionType;
+        } else if (waiterSuccessTerminalOnErrorResponse) {
+            return resolvedExceptionType;
+        }
+        return outputTypeName;
     }
 
     static void writeIndex(Model model, ServiceShape service, FileManifest fileManifest) {

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
@@ -162,6 +162,32 @@ structure MainServiceLinkedError {}
             }
         ]
     }
+    NumbersMisaligned: {
+        documentation: "wait until the numbers don't align"
+        acceptors: [
+            {
+                state: "retry"
+                matcher: { success: true }
+            }
+            {
+                state: "success"
+                matcher: { errorType: "HaltError" }
+            }
+        ]
+    }
+    NumbersWhatDoTheyDoAnyway: {
+        documentation: "wait until the numbers align or don't align"
+        acceptors: [
+            {
+                state: "success"
+                matcher: { success: true }
+            }
+            {
+                state: "success"
+                matcher: { errorType: "HaltError" }
+            }
+        ]
+    }
 )
 @paginated(inputToken: "startToken", outputToken: "nextToken", pageSize: "maxResults", items: "numbers")
 @readonly


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/smithy-lang/smithy-typescript/issues/1793

*Description of changes:*

aggregate service client typings now include the narrowed waiter result type.

For a visualization, see my comment in https://github.com/smithy-lang/smithy-typescript/issues/1793.
