### PR TITLE
fix(types): exclude SharedArrayBuffer from recursive type transform

### DIFF
--- a/.changeset/wise-pillows-lie.md
+++ b/.changeset/wise-pillows-lie.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+fix(types): exclude SharedArrayBuffer from recursive type transform

--- a/packages/types/src/transform/type-transform.spec.ts
+++ b/packages/types/src/transform/type-transform.spec.ts
@@ -21,6 +21,21 @@ type A = {
   const assert3: Exact<T["nested"]["nested"]["nested"]["b"], "enum"> = true as const;
 }
 
+// It should not recurse into SharedArrayBuffer.
+type B = {
+  typed: SharedArrayBuffer;
+  untyped: {
+    byteLength: number;
+  };
+};
+
+// Transform targets number, which is a sub-property type of SharedArrayBuffer (e.g. byteLength).
+// If recursion occurred, SharedArrayBuffer's byteLength would be transformed.
+type T = Transform<B, number, string>;
+
+const assert1: Exact<T["typed"]["byteLength"], number> = true as const;
+const assert2: Exact<T["untyped"]["byteLength"], string> = true as const;
+
 {
   // the downlevel should function similarly
   type T = DownlevelTransform<A, number | string, "enum">;

--- a/packages/types/src/transform/type-transform.ts
+++ b/packages/types/src/transform/type-transform.ts
@@ -16,21 +16,30 @@ export type Transform<T, FromType, ToType> = ConditionalRecursiveTransformExact<
 type TransformExact<T, FromType, ToType> = [T] extends [FromType] ? ([FromType] extends [T] ? ToType : T) : T;
 
 /**
+ * Types excluded from recursive transformation to avoid circular references.
+ *
+ * @internal
+ */
+type ExcludedTransformTypes = SharedArrayBuffer;
+
+/**
  * Applies TransformExact to members of an object recursively.
  *
  * @internal
  */
 type RecursiveTransformExact<T, FromType, ToType> = T extends Function
   ? T
-  : T extends object
-    ? {
-        [key in keyof T]: [T[key]] extends [FromType]
-          ? [FromType] extends [T[key]]
-            ? ToType
-            : ConditionalRecursiveTransformExact<T[key], FromType, ToType>
-          : ConditionalRecursiveTransformExact<T[key], FromType, ToType>;
-      }
-    : TransformExact<T, FromType, ToType>;
+  : T extends ExcludedTransformTypes
+    ? T
+    : T extends object
+      ? {
+          [key in keyof T]: [T[key]] extends [FromType]
+            ? [FromType] extends [T[key]]
+              ? ToType
+              : ConditionalRecursiveTransformExact<T[key], FromType, ToType>
+            : ConditionalRecursiveTransformExact<T[key], FromType, ToType>;
+        }
+      : TransformExact<T, FromType, ToType>;
 
 /**
  * Same as RecursiveTransformExact but does not assign to an object

--- a/packages/types/tsconfig.types.json
+++ b/packages/types/tsconfig.types.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "declarationDir": "dist-types",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noCheck": false
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]


### PR DESCRIPTION
*Issue #, if available:*
Internal P428473469

*Description of changes:*
Exclude SharedArrayBuffer from recursive type transformation to prevent circular type references caused by its self-referential [Symbol.species] property.


If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
