### PR TITLE
fix(core/serde): uuid generation compatible with minimum Node.js version

### DIFF
--- a/.changeset/cyan-bats-chew.md
+++ b/.changeset/cyan-bats-chew.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix for uuid generation in Node.js 18.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: "yarn"
 
       - name: Set up JDK ${{ matrix.java }}
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: "yarn"
       - name: Install dependencies
         run: yarn
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [18, 20, 22, 24, 26]
 
     steps:
       - uses: actions/checkout@v5
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: "yarn"
       - name: Install dependencies
         run: |
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: "yarn"
       - name: Install dependencies
         run: yarn
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: "yarn"
       - name: Install
         run: yarn

--- a/packages/core/src/submodules/serde/generateIdempotencyToken.spec.ts
+++ b/packages/core/src/submodules/serde/generateIdempotencyToken.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test as it } from "vitest";
 
-import { generateIdempotencyToken } from "./generateIdempotencyToken";
+import { generateIdempotencyToken } from "./index";
 
 describe("generateIdempotencyToken", () => {
   // This test is not meaningful when using uuid v4 as an external package, but

--- a/packages/core/src/submodules/serde/generateIdempotencyToken.ts
+++ b/packages/core/src/submodules/serde/generateIdempotencyToken.ts
@@ -1,3 +1,0 @@
-import { v4 as generateIdempotencyToken } from "./uuid/v4";
-
-export { generateIdempotencyToken };

--- a/packages/core/src/submodules/serde/index.browser.ts
+++ b/packages/core/src/submodules/serde/index.browser.ts
@@ -1,3 +1,5 @@
+import { bindV4 } from "./uuid/v4";
+
 const no = Symbol.for("node-only");
 
 export { copyDocumentWithTransform } from "./copyDocumentWithTransform";
@@ -8,7 +10,6 @@ export {
   parseRfc7231DateTime,
   parseEpochTimestamp,
 } from "./date-utils";
-export { generateIdempotencyToken } from "./generateIdempotencyToken";
 export { LazyJsonString, type AutomaticJsonStringConversion } from "./lazy-json";
 export {
   logger,
@@ -94,4 +95,6 @@ export { splitStream } from "./util-stream/splitStream.browser";
 export { isReadableStream, isBlob } from "./util-stream/stream-type-check";
 
 // @smithy/uuid
-export { v4 } from "./uuid/v4";
+const _getRandomValues = (array: Uint8Array) => crypto.getRandomValues(array);
+export const v4 = bindV4(_getRandomValues);
+export const generateIdempotencyToken = v4;

--- a/packages/core/src/submodules/serde/index.native.ts
+++ b/packages/core/src/submodules/serde/index.native.ts
@@ -1,3 +1,5 @@
+import { bindV4 } from "./uuid/v4";
+
 const no = Symbol.for("node-only");
 
 export { copyDocumentWithTransform } from "./copyDocumentWithTransform";
@@ -8,7 +10,6 @@ export {
   parseRfc7231DateTime,
   parseEpochTimestamp,
 } from "./date-utils";
-export { generateIdempotencyToken } from "./generateIdempotencyToken";
 export { LazyJsonString, type AutomaticJsonStringConversion } from "./lazy-json";
 export {
   logger,
@@ -94,4 +95,6 @@ export { splitStream } from "./util-stream/splitStream.browser";
 export { isReadableStream, isBlob } from "./util-stream/stream-type-check";
 
 // @smithy/uuid
-export { v4 } from "./uuid/v4";
+const _getRandomValues = (array: Uint8Array) => crypto.getRandomValues(array);
+export const v4 = bindV4(_getRandomValues);
+export const generateIdempotencyToken = v4;

--- a/packages/core/src/submodules/serde/index.ts
+++ b/packages/core/src/submodules/serde/index.ts
@@ -1,3 +1,7 @@
+import { getRandomValues } from "node:crypto";
+
+import { bindV4 } from "./uuid/v4";
+
 export { copyDocumentWithTransform } from "./copyDocumentWithTransform";
 export {
   dateToUtcString,
@@ -6,7 +10,6 @@ export {
   parseRfc7231DateTime,
   parseEpochTimestamp,
 } from "./date-utils";
-export { generateIdempotencyToken } from "./generateIdempotencyToken";
 export { LazyJsonString, type AutomaticJsonStringConversion } from "./lazy-json";
 export {
   logger,
@@ -92,4 +95,6 @@ export { splitStream } from "./util-stream/splitStream";
 export { isReadableStream, isBlob } from "./util-stream/stream-type-check";
 
 // @smithy/uuid
-export { v4 } from "./uuid/v4";
+const _getRandomValues = getRandomValues as (array: Uint8Array) => Uint8Array;
+export const v4 = bindV4(_getRandomValues);
+export const generateIdempotencyToken = v4;

--- a/packages/core/src/submodules/serde/uuid/randomUUID.ts
+++ b/packages/core/src/submodules/serde/uuid/randomUUID.ts
@@ -1,4 +1,0 @@
-export const randomUUID =
-  typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-    ? (crypto.randomUUID.bind(crypto) as typeof crypto.randomUUID)
-    : undefined;

--- a/packages/core/src/submodules/serde/uuid/v4.spec.ts
+++ b/packages/core/src/submodules/serde/uuid/v4.spec.ts
@@ -1,48 +1,55 @@
 import { getRandomValues } from "node:crypto";
-import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
+import { afterEach, describe, expect, test as it, vi } from "vitest";
 
-describe("randomUUID", () => {
+import { bindV4 } from "./v4";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("v4", () => {
   afterEach(() => {
-    vi.resetModules();
+    vi.restoreAllMocks();
   });
 
-  it("should call native randomUUID when available", async () => {
-    const mockUUID = "mocked-uuid";
-    const nativeRandomUUID = vi.fn(() => mockUUID);
-    vi.doMock("./randomUUID", () => ({ randomUUID: nativeRandomUUID }));
+  it("should call native crypto.randomUUID when available", () => {
+    const mockUUID = "mocked-uuid-value";
+    vi.stubGlobal("crypto", { randomUUID: vi.fn(() => mockUUID), getRandomValues });
 
-    const { v4 } = await import("./v4");
+    const v4 = bindV4(getRandomValues as (array: Uint8Array) => Uint8Array);
     const uuid = v4();
 
-    expect(nativeRandomUUID).toHaveBeenCalled();
+    expect(crypto.randomUUID).toHaveBeenCalled();
     expect(uuid).toBe(mockUUID);
   });
 
   describe("when native randomUUID is not available", () => {
-    let v4: any;
-    const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    it("falls back to getRandomValues", () => {
+      vi.stubGlobal("crypto", { getRandomValues });
 
-    beforeEach(async () => {
-      vi.doMock("./randomUUID", () => ({ randomUUID: undefined }));
-      v4 = (await import("./v4")).v4;
-
-      // Simulate crypto.getRandomValues in test, as it's expected to be available
-      Object.defineProperty(global, "crypto", {
-        value: {
-          getRandomValues: getRandomValues,
-        },
-        configurable: true,
+      const mockGetRandomValues = vi.fn((array: Uint8Array) => {
+        getRandomValues(array);
+        return array;
       });
+      const v4 = bindV4(mockGetRandomValues);
+
+      const uuid = v4();
+
+      expect(mockGetRandomValues).toHaveBeenCalledWith(expect.any(Uint8Array));
+      expect(uuid).toMatch(UUID_REGEX);
     });
 
     it("each generation is unique and matches regex", () => {
-      const uuids = new Set();
+      vi.stubGlobal("crypto", { getRandomValues });
+
+      const v4 = bindV4(getRandomValues as (array: Uint8Array) => Uint8Array);
+      const uuids = new Set<string>();
       const iterations = 10_000;
+
       for (let i = 0; i < iterations; i++) {
         const uuid = v4();
         expect(uuid).toMatch(UUID_REGEX);
         uuids.add(uuid);
       }
+
       expect(uuids.size).toBe(iterations);
     });
   });

--- a/packages/core/src/submodules/serde/uuid/v4.ts
+++ b/packages/core/src/submodules/serde/uuid/v4.ts
@@ -1,57 +1,63 @@
-import { randomUUID } from "./randomUUID";
-
 const decimalToHex = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, "0"));
 
 /**
- * Generates a RFC4122 version 4 UUID
+ * @internal
+ */
+export type GetRandomValues = (array: Uint8Array) => Uint8Array;
+
+/**
+ * Creates a RFC4122 version 4 UUID generator.
  *
- * This function generates a random UUID using one of two methods:
- * 1. The native randomUUID() function if available
- * 2. A fallback implementation using crypto.getRandomValues()
+ * Uses the native crypto.randomUUID() if available, otherwise falls back
+ * to a manual implementation using the provided getRandomValues function.
  *
  * The fallback implementation:
- * - Generates 16 random bytes using crypto.getRandomValues()
+ * - Generates 16 random bytes using getRandomValues()
  * - Sets the version bits to indicate version 4
  * - Sets the variant bits to indicate RFC4122
  * - Formats the bytes as a UUID string with dashes
  *
- * @returns A version 4 UUID string in the format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+ * @param getRandomValues - platform-specific random byte source.
+ * @returns A function that generates version 4 UUID strings
+ * in the format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
  * where x is any hexadecimal digit and y is one of 8, 9, a, or b.
  *
  * @internal
  */
-export const v4 = () => {
-  if (randomUUID) {
-    return randomUUID();
+export function bindV4(getRandomValues: GetRandomValues) {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return () => crypto.randomUUID();
   }
 
-  const rnds = new Uint8Array(16);
-  crypto.getRandomValues(rnds);
+  return (): string => {
+    const rnds = new Uint8Array(16);
+    getRandomValues(rnds);
 
-  // Set version (4) and variant (RFC4122)
-  rnds[6] = (rnds[6] & 0x0f) | 0x40; // version 4
-  rnds[8] = (rnds[8] & 0x3f) | 0x80; // variant
+    // Set version (4) and variant (RFC4122)
+    rnds[6] = (rnds[6] & 0x0f) | 0x40; // version 4
+    rnds[8] = (rnds[8] & 0x3f) | 0x80; // variant
 
-  return (
-    decimalToHex[rnds[0]] +
-    decimalToHex[rnds[1]] +
-    decimalToHex[rnds[2]] +
-    decimalToHex[rnds[3]] +
-    "-" +
-    decimalToHex[rnds[4]] +
-    decimalToHex[rnds[5]] +
-    "-" +
-    decimalToHex[rnds[6]] +
-    decimalToHex[rnds[7]] +
-    "-" +
-    decimalToHex[rnds[8]] +
-    decimalToHex[rnds[9]] +
-    "-" +
-    decimalToHex[rnds[10]] +
-    decimalToHex[rnds[11]] +
-    decimalToHex[rnds[12]] +
-    decimalToHex[rnds[13]] +
-    decimalToHex[rnds[14]] +
-    decimalToHex[rnds[15]]
-  );
-};
+    return (
+      decimalToHex[rnds[0]] +
+      decimalToHex[rnds[1]] +
+      decimalToHex[rnds[2]] +
+      decimalToHex[rnds[3]] +
+      "-" +
+      decimalToHex[rnds[4]] +
+      decimalToHex[rnds[5]] +
+      "-" +
+      decimalToHex[rnds[6]] +
+      decimalToHex[rnds[7]] +
+      "-" +
+      decimalToHex[rnds[8]] +
+      decimalToHex[rnds[9]] +
+      "-" +
+      decimalToHex[rnds[10]] +
+      decimalToHex[rnds[11]] +
+      decimalToHex[rnds[12]] +
+      decimalToHex[rnds[13]] +
+      decimalToHex[rnds[14]] +
+      decimalToHex[rnds[15]]
+    );
+  };
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/smithy-lang/smithy-typescript/issues/2022

*Description of changes:*

use dependency injection pattern for UUID generation to support Node.js 18.x. Although new SDK clients no longer support that version, this major version of smithy/core goes back to all Node.js 18.x clients.
