### PR TITLE
docs(undici-http-handler): remove note about dispatcher destroy on cleanup

### DIFF
--- a/.changeset/poor-coats-reply.md
+++ b/.changeset/poor-coats-reply.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+Remove note about dispatcher destroy on cleanup

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -99,11 +99,6 @@ const client = new DynamoDB({
 client.listTables({}).then(console.log);
 ```
 
-> **Note:** When you pass a `Dispatcher` instance, the handler treats it as
-> externally owned and will not destroy it when `handler.destroy()` is called.
-> When you pass `Agent.Options`, the handler owns the created Agent and will
-> destroy it on cleanup.
-
 ## Benchmarks
 
 Our benchmark spin up a local HTTP server and runs two scenarios:


### PR DESCRIPTION
*Issue #, if available:*

Although we were not destroying customer provided agent initially, it was updated in https://github.com/smithy-lang/smithy-typescript/pull/2029#discussion_r3250574604

The README wasn't updated though.

*Description of changes:*

Remove note about dispatcher destroy on cleanup

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
