### PR TITLE
feat(node-http-handler): passes client logger to request handler in codegen

### DIFF
--- a/.changeset/three-houses-shop.md
+++ b/.changeset/three-houses-shop.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": minor
+---
+
+pass client logger to request handler

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -401,6 +401,22 @@ describe("NodeHttpHandler", () => {
 
       expect(result.httpHandlerConfigs().requestTimeout).toBe(randomRequestTimeout);
     });
+
+    it("passes client logger to the handler as fallback", async () => {
+      const clientLogger = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const result = NodeHttpHandler.create({}, clientLogger);
+      expect(result).toBeInstanceOf(NodeHttpHandler);
+      await result.handle({} as any);
+      expect((result as NodeHttpHandler).httpHandlerConfigs().logger).toBe(clientLogger);
+    });
+
+    it("does not override handler-level logger with client logger", async () => {
+      const handlerLogger = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const clientLogger = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const result = NodeHttpHandler.create({ logger: handlerLogger }, clientLogger);
+      await result.handle({} as any);
+      expect((result as NodeHttpHandler).httpHandlerConfigs().logger).toBe(handlerLogger);
+    });
   });
 
   describe("#destroy", () => {

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -50,14 +50,15 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
    * or instantiates a new instance of this handler.
    */
   public static create(
-    instanceOrOptions?: HttpHandler<any> | NodeHttpHandlerOptions | Provider<NodeHttpHandlerOptions | void>
+    instanceOrOptions?: HttpHandler<any> | NodeHttpHandlerOptions | Provider<NodeHttpHandlerOptions | void>,
+    logger?: Logger
   ) {
     if (typeof (instanceOrOptions as any)?.handle === "function") {
       // is already an instance of HttpHandler.
       return instanceOrOptions as HttpHandler<any>;
     }
     // input is ctor options or undefined.
-    return new NodeHttpHandler(instanceOrOptions as NodeHttpHandlerOptions);
+    return new NodeHttpHandler(instanceOrOptions as NodeHttpHandlerOptions, logger);
   }
 
   /**
@@ -114,16 +115,16 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
     return socketWarningTimestamp;
   }
 
-  constructor(options?: NodeHttpHandlerOptions | Provider<NodeHttpHandlerOptions | void>) {
+  constructor(options?: NodeHttpHandlerOptions | Provider<NodeHttpHandlerOptions | void>, clientLogger?: Logger) {
     this.configProvider = new Promise((resolve, reject) => {
       if (typeof options === "function") {
         options()
           .then((_options) => {
-            resolve(this.resolveDefaultConfig(_options));
+            resolve(this.resolveDefaultConfig(_options, clientLogger));
           })
           .catch(reject);
       } else {
-        resolve(this.resolveDefaultConfig(options));
+        resolve(this.resolveDefaultConfig(options, clientLogger));
       }
     });
   }
@@ -335,7 +336,10 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
     return this.config ?? {};
   }
 
-  private resolveDefaultConfig(options?: NodeHttpHandlerOptions | void): ResolvedNodeHttpHandlerConfig {
+  private resolveDefaultConfig(
+    options?: NodeHttpHandlerOptions | void,
+    clientLogger?: Logger
+  ): ResolvedNodeHttpHandlerConfig {
     const {
       requestTimeout,
       connectionTimeout,
@@ -373,7 +377,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         }
         return new hsAgent({ keepAlive, maxSockets, ...httpsAgent });
       })(),
-      logger,
+      logger: logger ?? clientLogger,
     };
   }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -47,7 +47,8 @@ final class RuntimeConfigGenerator {
         "requestHandler",
         writer -> {
             writer.addImport("NodeHttpHandler", "RequestHandler", TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
-            writer.write("RequestHandler.create(config?.requestHandler ?? defaultConfigProvider)");
+            writer.write(
+                "RequestHandler.create(config?.requestHandler ?? defaultConfigProvider, clientSharedValues.logger)");
         },
         "sha256",
         writer -> {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/6130

*Description of changes:*
`NodeHttpHandler` emits socket exhaustion and request timeout warnings via `console.warn`, even when the user sets a custom logger on the SDK client. The client's logger and the request handler are assembled independently during client construction.
- `NodeHttpHandler.create()` and the constructor now accept an optional `clientLogger` parameter. This is used as a fallback, if the user didn't explicitly set logger in the handler's own options, the client logger is used instead.
- The generated `runtimeConfig.ts` now passes `clientSharedValues.logger` as an argument to `RequestHandler.create()` 
- Precedence: handler-level logger > client-level logger > console (fallback)

*Testing*
- new unit tests
```console
RUN  v3.2.4 /../smithy-typescript
  
   ✓ packages/node-http-handler/src/node-http-handler.spec.ts (38 tests)
  61ms
  
   Test Files  1 passed (1)
        Tests  38 passed (38)
```

*Usage*
Before (warning goes to console.warn):
```
  const client = new S3Client({
    logger: myLogger,
  });
  // Socket exhaustion warning still prints to console.warn
```
  After (warning goes to myLogger.warn):
``` 
  const client = new S3Client({
    logger: myLogger,
  });
  // Socket exhaustion warning now routed through myLogger.warn
```
Output:
```
Output:
  
  [myLogger.warn] @smithy/node-http-handler:WARN - socket usage at
  capacity=50 and 100 additional requests are enqueued.
```


If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
