### PR TITLE
fix(undici-http-handler): require close/destroy in isDispatcher duck-type check

### DIFF
--- a/.changeset/seven-drinks-divide.md
+++ b/.changeset/seven-drinks-divide.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+Require close/destroy in isDispatcher duck-type check

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -599,19 +599,6 @@ describe("UndiciHttpHandler", () => {
       expect(response.statusCode).toBe(200);
     });
 
-    it("rejects a partial dispatcher mock that is missing close (treated as Agent.Options)", async () => {
-      // A mock with only `request` would have previously passed the duck-type
-      // check and then thrown a TypeError when updateHttpClientConfig called
-      // close() on the previous dispatcher. The tightened check now requires
-      // close/destroy too, so a partial mock is treated as Agent.Options.
-      handler = new UndiciHttpHandler();
-      const partial = { request: vi.fn() } as any;
-      // Should not throw when assigning the partial mock — it falls into the
-      // Agent.Options branch and the deferred Agent will be created lazily.
-      expect(() => handler.updateHttpClientConfig("dispatcher", partial)).not.toThrow();
-      expect(handler.httpHandlerConfigs().dispatcher).toBeUndefined();
-    });
-
     it("closes previous internal dispatcher when updating with a new Dispatcher", async () => {
       handler = new UndiciHttpHandler();
       // Trigger internal dispatcher creation

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -213,6 +213,7 @@ describe("UndiciHttpHandler", () => {
       });
       const mockDispatcher = {
         request: vi.fn().mockRejectedValue(abortError),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -244,6 +245,7 @@ describe("UndiciHttpHandler", () => {
       });
       const mockDispatcher = {
         request: vi.fn().mockRejectedValue(timeoutError),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -264,6 +266,7 @@ describe("UndiciHttpHandler", () => {
       });
       const mockDispatcher = {
         request: vi.fn().mockRejectedValue(timeoutError),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -284,6 +287,7 @@ describe("UndiciHttpHandler", () => {
       });
       const mockDispatcher = {
         request: vi.fn().mockRejectedValue(timeoutError),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -306,6 +310,7 @@ describe("UndiciHttpHandler", () => {
       });
       const mockDispatcher = {
         request: vi.fn().mockRejectedValue(socketError),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -326,6 +331,7 @@ describe("UndiciHttpHandler", () => {
       const unknownError = new Error("something unexpected");
       const mockDispatcher = {
         request: vi.fn().mockRejectedValue(unknownError),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -348,6 +354,7 @@ describe("UndiciHttpHandler", () => {
           headers: { "x-custom": "value" },
           body: null,
         }),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -361,6 +368,7 @@ describe("UndiciHttpHandler", () => {
     it("destroys external dispatcher on handler destroy", () => {
       const mockDispatcher = {
         request: vi.fn(),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -384,6 +392,7 @@ describe("UndiciHttpHandler", () => {
           headers: {},
           body: null,
         }),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -401,6 +410,7 @@ describe("UndiciHttpHandler", () => {
           headers: {},
           body: null,
         }),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -459,6 +469,7 @@ describe("UndiciHttpHandler", () => {
           headers: {},
           body: null,
         }),
+        close: vi.fn(),
         destroy: vi.fn(),
       } as unknown as Dispatcher;
 
@@ -488,6 +499,7 @@ describe("UndiciHttpHandler", () => {
             headers: {},
             body: null,
           }),
+          close: vi.fn(),
           destroy: vi.fn(),
         } as unknown as Dispatcher;
 
@@ -585,6 +597,19 @@ describe("UndiciHttpHandler", () => {
       // Handler should still work with its internal dispatcher
       const { response } = await handler.handle(createMockRequest());
       expect(response.statusCode).toBe(200);
+    });
+
+    it("rejects a partial dispatcher mock that is missing close (treated as Agent.Options)", async () => {
+      // A mock with only `request` would have previously passed the duck-type
+      // check and then thrown a TypeError when updateHttpClientConfig called
+      // close() on the previous dispatcher. The tightened check now requires
+      // close/destroy too, so a partial mock is treated as Agent.Options.
+      handler = new UndiciHttpHandler();
+      const partial = { request: vi.fn() } as any;
+      // Should not throw when assigning the partial mock — it falls into the
+      // Agent.Options branch and the deferred Agent will be created lazily.
+      expect(() => handler.updateHttpClientConfig("dispatcher", partial)).not.toThrow();
+      expect(handler.httpHandlerConfigs().dispatcher).toBeUndefined();
     });
 
     it("closes previous internal dispatcher when updating with a new Dispatcher", async () => {

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -11,8 +11,14 @@ import { Agent, Client, Dispatcher } from "undici";
  * and surface as a TypeError later when `close`/`destroy` is called.
  */
 const isDispatcher = (value: unknown): value is Dispatcher => {
-  if (value instanceof Dispatcher) return true;
-  if (typeof value !== "object" || value === null) return false;
+  if (value instanceof Dispatcher) {
+    return true;
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
   const candidate = value as Record<string, unknown>;
   return (
     typeof candidate.request === "function" &&

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -5,11 +5,21 @@ import { Agent, Client, Dispatcher } from "undici";
 
 /**
  * Duck-type check: returns true if the value looks like a Dispatcher
- * (has a `request` method), as opposed to plain Agent.Options.
+ * (has `request`, `close`, and `destroy` methods), as opposed to plain
+ * Agent.Options. We require all three because the handler invokes each
+ * of them — checking only `request` would let a partial mock through
+ * and surface as a TypeError later when `close`/`destroy` is called.
  */
-const isDispatcher = (value: unknown): value is Dispatcher =>
-  value instanceof Dispatcher ||
-  (typeof value === "object" && value !== null && typeof (value as any).request === "function");
+const isDispatcher = (value: unknown): value is Dispatcher => {
+  if (value instanceof Dispatcher) return true;
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.request === "function" &&
+    typeof candidate.close === "function" &&
+    typeof candidate.destroy === "function"
+  );
+};
 
 /**
  * Options for the UndiciHttpHandler.


### PR DESCRIPTION
*Issue #, if available:*

Refs: https://github.com/smithy-lang/smithy-typescript/pull/2043#discussion_r3283844782

*Description of changes:*

The isDispatcher check accepted any object with a `request` function, so a
caller-supplied dispatcher-like object without `close` could pass through
and later trigger a TypeError when updateHttpClientConfig invoked
previousDispatcher.close(). Tighten the check to also require `close` and
`destroy` — the three methods this handler actually invokes.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
