### PR TITLE
fix(scripts): use correct folder variable name in scripts/check-deps.js

### DIFF
--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -41,10 +41,10 @@ const node_libraries = [
 
 (async () => {
   const errors = [];
-  for (const folder of fs.readdirSync(packages)) {
-    const pkgJsonPath = path.join(packages, folder, "package.json");
+  for (const packageFolder of fs.readdirSync(packages)) {
+    const pkgJsonPath = path.join(packages, packageFolder, "package.json");
     errors.push(...pkgJsonEnforcement(pkgJsonPath, true));
-    const srcPath = path.join(packages, folder, "src");
+    const srcPath = path.join(packages, packageFolder, "src");
     const pkgJson = require(pkgJsonPath);
 
     for await (const file of walk(srcPath, ["node_modules"])) {


### PR DESCRIPTION
*Issue #, if available:*

I noticed the following error when working on another PR
```console
husky > pre-commit (node v18.20.8)
/local/home/trivikr/workspace/smithy-typescript/scripts/check-dependencies.js:86
          errors.push(`${dep} incorrectly declared in devDependencies of ${packageFolder}`);
                                                                           ^

ReferenceError: packageFolder is not defined
    at /local/home/trivikr/workspace/smithy-typescript/scripts/check-dependencies.js:86:76
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

*Description of changes:*

Uses correct folder variable name in scripts/check-dependencies.js

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
