### PR TITLE
chore(undici-http-handler): skip compiling test files

### DIFF
--- a/.changeset/late-hornets-agree.md
+++ b/.changeset/late-hornets-agree.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+Skip compiling test files

--- a/packages/undici-http-handler/tsconfig.es.json
+++ b/packages/undici-http-handler/tsconfig.es.json
@@ -7,5 +7,5 @@
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"],
-  "exclude": ["src/**/*.bench.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.bench.ts"]
 }

--- a/packages/undici-http-handler/tsconfig.types.json
+++ b/packages/undici-http-handler/tsconfig.types.json
@@ -7,5 +7,5 @@
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"],
-  "exclude": ["src/**/*.bench.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.bench.ts"]
 }


### PR DESCRIPTION
*Issue #, if available:*

The test files are published on npm: https://www.npmjs.com/package/@smithy/undici-http-handler/v/1.0.2?activeTab=code

*Description of changes:*

Skip compiling test files

Before

```console
$ undici-http-handler> ls dist-*
dist-cjs:
index.js

dist-es:
index.js  undici-http-handler.js  undici-http-handler.spec.js  undici-http-handler.version.spec.js

dist-types:
index.d.ts  undici-http-handler.d.ts  undici-http-handler.spec.d.ts  undici-http-handler.version.spec.d.ts
```

After

```console
$ undici-http-handler> ls dist-*
dist-cjs:
index.js

dist-es:
index.js  undici-http-handler.js

dist-types:
index.d.ts  undici-http-handler.d.ts
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
