### PR TITLE
docs(undici-http-handler): call out performance aspects of undici

### DIFF
--- a/.changeset/afraid-swans-confess.md
+++ b/.changeset/afraid-swans-confess.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+A dummy change for automated patch release, which fixes installation issue

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://img.shields.io/npm/v/@smithy/undici-http-handler/latest.svg)](https://www.npmjs.com/package/@smithy/undici-http-handler)
 [![NPM downloads](https://img.shields.io/npm/dm/@smithy/undici-http-handler.svg)](https://www.npmjs.com/package/@smithy/undici-http-handler)
 
-Smithy-compatible HTTP handler backed by Node.js [undici][].
+Smithy-compatible HTTP handler backed by modern and high performance Node.js [undici][].
 
 ## Usage
 

--- a/packages/undici-http-handler/package.json
+++ b/packages/undici-http-handler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smithy/undici-http-handler",
   "version": "1.0.0",
-  "description": "Smithy-compatible HTTP handler backed by Node.js undici",
+  "description": "Smithy-compatible HTTP handler backed by modern and high performance Node.js undici",
   "scripts": {
     "build": "concurrently 'yarn:build:types' 'yarn:build:es:cjs'",
     "build:es:cjs": "yarn g:tsc -p tsconfig.es.json && node ../../scripts/inline undici-http-handler",


### PR DESCRIPTION
*Issue #, if available:*

This is a dummy change for publishing `@smithy/undici-http-handler@1.0.1` , as the manual publish in https://github.com/smithy-lang/smithy-typescript/pull/2029#issuecomment-4500809849 missed updating dependencies causing installation failures

```console
$ npm install @smithy/undici-http-handler --save-exact
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

*Description of changes:*

Calls out the performance aspects of undici in description and README.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
