### PR TITLE
fix(util-retry): missing call to getSendToken in Adaptive mode retries

### DIFF
--- a/.changeset/perfect-bags-flash.md
+++ b/.changeset/perfect-bags-flash.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-retry": patch
+---
+
+add a missing call to getSendToken in Adaptive mode retries

--- a/packages/util-retry/src/AdaptiveRetryStrategy.spec.ts
+++ b/packages/util-retry/src/AdaptiveRetryStrategy.spec.ts
@@ -74,18 +74,51 @@ describe(AdaptiveRetryStrategy.name, () => {
   });
 
   describe("refreshRetryTokenForRetry", () => {
-    it("calls rateLimiter.updateCientSendingRate and refreshes retry token", async () => {
+    it("calls getSendToken, updateClientSendingRate, and refreshes retry token", async () => {
       const mockedStandardRetryStrategy = vi.spyOn(StandardRetryStrategy.prototype, "refreshRetryTokenForRetry");
       mockedStandardRetryStrategy.mockResolvedValue(mockRetryToken);
       const retryStrategy = new AdaptiveRetryStrategy(maxAttemptsProvider, {
         rateLimiter: mockDefaultRateLimiter,
       });
       const token = await retryStrategy.refreshRetryTokenForRetry(mockRetryToken, errorInfo);
+      expect(mockDefaultRateLimiter.getSendToken).toHaveBeenCalledTimes(1);
       expect(mockDefaultRateLimiter.updateClientSendingRate).toHaveBeenCalledTimes(1);
       expect(mockDefaultRateLimiter.updateClientSendingRate).toHaveBeenCalledWith(errorInfo);
       expect(mockedStandardRetryStrategy).toHaveBeenCalledTimes(1);
       expect(mockedStandardRetryStrategy).toHaveBeenCalledWith(mockRetryToken, errorInfo);
       expect(token).toStrictEqual(mockRetryToken);
+    });
+
+    it("calls updateClientSendingRate before getSendToken", async () => {
+      const callOrder: string[] = [];
+      mockDefaultRateLimiter.getSendToken.mockImplementation(() => {
+        callOrder.push("getSendToken");
+        return Promise.resolve();
+      });
+      mockDefaultRateLimiter.updateClientSendingRate.mockImplementation(() => {
+        callOrder.push("updateClientSendingRate");
+      });
+      vi.spyOn(StandardRetryStrategy.prototype, "refreshRetryTokenForRetry").mockResolvedValue(mockRetryToken);
+
+      const retryStrategy = new AdaptiveRetryStrategy(maxAttemptsProvider, {
+        rateLimiter: mockDefaultRateLimiter,
+      });
+      await retryStrategy.refreshRetryTokenForRetry(mockRetryToken, errorInfo);
+      expect(callOrder).toEqual(["updateClientSendingRate", "getSendToken"]);
+    });
+
+    it("calls getSendToken for each retry in a multi-retry sequence", async () => {
+      vi.spyOn(StandardRetryStrategy.prototype, "refreshRetryTokenForRetry").mockResolvedValue(mockRetryToken);
+      const retryStrategy = new AdaptiveRetryStrategy(maxAttemptsProvider, {
+        rateLimiter: mockDefaultRateLimiter,
+      });
+
+      await retryStrategy.refreshRetryTokenForRetry(mockRetryToken, errorInfo);
+      await retryStrategy.refreshRetryTokenForRetry(mockRetryToken, errorInfo);
+      await retryStrategy.refreshRetryTokenForRetry(mockRetryToken, errorInfo);
+
+      expect(mockDefaultRateLimiter.getSendToken).toHaveBeenCalledTimes(3);
+      expect(mockDefaultRateLimiter.updateClientSendingRate).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/util-retry/src/AdaptiveRetryStrategy.ts
+++ b/packages/util-retry/src/AdaptiveRetryStrategy.ts
@@ -46,8 +46,9 @@ export class AdaptiveRetryStrategy implements RetryStrategyV2 {
   }
 
   public async acquireInitialRetryToken(retryTokenScope: string): Promise<RetryToken> {
+    const token = this.standardRetryStrategy.acquireInitialRetryToken(retryTokenScope);
     await this.rateLimiter.getSendToken();
-    return this.standardRetryStrategy.acquireInitialRetryToken(retryTokenScope);
+    return token;
   }
 
   public async refreshRetryTokenForRetry(
@@ -55,7 +56,10 @@ export class AdaptiveRetryStrategy implements RetryStrategyV2 {
     errorInfo: RetryErrorInfo
   ): Promise<RetryToken> {
     this.rateLimiter.updateClientSendingRate(errorInfo);
-    return this.standardRetryStrategy.refreshRetryTokenForRetry(tokenToRenew, errorInfo);
+    const token = this.standardRetryStrategy.refreshRetryTokenForRetry(tokenToRenew, errorInfo);
+    // called prior to return in case the token refresh throws (no need to wait in that case).
+    await this.rateLimiter.getSendToken();
+    return token;
   }
 
   public recordSuccess(token: StandardRetryToken): void {


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

adds missing sendToken acquisition in adaptive mode retry path