### PR TITLE
fix(undici-http-handler): honor caller dispatcher for event streams

### DIFF
--- a/.changeset/fifty-lions-pull.md
+++ b/.changeset/fifty-lions-pull.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+Honor caller dispatcher for event streams

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -386,6 +386,14 @@ describe("UndiciHttpHandler", () => {
     });
 
     it("does not use the shared dispatcher for event stream requests", async () => {
+      handler = new UndiciHttpHandler();
+      // Internal Agent is in use here, so the isolated client path applies.
+      // Event stream goes through an isolated Client instead of the shared Agent.
+      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("routes event streams through caller-provided dispatcher", async () => {
       const mockDispatcher = {
         request: vi.fn().mockResolvedValue({
           statusCode: 200,
@@ -399,8 +407,34 @@ describe("UndiciHttpHandler", () => {
       handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
       const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
       expect(response.statusCode).toBe(200);
-      // The shared dispatcher should NOT have been called — an isolated client is used instead.
-      expect(mockDispatcher.request).not.toHaveBeenCalled();
+      // When caller supplies a Dispatcher, event streams go through it so
+      // proxy / mock / pool-sizing decisions are honored.
+      expect(mockDispatcher.request).toHaveBeenCalledOnce();
+    });
+
+    it("routes event streams through caller-provided dispatcher set via updateHttpClientConfig", async () => {
+      const mockDispatcher = {
+        request: vi.fn().mockResolvedValue({
+          statusCode: 200,
+          headers: {},
+          body: null,
+        }),
+        destroy: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler();
+      handler.updateHttpClientConfig("dispatcher", mockDispatcher);
+      await handler.handle(createMockRequest(), { isEventStream: true });
+      expect(mockDispatcher.request).toHaveBeenCalledOnce();
+    });
+
+    it("uses isolated client for event streams when Agent.Options were provided", async () => {
+      // Agent.Options means the handler created the Agent internally, so
+      // an isolated client should still be used for event streams.
+      handler = new UndiciHttpHandler({ dispatcher: { connections: 2 } });
+      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
+      expect(response.statusCode).toBe(200);
     });
 
     it("uses the shared dispatcher when isEventStream is false", async () => {
@@ -458,6 +492,40 @@ describe("UndiciHttpHandler", () => {
       );
       expect(response.statusCode).toBe(200);
       expect(response.headers["x-url"]).toContain("foo=bar");
+    });
+
+    it("propagates Agent.Options 'connect' to the isolated Client for event streams", async () => {
+      const connect = vi.fn(((opts: any, cb: any) => {
+        // Delegate to undici's default connector so the request still completes.
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { buildConnector } = require("undici");
+        const real = buildConnector({});
+        return real(opts, cb);
+      }) as any);
+
+      handler = new UndiciHttpHandler({ dispatcher: { connect } });
+      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
+      expect(response.statusCode).toBe(200);
+      expect(connect).toHaveBeenCalled();
+    });
+
+    it("strips Agent/Pool-only options ('connections', 'factory', 'maxRedirections', 'interceptors') from isolated Client", async () => {
+      // 'connections' would throw on Client.Options but is valid on Agent/Pool;
+      // verify the handler does not propagate it to the isolated Client.
+      handler = new UndiciHttpHandler({
+        dispatcher: {
+          connections: 4,
+          maxRedirections: 0,
+          factory: ((origin: any, opts: any) => {
+            // Should not be called for the isolated Client.
+            const { Pool } = require("undici");
+            return new Pool(origin, opts);
+          }) as any,
+        } as any,
+      });
+
+      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
+      expect(response.statusCode).toBe(200);
     });
   });
 
@@ -583,6 +651,25 @@ describe("UndiciHttpHandler", () => {
 
       const { response } = await handler.handle(createMockRequest());
       expect(response.statusCode).toBe(200);
+    });
+
+    it("defers Agent creation when constructed with Agent.Options", () => {
+      handler = new UndiciHttpHandler({ dispatcher: { connections: 2 } });
+      // No request made yet — dispatcher should not exist.
+      expect(handler.httpHandlerConfigs().dispatcher).toBeUndefined();
+    });
+
+    it("defers Agent creation when Agent.Options are set via updateHttpClientConfig", () => {
+      handler = new UndiciHttpHandler();
+      handler.updateHttpClientConfig("dispatcher", { connections: 2 } as any);
+      expect(handler.httpHandlerConfigs().dispatcher).toBeUndefined();
+    });
+
+    it("materializes Agent on first request when Agent.Options were provided", async () => {
+      handler = new UndiciHttpHandler({ dispatcher: { connections: 2 } });
+      expect(handler.httpHandlerConfigs().dispatcher).toBeUndefined();
+      await handler.handle(createMockRequest());
+      expect(handler.httpHandlerConfigs().dispatcher).toBeInstanceOf(Agent);
     });
 
     it("does not destroy previous dispatcher when validation fails", async () => {

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -386,11 +386,13 @@ describe("UndiciHttpHandler", () => {
     });
 
     it("does not use the shared dispatcher for event stream requests", async () => {
+      const sharedAgentRequestSpy = vi.spyOn(Agent.prototype, "request");
       handler = new UndiciHttpHandler();
       // Internal Agent is in use here, so the isolated client path applies.
       // Event stream goes through an isolated Client instead of the shared Agent.
       const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
       expect(response.statusCode).toBe(200);
+      expect(sharedAgentRequestSpy).not.toHaveBeenCalled();
     });
 
     it("routes event streams through caller-provided dispatcher", async () => {

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { HttpRequest } from "@smithy/core/protocols";
-import { Agent, type Dispatcher } from "undici";
+import { Agent, Pool, buildConnector, type Dispatcher } from "undici";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { UndiciHttpHandler } from "./undici-http-handler";
@@ -499,8 +499,6 @@ describe("UndiciHttpHandler", () => {
     it("propagates Agent.Options 'connect' to the isolated Client for event streams", async () => {
       const connect = vi.fn(((opts: any, cb: any) => {
         // Delegate to undici's default connector so the request still completes.
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { buildConnector } = require("undici");
         const real = buildConnector({});
         return real(opts, cb);
       }) as any);
@@ -520,7 +518,6 @@ describe("UndiciHttpHandler", () => {
           maxRedirections: 0,
           factory: ((origin: any, opts: any) => {
             // Should not be called for the isolated Client.
-            const { Pool } = require("undici");
             return new Pool(origin, opts);
           }) as any,
         } as any,

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -686,6 +686,19 @@ describe("UndiciHttpHandler", () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it("rejects a partial dispatcher mock that is missing close (treated as Agent.Options)", async () => {
+      // A mock with only `request` would have previously passed the duck-type
+      // check and then thrown a TypeError when updateHttpClientConfig called
+      // close() on the previous dispatcher. The tightened check now requires
+      // close/destroy too, so a partial mock is treated as Agent.Options.
+      handler = new UndiciHttpHandler();
+      const partial = { request: vi.fn() } as any;
+      // Should not throw when assigning the partial mock — it falls into the
+      // Agent.Options branch and the deferred Agent will be created lazily.
+      expect(() => handler.updateHttpClientConfig("dispatcher", partial)).not.toThrow();
+      expect(handler.httpHandlerConfigs().dispatcher).toBeUndefined();
+    });
+
     it("closes previous internal dispatcher when updating with a new Dispatcher", async () => {
       handler = new UndiciHttpHandler();
       // Trigger internal dispatcher creation

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -28,6 +28,25 @@ const isDispatcher = (value: unknown): value is Dispatcher => {
 };
 
 /**
+ * Keys present on Agent.Options or Pool.Options that are not valid on
+ * Client.Options. We strip these when propagating the caller's options
+ * to an isolated Client used for event streams.
+ */
+const AGENT_AND_POOL_ONLY_OPTION_KEYS = ["factory", "maxRedirections", "connections", "interceptors"] as const;
+
+/**
+ * Returns a Client.Options-compatible subset of the given Agent.Options by
+ * removing keys that only apply to Agent or Pool.
+ */
+const toClientOptions = (options: Agent.Options): Client.Options => {
+  const result: Record<string, unknown> = { ...options };
+  for (const key of AGENT_AND_POOL_ONLY_OPTION_KEYS) {
+    delete result[key];
+  }
+  return result as Client.Options;
+};
+
+/**
  * Options for the UndiciHttpHandler.
  *
  * @public
@@ -71,12 +90,37 @@ type EventStreamSignal = {
 export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> {
   private config: { dispatcher?: Dispatcher; logger?: Logger };
 
+  /**
+   * Tracks whether the current dispatcher was created internally by this
+   * handler (true) or supplied by the caller as a Dispatcher instance (false).
+   *
+   * When the caller supplied their own Dispatcher, event-stream requests
+   * are routed through it as well so that proxy settings, mock interceptors,
+   * and similar behaviors are honored. When we own the dispatcher, event
+   * streams get an isolated Client so a long-lived stream does not occupy
+   * a slot in the shared pool.
+   */
+  private isInternalDispatcher: boolean = true;
+
+  /**
+   * Options used to construct the internally-managed Agent, retained so they
+   * can be propagated to isolated Clients created for event streams. This
+   * preserves caller-configured TLS, connect, and timeout settings on the
+   * dedicated event-stream connection.
+   */
+  private internalAgentOptions?: Agent.Options;
+
   constructor(options?: UndiciHttpHandlerOptions) {
     if (options?.dispatcher && isDispatcher(options.dispatcher)) {
       this.config = { ...options, dispatcher: options.dispatcher };
+      this.isInternalDispatcher = false;
     } else if (options?.dispatcher) {
-      // Caller passed Agent.Options — create an Agent for them.
-      this.config = { ...options, dispatcher: new Agent({ allowH2: true, ...options.dispatcher }) };
+      // Caller passed Agent.Options — store them and defer Agent creation
+      // until the first request, so we don't pay for an unused dispatcher
+      // (e.g. when the handler is constructed but never invoked).
+      this.internalAgentOptions = { allowH2: true, ...options.dispatcher };
+      const { dispatcher: _ignored, ...rest } = options;
+      this.config = rest;
     } else {
       this.config = { ...options } as { dispatcher?: Dispatcher; logger?: Logger };
     }
@@ -91,9 +135,12 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
     request: HttpRequest,
     { abortSignal, requestTimeout, isEventStream }: HttpHandlerOptions & EventStreamSignal = {}
   ): Promise<{ response: HttpResponse }> {
-    // Use an isolated client for event streams to avoid sharing the
-    // connection pool with regular requests.
-    const isolatedClient = isEventStream ? this.createIsolatedClient(request) : undefined;
+    // Use an isolated client for event streams only when the dispatcher is
+    // internally managed. If the caller supplied their own Dispatcher, route
+    // event streams through it as well so proxy settings, mock interceptors,
+    // and pool sizing decisions made by the caller are preserved.
+    const useIsolatedClient = isEventStream && this.isInternalDispatcher;
+    const isolatedClient = useIsolatedClient ? this.createIsolatedClient(request) : undefined;
     const dispatcher = isolatedClient ?? this.getOrCreateDispatcher();
 
     if (abortSignal?.aborted) {
@@ -230,38 +277,46 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
       return;
     }
 
-    let newDispatcher: Dispatcher;
-
     if (value === undefined) {
       // Retain existing dispatcher, matching constructor behavior.
       return;
-    } else if (isDispatcher(value)) {
-      newDispatcher = value;
-    } else if (typeof value === "object" && value !== null) {
-      // Caller passed Agent.Options — create an Agent for them.
-      newDispatcher = new Agent({ allowH2: true, ...(value as Agent.Options) });
-    } else {
-      throw new Error(
-        "updateHttpClientConfig: value for 'dispatcher' must be an instance of undici Dispatcher or Agent.Options."
-      );
     }
 
-    // No-op when the same dispatcher instance is reassigned.
-    if (newDispatcher === this.config.dispatcher) {
+    if (isDispatcher(value)) {
+      // No-op when the same dispatcher instance is reassigned.
+      if (value === this.config.dispatcher) {
+        return;
+      }
+
+      const previousDispatcher = this.config.dispatcher;
+      // Close the previous dispatcher regardless of whether it was externally provided.
+      // Fire-and-forget: let in-flight requests drain without blocking.
+      if (previousDispatcher) {
+        previousDispatcher.close();
+      }
+
+      this.config.dispatcher = value;
+      this.isInternalDispatcher = false;
+      this.internalAgentOptions = undefined;
       return;
     }
 
-    // Capture the previous dispatcher before assignment.
-    const previousDispatcher = this.config.dispatcher;
+    if (typeof value === "object" && value !== null) {
+      // Caller passed Agent.Options — defer Agent creation to first request.
+      const previousDispatcher = this.config.dispatcher;
+      if (previousDispatcher) {
+        previousDispatcher.close();
+      }
 
-    // Close the previous dispatcher regardless of whether it was externally provided.
-    // Fire-and-forget: let in-flight requests drain without blocking.
-    if (previousDispatcher) {
-      previousDispatcher.close();
+      this.internalAgentOptions = { allowH2: true, ...(value as Agent.Options) };
+      this.config.dispatcher = undefined;
+      this.isInternalDispatcher = true;
+      return;
     }
 
-    // Assign the new value.
-    this.config.dispatcher = newDispatcher;
+    throw new Error(
+      "updateHttpClientConfig: value for 'dispatcher' must be an instance of undici Dispatcher or Agent.Options."
+    );
   }
 
   public httpHandlerConfigs(): { dispatcher?: Dispatcher; logger?: Logger } {
@@ -272,6 +327,10 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
    * Creates a one-off undici Client for an event stream request.
    * This mirrors NodeHttp2Handler's isolated session behavior — the event stream
    * gets its own dedicated connection that isn't shared with the connection pool.
+   *
+   * Caller-provided Agent.Options (TLS, connect, timeouts, etc.) are propagated
+   * to the isolated Client. Agent/Pool-only keys are stripped. `pipelining` is
+   * forced to 0 so the dedicated connection is not pipelined.
    */
   private createIsolatedClient(request: HttpRequest): Client {
     const port = request.port ? `:${request.port}` : "";
@@ -284,8 +343,12 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
       origin = `${request.protocol}//${request.hostname}${port}`;
     }
 
+    const baseOptions: Client.Options = this.internalAgentOptions
+      ? toClientOptions(this.internalAgentOptions)
+      : { allowH2: true };
+
     return new Client(origin, {
-      allowH2: true,
+      ...baseOptions,
       pipelining: 0, // no pipelining — dedicated connection
     });
   }
@@ -298,6 +361,6 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
       return dispatcher;
     }
 
-    return (config.dispatcher = new Agent({ allowH2: true }));
+    return (config.dispatcher = new Agent(this.internalAgentOptions ?? { allowH2: true }));
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes: https://github.com/smithy-lang/smithy-typescript/issues/2042

*Description of changes:*

Previously, isEventStream always created an isolated Client with hardcoded
options, bypassing any caller-supplied Dispatcher and dropping caller-
supplied Agent.Options. This silently defeated proxy agents, mock
interceptors, and caller-tuned TLS, connect, and timeout settings on
event-stream connections.

- Track whether the dispatcher is internally managed. When the caller
  supplied a Dispatcher instance, route event streams through it so
  proxies and mocks work as expected.
- Retain caller-supplied Agent.Options and propagate the Client-compatible
  subset to isolated event-stream Clients. Agent/Pool-only keys (factory,
  maxRedirections, connections, interceptors) are stripped; pipelining is
  forced to 0.
- Defer Agent construction to the first request when only Agent.Options
  were provided, so handlers that are constructed but never invoked do
  not allocate a dispatcher.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
