### PR TITLE
docs(undici-http-handler): custom dispatcher unlocks latest undici

### DIFF
--- a/.changeset/loud-mangos-rhyme.md
+++ b/.changeset/loud-mangos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+Document that passing a user-owned Dispatcher lets the application pin a newer undici than the one bundled with the handler, picking up upstream performance improvements (HTTP parser, connection pooling, etc.).

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -99,6 +99,11 @@ const client = new DynamoDB({
 client.listTables({}).then(console.log);
 ```
 
+> **Tip:** When you pass your own `Dispatcher`, you control which version of
+> `undici` is used. For best performance, install the latest `undici` directly
+> in your application — improvements in newer releases (HTTP parser, connection
+> pooling, etc.) will then apply to requests made through this handler.
+
 ## Benchmarks
 
 Our benchmark spin up a local HTTP server and runs two scenarios:

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -20,6 +20,10 @@ export interface UndiciHttpHandlerOptions {
   /**
    * You can pass an existing undici Dispatcher (Agent, Pool, Client, etc.)
    * or Agent.Options to have one created for you.
+   *
+   * Passing your own Dispatcher lets you control the undici version at
+   * runtime, independent of this package's bundled version. This lets
+   * you pick up upstream performance improvements sooner.
    */
   dispatcher?: Dispatcher | Agent.Options;
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Document that passing a user-owned Dispatcher lets the application pin a newer undici than the one bundled with the handler, picking up upstream performance improvements (HTTP parser, connection pooling, etc.)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
