### PR TITLE
fix(codegen): correct source package for compression plugin

### DIFF
--- a/private/my-local-model-schema/test/functional/rpcv2cbor.spec.ts
+++ b/private/my-local-model-schema/test/functional/rpcv2cbor.spec.ts
@@ -4,9 +4,9 @@ import { afterAll, expect, test as it } from "vitest";
 import { GetNumbersCommand } from "../../src/commands/GetNumbersCommand";
 import { HttpLabelCommandCommand } from "../../src/commands/HttpLabelCommandCommand";
 import { XYZServiceClient } from "../../src/XYZServiceClient";
-import type { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
-import { type HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "node:stream";
+import { HttpRequest, HttpResponse, type HttpHandler } from "@smithy/core/protocols";
+import type { Endpoint, HeaderBag, HttpHandlerOptions } from "@smithy/types";
 
 /**
  * Throws an expected exception that contains the serialized request.

--- a/private/my-local-model/test/functional/rpcv2cbor.spec.ts
+++ b/private/my-local-model/test/functional/rpcv2cbor.spec.ts
@@ -4,9 +4,9 @@ import { afterAll, expect, test as it } from "vitest";
 import { GetNumbersCommand } from "../../src/commands/GetNumbersCommand";
 import { HttpLabelCommandCommand } from "../../src/commands/HttpLabelCommandCommand";
 import { XYZServiceClient } from "../../src/XYZServiceClient";
-import type { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
-import { type HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "node:stream";
+import { HttpRequest, HttpResponse, type HttpHandler } from "@smithy/core/protocols";
+import type { Endpoint, HeaderBag, HttpHandlerOptions } from "@smithy/types";
 
 /**
  * Throws an expected exception that contains the serialized request.

--- a/private/smithy-rpcv2-cbor-schema/test/functional/rpcv2cbor.spec.ts
+++ b/private/smithy-rpcv2-cbor-schema/test/functional/rpcv2cbor.spec.ts
@@ -16,9 +16,9 @@ import { RpcV2CborSparseMapsCommand } from "../../src/commands/RpcV2CborSparseMa
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
 import { SparseNullsOperationCommand } from "../../src/commands/SparseNullsOperationCommand";
 import { RpcV2ProtocolClient } from "../../src/RpcV2ProtocolClient";
-import type { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
-import { type HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "node:stream";
+import { HttpRequest, HttpResponse, type HttpHandler } from "@smithy/core/protocols";
+import type { Endpoint, HeaderBag, HttpHandlerOptions } from "@smithy/types";
 
 /**
  * Throws an expected exception that contains the serialized request.

--- a/private/smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
+++ b/private/smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
@@ -16,9 +16,9 @@ import { RpcV2CborSparseMapsCommand } from "../../src/commands/RpcV2CborSparseMa
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
 import { SparseNullsOperationCommand } from "../../src/commands/SparseNullsOperationCommand";
 import { RpcV2ProtocolClient } from "../../src/RpcV2ProtocolClient";
-import type { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
-import { type HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "node:stream";
+import { HttpRequest, HttpResponse, type HttpHandler } from "@smithy/core/protocols";
+import type { Endpoint, HeaderBag, HttpHandlerOptions } from "@smithy/types";
 
 /**
  * Throws an expected exception that contains the serialized request.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -382,7 +382,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private Symbol.Builder addSmithyUseImport(Symbol.Builder builder, String name, String as) {
-        Symbol importSymbol = Symbol.builder().name(name).namespace("@smithy/smithy-client", "/").build();
+        Symbol importSymbol = Symbol.builder().name(name).namespace("@smithy/core/serde", "/").build();
         SymbolReference reference = SymbolReference.builder()
             .symbol(importSymbol)
             .alias(as)

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddCompressionDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddCompressionDependency.java
@@ -50,37 +50,31 @@ public final class AddCompressionDependency implements TypeScriptIntegration {
                 return MapUtils.of(
                     "disableRequestCompression",
                     writer -> {
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
                         writer.addImportSubmodule(
                             "loadConfig",
                             "loadNodeConfig",
                             TypeScriptDependency.SMITHY_CORE,
                             SmithyCoreSubmodules.CONFIG
                         );
-                        writer.addImportSubmodule(
+                        writer.addImport(
                             "NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS",
                             null,
-                            TypeScriptDependency.SMITHY_CORE,
-                            SmithyCoreSubmodules.PROTOCOLS
+                            TypeScriptDependency.MIDDLEWARE_COMPRESSION
                         );
                         writer.write("loadNodeConfig(NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS, config)");
                     },
                     "requestMinCompressionSizeBytes",
                     writer -> {
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
                         writer.addImportSubmodule(
                             "loadConfig",
                             "loadNodeConfig",
                             TypeScriptDependency.SMITHY_CORE,
                             SmithyCoreSubmodules.CONFIG
                         );
-                        writer.addImportSubmodule(
+                        writer.addImport(
                             "NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS",
                             null,
-                            TypeScriptDependency.SMITHY_CORE,
-                            SmithyCoreSubmodules.PROTOCOLS
+                            TypeScriptDependency.MIDDLEWARE_COMPRESSION
                         );
                         writer.write(
                             "loadNodeConfig(NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS, config)"
@@ -91,23 +85,19 @@ public final class AddCompressionDependency implements TypeScriptIntegration {
                 return MapUtils.of(
                     "disableRequestCompression",
                     writer -> {
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
-                        writer.addImportSubmodule(
+                        writer.addImport(
                             "DEFAULT_DISABLE_REQUEST_COMPRESSION",
                             null,
-                            TypeScriptDependency.SMITHY_CORE,
-                            SmithyCoreSubmodules.PROTOCOLS
+                            TypeScriptDependency.MIDDLEWARE_COMPRESSION
                         );
                         writer.write("DEFAULT_DISABLE_REQUEST_COMPRESSION");
                     },
                     "requestMinCompressionSizeBytes",
                     writer -> {
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
-                        writer.addImportSubmodule(
+                        writer.addImport(
                             "DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES",
                             null,
-                            TypeScriptDependency.SMITHY_CORE,
-                            SmithyCoreSubmodules.PROTOCOLS
+                            TypeScriptDependency.MIDDLEWARE_COMPRESSION
                         );
                         writer.write("DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES");
                     }
@@ -122,8 +112,7 @@ public final class AddCompressionDependency implements TypeScriptIntegration {
         return ListUtils.of(
             RuntimeClientPlugin.builder()
                 .withConventions(
-                    "@smithy/core/protocols",
-                    TypeScriptDependency.SMITHY_CORE.dependency.getVersion(),
+                    TypeScriptDependency.MIDDLEWARE_COMPRESSION.dependency,
                     "Compression",
                     RuntimeClientPlugin.Convention.HAS_CONFIG
                 )
@@ -131,8 +120,7 @@ public final class AddCompressionDependency implements TypeScriptIntegration {
                 .build(),
             RuntimeClientPlugin.builder()
                 .withConventions(
-                    "@smithy/core/protocols",
-                    TypeScriptDependency.SMITHY_CORE.dependency.getVersion(),
+                    TypeScriptDependency.MIDDLEWARE_COMPRESSION.dependency,
                     "Compression",
                     RuntimeClientPlugin.Convention.HAS_MIDDLEWARE
                 )

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.ts
@@ -1,8 +1,8 @@
 // derived from https://github.com/aws/aws-sdk-js-v3/blob/e35f78c97fa6710ff9c444351893f0f06755e771/packages/middleware-endpoint-discovery/src/endpointDiscoveryMiddleware.ts
 
-import { HttpRequest } from "@smithy/protocol-http";
+import { normalizeProvider } from "@smithy/core/client";
+import { HttpRequest } from "@smithy/core/protocols";
 import { BuildMiddleware, Pluggable, Provider, RelativeMiddlewareOptions } from "@smithy/types";
-import { normalizeProvider } from "@smithy/util-middleware";
 
 interface HttpApiKeyAuthMiddlewareConfig {
   /**
@@ -51,7 +51,7 @@ export interface HttpApiKeyAuthResolvedConfig {
 // or resolveFunction are set, then all of inputConfig, resolvedConfig, and
 // resolveFunction must be set."
 export function resolveHttpApiKeyAuthConfig<T>(
-  input: T & ApiKeyPreviouslyResolved & HttpApiKeyAuthInputConfig,
+  input: T & ApiKeyPreviouslyResolved & HttpApiKeyAuthInputConfig
 ): T & HttpApiKeyAuthResolvedConfig {
   return {
     ...input,
@@ -75,7 +75,7 @@ export function resolveHttpApiKeyAuthConfig<T>(
 export const httpApiKeyAuthMiddleware =
   <Input extends object, Output extends object>(
     pluginConfig: HttpApiKeyAuthResolvedConfig,
-    middlewareConfig: HttpApiKeyAuthMiddlewareConfig,
+    middlewareConfig: HttpApiKeyAuthMiddlewareConfig
   ): BuildMiddleware<Input, Output> =>
   (next) =>
   async (args) => {
@@ -122,12 +122,12 @@ export const httpApiKeyAuthMiddlewareOptions: RelativeMiddlewareOptions = {
 
 export const getHttpApiKeyAuthPlugin = (
   pluginConfig: HttpApiKeyAuthResolvedConfig,
-  middlewareConfig: HttpApiKeyAuthMiddlewareConfig,
+  middlewareConfig: HttpApiKeyAuthMiddlewareConfig
 ): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.addRelativeTo(
       httpApiKeyAuthMiddleware(pluginConfig, middlewareConfig),
-      httpApiKeyAuthMiddlewareOptions,
+      httpApiKeyAuthMiddlewareOptions
     );
   },
 });

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -1,6 +1,6 @@
-import type { HttpHandlerOptions, HeaderBag, Endpoint } from "@smithy/types";
-import { type HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "node:stream";
+import { HttpRequest, HttpResponse, type HttpHandler } from "@smithy/core/protocols";
+import type { Endpoint, HeaderBag, HttpHandlerOptions } from "@smithy/types";
 
 /**
  * Throws an expected exception that contains the serialized request.


### PR DESCRIPTION
Compression config options (NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS, etc.) were incorrectly imported from @smithy/core/protocols. They belong to @smithy/middleware-compression.