### PR TITLE
feat(node-http-handler): pass opts to http2.connect

### DIFF
--- a/.changeset/metal-flowers-guess.md
+++ b/.changeset/metal-flowers-guess.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Support passing options through to Node's http2.connect

--- a/packages/node-http-handler/src/node-http2-connection-manager.ts
+++ b/packages/node-http-handler/src/node-http2-connection-manager.ts
@@ -1,4 +1,4 @@
-import http2 from "node:http2";
+import http2, { type ClientHttp2Session, type ClientSessionOptions, type SecureClientSessionOptions } from "node:http2";
 import type {
   ConnectConfiguration,
   ConnectionManager,
@@ -18,6 +18,7 @@ import { NodeHttp2ConnectionPool } from "./node-http2-connection-pool";
  */
 export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2SessionRef> {
   private config: ConnectionManagerConfiguration;
+  private connectOptions?: Partial<SecureClientSessionOptions | ClientSessionOptions>;
   private readonly connectionPools: Map<string, NodeHttp2ConnectionPool> = new Map<string, NodeHttp2ConnectionPool>();
 
   constructor(config: ConnectionManagerConfiguration) {
@@ -44,7 +45,7 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
       }
     }
 
-    const ref = new ClientHttp2SessionRef(http2.connect(url));
+    const ref = new ClientHttp2SessionRef(this.connect(url));
     const session = ref.deref();
 
     if (this.config.maxConcurrency) {
@@ -99,7 +100,7 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
     connectionConfiguration: ConnectConfiguration
   ): ClientHttp2SessionRef {
     const url = this.getUrlString(requestContext);
-    const ref = new ClientHttp2SessionRef(http2.connect(url));
+    const ref = new ClientHttp2SessionRef(this.connect(url));
     const session = ref.deref();
 
     session.settings({ maxConcurrentStreams: 1 });
@@ -146,6 +147,12 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
 
   public setDisableConcurrentStreams(disableConcurrentStreams: boolean) {
     this.config.disableConcurrency = disableConcurrentStreams;
+  }
+
+  public setNodeHttp2ConnectOptions(
+    nodeHttp2ConnectOptions: Partial<SecureClientSessionOptions | ClientSessionOptions>
+  ) {
+    this.connectOptions = nodeHttp2ConnectOptions;
   }
 
   /**
@@ -195,5 +202,9 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
 
   private getUrlString(request: RequestContext): string {
     return request.destination.toString();
+  }
+
+  private connect(url: string): ClientHttp2Session {
+    return this.connectOptions === undefined ? http2.connect(url) : http2.connect(url, this.connectOptions);
   }
 }

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -903,4 +903,27 @@ describe(NodeHttp2Handler.name, () => {
       handler.destroy();
     });
   });
+
+  describe("nodeHttp2ConnectOptions", () => {
+    it("passes nodeHttp2ConnectOptions to http2.connect", async () => {
+      const handler = new NodeHttp2Handler({ nodeHttp2ConnectOptions: { maxSessionMemory: 64 } });
+      const connectSpy = vi.spyOn(http2, "connect");
+      await handler.handle(new HttpRequest(getMockReqOptions()), {});
+      expect(connectSpy).toHaveBeenCalledWith(authority, { maxSessionMemory: 64 });
+      handler.destroy();
+    });
+
+    it("passes nodeHttp2ConnectOptions to http2.connect for isolated sessions", async () => {
+      const handler = new NodeHttp2Handler({
+        disableConcurrentStreams: true,
+        nodeHttp2ConnectOptions: { maxSessionMemory: 64 },
+      });
+      const connectSpy = vi.spyOn(http2, "connect");
+
+      await handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+      expect(connectSpy).toHaveBeenCalledWith(authority, { maxSessionMemory: 64 });
+      handler.destroy();
+    });
+  });
 });

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -1,4 +1,4 @@
-import { constants } from "node:http2";
+import { constants, type ClientSessionOptions, type SecureClientSessionOptions } from "node:http2";
 import { HttpResponse, buildQueryString, type HttpHandler, type HttpRequest } from "@smithy/core/protocols";
 import type { HttpHandlerOptions, Provider, RequestContext } from "@smithy/types";
 
@@ -40,6 +40,12 @@ export interface NodeHttp2HandlerOptions {
    * https://nodejs.org/api/http2.html#class-http2stream
    */
   maxConcurrentStreams?: number;
+
+  /**
+   * A set of raw options that will be passed to http2.connect.
+   * https://nodejs.org/api/http2.html#http2connectauthority-options-listener
+   */
+  nodeHttp2ConnectOptions?: Partial<SecureClientSessionOptions | ClientSessionOptions>;
 }
 
 /**
@@ -106,11 +112,14 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
   ): Promise<{ response: HttpResponse }> {
     if (!this.config) {
       this.config = await this.configProvider;
-      const { disableConcurrentStreams, maxConcurrentStreams } = this.config;
+      const { disableConcurrentStreams, maxConcurrentStreams, nodeHttp2ConnectOptions } = this.config;
 
       this.connectionManager.setDisableConcurrentStreams(disableConcurrentStreams ?? false);
       if (maxConcurrentStreams) {
         this.connectionManager.setMaxConcurrentStreams(maxConcurrentStreams);
+      }
+      if (nodeHttp2ConnectOptions) {
+        this.connectionManager.setNodeHttp2ConnectOptions(nodeHttp2ConnectOptions);
       }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#1996 

*Description of changes:*
This adds the ability to pass raw options such as maxSessionMemory from NodeHttp2HandlerOptions through to http2.connect.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
