### PR TITLE
fix(core/client): fix for waiter 403 warning with no observed responses

### DIFF
--- a/.changeset/quiet-waiters-warn.md
+++ b/.changeset/quiet-waiters-warn.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Avoid throwing from waiter 403 warning checks when no responses have been observed.

--- a/packages/core/src/submodules/client/util-waiter/poller.spec.ts
+++ b/packages/core/src/submodules/client/util-waiter/poller.spec.ts
@@ -239,6 +239,45 @@ describe(runPolling.name, () => {
     nowMock.mockReset();
   });
 
+  it("should not warn or throw when polling exceeds 60s without observed responses", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Simulate time: start at T=0, each Date.now() call advances 20s.
+    // This ensures we cross the 60s warn403Time threshold after a few polls.
+    let now = 1_000_000;
+    const nowMock = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(now) // waitUntil
+      .mockImplementation(() => {
+        const rtn = now;
+        now += 20_000;
+        return rtn;
+      });
+
+    const localConfig = {
+      ...config,
+      minDelay: 2,
+      maxDelay: 2,
+      maxWaitTime: 300,
+      client: { config: {} },
+    } as WaiterOptions<any>;
+
+    mockAcceptorChecks = vi
+      .fn()
+      .mockResolvedValueOnce(retryState) // initial check
+      .mockResolvedValueOnce(retryState) // poll 1
+      .mockResolvedValueOnce(retryState) // poll 2
+      .mockResolvedValueOnce({ state: WaiterState.SUCCESS, reason: { $metadata: { httpStatusCode: 200 } } });
+
+    await expect(runPolling(localConfig, input, mockAcceptorChecks)).resolves.toMatchObject({
+      state: WaiterState.SUCCESS,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    nowMock.mockReset();
+  });
+
   it("should truncate delay to fire a last poll before timeout", async () => {
     // Use real-ish time: start at T=0, advance 1s per Date.now() call.
     let now = 1_000_000;

--- a/packages/core/src/submodules/client/util-waiter/poller.ts
+++ b/packages/core/src/submodules/client/util-waiter/poller.ts
@@ -89,7 +89,7 @@ const checkWarn403 = (observedResponses: Record<string, number> = {}, client: an
       ? clientLogger
       : console;
 
-  if (count403 >= 3 || orderedErrors[orderedErrors.length - 1].startsWith("403:")) {
+  if (count403 >= 3 || orderedErrors[orderedErrors.length - 1]?.startsWith("403:")) {
     warningLogger.warn(`@smithy/util-waiter WARN - 403 status code encountered during waiter polling.`);
   }
 };


### PR DESCRIPTION
*Issue #, if available:*

Closes #2011

*Description of changes:*

This fixes a crash in the waiter 403 warning path when a waiter has been polling for more than 60 seconds but has not observed any response reasons.

`WaiterResult.reason` is optional, so a custom waiter can validly return `WaiterState.RETRY` without a reason while a resource is still in a normal in-progress state. In that case, `observedResponses` stays empty. The existing 403 warning check then tried to call `.startsWith()` on the last observed response key, which is `undefined` when no responses have been observed.

The fix uses optional chaining for the last observed response check, preserving the existing warning behavior for observed 403s while avoiding a `TypeError` when there are no observed responses. A regression test covers polling past the 60 second warning threshold with retry results that do not include a reason.

Since this modifies `@smithy/core`, this PR includes a patch changeset.

Validation:

- `yarn build`
- `yarn workspace @smithy/core test src/submodules/client/util-waiter/poller.spec.ts`
- `yarn workspace @smithy/core build`
- `yarn workspace @smithy/core test`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
