### PR TITLE
perf(node-http-handler): avoid array allocation in header transform

### DIFF
--- a/.changeset/dirty-otters-add.md
+++ b/.changeset/dirty-otters-add.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Avoid array allocation in header transform

--- a/packages/node-http-handler/src/get-transformed-headers.ts
+++ b/packages/node-http-handler/src/get-transformed-headers.ts
@@ -4,7 +4,7 @@ import type { IncomingHttpHeaders } from "node:http2";
 const getTransformedHeaders = (headers: IncomingHttpHeaders) => {
   const transformedHeaders: HeaderBag = {};
 
-  for (const name of Object.keys(headers)) {
+  for (const name in headers) {
     const headerValues = <string>headers[name];
     transformedHeaders[name] = Array.isArray(headerValues) ? headerValues.join(",") : headerValues;
   }


### PR DESCRIPTION
*Issue #, if available:*

Improving HttpHandler performance before benchmarking with [undici handler](https://github.com/trivikr/trivikr-test-undici-http-handler)

*Description of changes:*

Use for...in instead of Object.keys() to iterate response headers, eliminating an intermediate array allocation on every response.

Verified that there are no other occurrences of Object.keys/values/entries in handler source code 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
