### PR TITLE
fix(core/schema): allow shape id lookup to match without namespace if only 1 candidate

### DIFF
--- a/.changeset/few-baboons-care.md
+++ b/.changeset/few-baboons-care.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+retrieve schemas with matching shape name if unambiguous

--- a/packages/core/src/submodules/schema/TypeRegistry.spec.ts
+++ b/packages/core/src/submodules/schema/TypeRegistry.spec.ts
@@ -46,6 +46,27 @@ describe(TypeRegistry.name, () => {
     expect(tr.getBaseException()).toBe(err);
   });
 
+  describe("unqualified shapeId lookup", () => {
+    it("resolves an unqualified name when there is exactly one matching schema", () => {
+      const tr = TypeRegistry.for("com.unrelated");
+      tr.register("com.example#MyShape", List);
+      expect(tr.getSchema("MyShape")).toBe(List);
+    });
+
+    it("throws when an unqualified name matches multiple schemas", () => {
+      const tr = TypeRegistry.for("com.unrelated");
+      tr.register("com.example#Ambiguous", List);
+      tr.register("com.other#Ambiguous", Map);
+      expect(() => tr.getSchema("Ambiguous")).toThrow("schema not found");
+    });
+
+    it("throws when an unqualified name matches no schemas", () => {
+      const tr = TypeRegistry.for("com.unrelated");
+      tr.register("com.example#Exists", List);
+      expect(() => tr.getSchema("DoesNotExist")).toThrow("schema not found");
+    });
+  });
+
   describe("composition", () => {
     it("can be composed", () => {
       const tr1 = TypeRegistry.for("namespace");

--- a/packages/core/src/submodules/schema/TypeRegistry.ts
+++ b/packages/core/src/submodules/schema/TypeRegistry.ts
@@ -67,6 +67,18 @@ export class TypeRegistry {
   public getSchema(shapeId: string): ISchema {
     const id = this.normalizeShapeId(shapeId);
     if (!this.schemas.has(id)) {
+      if (!shapeId.includes("#")) {
+        const suffix = "#" + shapeId;
+        const candidates: ISchema[] = [];
+        for (const [shapeId, schema] of this.schemas.entries()) {
+          if (shapeId.endsWith(suffix)) {
+            candidates.push(schema);
+          }
+        }
+        if (candidates.length === 1) {
+          return candidates[0];
+        }
+      }
       throw new Error(`@smithy/core/schema - schema not found for ${id}`);
     }
     return this.schemas.get(id)!;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/smithy-lang/smithy-typescript/issues/2008

*Description of changes:*

Within a type registry instance, if a lookup request arrives with only a shape name, return a schema if it matches by name even if it is not part of the default namespace of the registry.