### PR TITLE
perf(node-http-handler): cache 100-continue agents at module level

### DIFF
--- a/.changeset/gentle-brooms-compete.md
+++ b/.changeset/gentle-brooms-compete.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Cache 100-continue agents at module level

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -34,6 +34,14 @@ let hAgent: { new (...args: any): hAgentType } | undefined = undefined;
 let hRequest: typeof hRequestType | undefined = undefined;
 
 /**
+ * Cached agents for 100-continue requests, shared across all NodeHttpHandler instances.
+ * Reusing a single agent per protocol avoids GC pressure from creating a new Agent
+ * on every 100-continue request (e.g., S3 PutObject workloads).
+ */
+let continueHttpAgent: hAgentType | undefined = undefined;
+let continueHttpsAgent: hsAgent | undefined = undefined;
+
+/**
  * @public
  * A request handler that uses the Node.js http and https modules.
  */
@@ -182,12 +190,25 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         // Because awaiting 100-continue desynchronizes the request and request body transmission,
         // such requests must be offloaded to a separate Agent instance.
         // Additional logic will exist on the client using this handler to determine whether to add the header at all.
-        agent = new (isSSL ? hsAgent : hAgent!)({
-          keepAlive: false,
-          // This is an explicit value matching the default (Infinity).
-          // This should allow the connection to close cleanly after making the single request.
-          maxSockets: Infinity,
-        });
+        // A single cached agent per protocol is reused to avoid GC pressure from creating
+        // a new Agent on every 100-continue request (e.g., S3 PutObject workloads).
+        if (isSSL) {
+          if (!continueHttpsAgent) {
+            continueHttpsAgent = new hsAgent({
+              keepAlive: false,
+              maxSockets: Infinity,
+            });
+          }
+          agent = continueHttpsAgent;
+        } else {
+          if (!continueHttpAgent) {
+            continueHttpAgent = new hAgent!({
+              keepAlive: false,
+              maxSockets: Infinity,
+            });
+          }
+          agent = continueHttpAgent;
+        }
       }
 
       // If the request is taking a long time, check socket usage and potentially warn.


### PR DESCRIPTION
*Issue #, if available:*

Improving HttpHandler performance before benchmarking with [undici handler](https://github.com/trivikr/trivikr-test-undici-http-handler)

*Description of changes:*

Replaces per-request Agent creation for 100-continue requests with lazily initialized module-level singletons.

Workloads that send many 100-continue requests (e.g., S3 PutObject) were creating a new Agent per request, causing significant GC pressure. A single cached agent per protocol (HTTP/HTTPS) is now reused across all handler instances.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
