### PR TITLE
fix(undici-http-handler): preserve AbortSignal.reason on aborted requests

### DIFF
--- a/.changeset/old-rice-move.md
+++ b/.changeset/old-rice-move.md
@@ -1,2 +1,5 @@
 ---
+"@smithy/undici-http-handler": patch
 ---
+
+Preserve AbortSignal.reason on aborted requests

--- a/packages/undici-http-handler/src/build-abort-error.ts
+++ b/packages/undici-http-handler/src/build-abort-error.ts
@@ -1,0 +1,29 @@
+/**
+ * Builds an abort error, using the AbortSignal's reason if available.
+ *
+ * @param abortSignal - Optional AbortSignal that may contain a reason.
+ * @returns A new Error with name "AbortError". If the signal has a reason that's
+ *          already an Error, the reason is set as `cause`. Otherwise creates a
+ *          new Error with the reason as the message, or "Request aborted" if no
+ *          reason.
+ */
+export function buildAbortError(abortSignal?: unknown): Error {
+  const reason =
+    abortSignal && typeof abortSignal === "object" && "reason" in abortSignal
+      ? (abortSignal as { reason?: unknown }).reason
+      : undefined;
+  if (reason) {
+    if (reason instanceof Error) {
+      const abortError = new Error("Request aborted");
+      abortError.name = "AbortError";
+      (abortError as { cause?: unknown }).cause = reason;
+      return abortError;
+    }
+    const abortError = new Error(String(reason));
+    abortError.name = "AbortError";
+    return abortError;
+  }
+  const abortError = new Error("Request aborted");
+  abortError.name = "AbortError";
+  return abortError;
+}

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -196,6 +196,39 @@ describe("UndiciHttpHandler", () => {
       }
     });
 
+    it("preserves AbortSignal.reason as cause when signal is already aborted with Error reason", async () => {
+      handler = new UndiciHttpHandler();
+      const controller = new AbortController();
+      const reason = new Error("custom abort reason");
+      reason.name = "MyCustomAbortError";
+      controller.abort(reason);
+      try {
+        await handler.handle(createMockRequest(), {
+          abortSignal: controller.signal as any,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("AbortError");
+        expect(err.message).toBe("Request aborted");
+        expect(err.cause).toBe(reason);
+      }
+    });
+
+    it("uses AbortSignal.reason as message when reason is not an Error", async () => {
+      handler = new UndiciHttpHandler();
+      const controller = new AbortController();
+      controller.abort("string reason");
+      try {
+        await handler.handle(createMockRequest(), {
+          abortSignal: controller.signal as any,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("AbortError");
+        expect(err.message).toBe("string reason");
+      }
+    });
+
     it("throws AbortError when signal is aborted during request", async () => {
       handler = new UndiciHttpHandler();
       const controller = new AbortController();
@@ -225,6 +258,37 @@ describe("UndiciHttpHandler", () => {
         expect(err.name).toBe("AbortError");
         expect(err.code).toBe("UND_ERR_ABORTED");
         expect(err).toBe(abortError);
+      }
+    });
+
+    it("sets AbortSignal.reason as cause on mid-flight UND_ERR_ABORTED", async () => {
+      const reason = new Error("custom abort reason");
+      reason.name = "MyCustomAbortError";
+
+      const abortError = Object.assign(new Error("aborted"), {
+        code: "UND_ERR_ABORTED",
+      });
+      const controller = new AbortController();
+      // Abort the signal mid-flight before the dispatcher rejects, so the
+      // catch path sees `abortSignal.reason` populated alongside UND_ERR_ABORTED.
+      const mockDispatcher = {
+        request: vi.fn().mockImplementation(async () => {
+          controller.abort(reason);
+          throw abortError;
+        }),
+        close: vi.fn(),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+
+      try {
+        await handler.handle(createMockRequest(), { abortSignal: controller.signal as any });
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("AbortError");
+        expect(err.code).toBe("UND_ERR_ABORTED");
+        expect(err.cause).toBe(reason);
       }
     });
   });

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -3,6 +3,8 @@ import { HttpResponse, buildQueryString, type HttpHandler, type HttpRequest } fr
 import type { HttpHandlerOptions, Logger } from "@smithy/types";
 import { Agent, Client, Dispatcher } from "undici";
 
+import { buildAbortError } from "./build-abort-error";
+
 /**
  * Duck-type check: returns true if the value looks like a Dispatcher
  * (has `request`, `close`, and `destroy` methods), as opposed to plain
@@ -147,9 +149,7 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
       if (isolatedClient) {
         isolatedClient.destroy();
       }
-      throw Object.assign(new Error("Request aborted"), {
-        name: "AbortError",
-      });
+      throw buildAbortError(abortSignal);
     }
 
     // Build path with query string — skip buildQueryString when query is undefined.
@@ -250,7 +250,17 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
       }
 
       if (err?.code === "UND_ERR_ABORTED") {
-        throw Object.assign(err, { name: "AbortError" });
+        // Preserve the abort reason from the signal as `cause` so callers can
+        // distinguish user-provided abort reasons from undici's generic abort.
+        const reason =
+          abortSignal && typeof abortSignal === "object" && "reason" in abortSignal
+            ? (abortSignal as { reason?: unknown }).reason
+            : undefined;
+        const assigned: { name: string; cause?: unknown } = { name: "AbortError" };
+        if (reason !== undefined && (err as { cause?: unknown }).cause === undefined) {
+          assigned.cause = reason;
+        }
+        throw Object.assign(err, assigned);
       }
 
       if (


### PR DESCRIPTION
*Issue #, if available:*

Fixes: https://github.com/smithy-lang/smithy-typescript/issues/2047

*Description of changes:*

Preserve AbortSignal.reason on aborted requests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
