### PR TITLE
perf(node-http-handler): remove empty object allocation in hot paths

### DIFF
--- a/.changeset/empty-deers-drum.md
+++ b/.changeset/empty-deers-drum.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Remove empty object allocation in hot paths

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -174,8 +174,8 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         return;
       }
 
-      const headers = request.headers ?? {};
-      const expectContinue = (headers.Expect ?? headers.expect) === "100-continue";
+      const headers = request.headers;
+      const expectContinue = headers ? (headers.Expect ?? headers.expect) === "100-continue" : false;
 
       let agent = isSSL ? config.httpsAgent : config.httpAgent;
       if (expectContinue && !this.externalAgent) {
@@ -205,7 +205,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         )
       );
 
-      const queryString = buildQueryString(request.query || {});
+      const queryString = request.query ? buildQueryString(request.query) : "";
       let auth = undefined;
       if (request.username != null || request.password != null) {
         const username = request.username ?? "";

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -171,7 +171,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
         reject(err);
       };
 
-      const queryString = buildQueryString(query ?? {});
+      const queryString = query ? buildQueryString(query) : "";
       let path = request.path;
       if (queryString) {
         path += `?${queryString}`;

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -21,8 +21,8 @@ export async function writeRequestBody(
   maxContinueTimeoutMs = MIN_WAIT_TIME,
   externalAgent = false
 ): Promise<void> {
-  const headers = request.headers ?? {};
-  const expect = headers.Expect || headers.expect;
+  const headers = request.headers;
+  const expect = headers ? headers.Expect || headers.expect : undefined;
 
   let timeoutId = -1;
   let sendBody = true;


### PR DESCRIPTION
*Issue #, if available:*

Improving HttpHandler performance before benchmarking with [undici handler](https://github.com/trivikr/trivikr-test-undici-http-handler)

*Description of changes:*

Removes empty object allocation in hot paths

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
