### PR TITLE
perf(node-http-handler): skip await on settled writeRequestBodyPromise

### DIFF
--- a/.changeset/three-dodos-compete.md
+++ b/.changeset/three-dodos-compete.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Skip await on settled writeRequestBodyPromise

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -152,17 +152,22 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
 
     return new Promise((_resolve, _reject) => {
       let writeRequestBodyPromise: Promise<void> | undefined = undefined;
+      let hasWriteRequestBodyPromiseSettled = false;
 
       // Timeouts related to this request to clear upon completion.
       const timeouts = [] as (number | NodeJS.Timeout)[];
 
       const resolve = async (arg: { response: HttpResponse }) => {
-        await writeRequestBodyPromise;
+        if (!hasWriteRequestBodyPromiseSettled) {
+          await writeRequestBodyPromise;
+        }
         timeouts.forEach(timing.clearTimeout);
         _resolve(arg);
       };
       const reject = async (arg: unknown) => {
-        await writeRequestBodyPromise;
+        if (!hasWriteRequestBodyPromiseSettled) {
+          await writeRequestBodyPromise;
+        }
         timeouts.forEach(timing.clearTimeout);
         _reject(arg);
       };
@@ -299,7 +304,10 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         );
       }
 
-      writeRequestBodyPromise = writeRequestBody(req, request, effectiveRequestTimeout, this.externalAgent).catch(
+      writeRequestBodyPromise = writeRequestBody(req, request, effectiveRequestTimeout, this.externalAgent).then(
+        () => {
+          hasWriteRequestBodyPromiseSettled = true;
+        },
         (e) => {
           timeouts.forEach(timing.clearTimeout);
           return _reject(e);

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -126,12 +126,17 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
       let fulfilled = false;
 
       let writeRequestBodyPromise: Promise<void> | undefined = undefined;
+      let hasWriteRequestBodyPromiseSettled = false;
       const resolve = async (arg: { response: HttpResponse }) => {
-        await writeRequestBodyPromise;
+        if (!hasWriteRequestBodyPromiseSettled) {
+          await writeRequestBodyPromise;
+        }
         _resolve(arg);
       };
       const reject = async (arg: unknown) => {
-        await writeRequestBodyPromise;
+        if (!hasWriteRequestBodyPromiseSettled) {
+          await writeRequestBodyPromise;
+        }
         _reject(arg);
       };
 
@@ -255,7 +260,14 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
         }
       });
 
-      writeRequestBodyPromise = writeRequestBody(clientHttp2Stream, request, effectiveRequestTimeout);
+      writeRequestBodyPromise = writeRequestBody(clientHttp2Stream, request, effectiveRequestTimeout).then(
+        () => {
+          hasWriteRequestBodyPromiseSettled = true;
+        },
+        () => {
+          hasWriteRequestBodyPromiseSettled = true;
+        }
+      );
     });
   }
 


### PR DESCRIPTION
*Issue #, if available:*

Improving HttpHandler performance before benchmarking with [undici handler](https://github.com/trivikr/trivikr-test-undici-http-handler)

*Description of changes:*

Track writeRequestBodyPromise settlement with a boolean flag and only await when the promise is still pending.

In the common case where the request body has already been written before the response callback fires, this avoids scheduling an unnecessary microtask on every resolve and reject call.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
