### PR TITLE
ci: skip undici-http-handler build and test on node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,24 @@ jobs:
         run: |
           yarn
           yarn turbo telemetry disable
+      # @smithy/undici-http-handler requires undici, which may drop Node 18
+      # support in a future major. Skip build/test of that package on Node 18
+      # so the rest of the matrix continues to validate it.
       - name: Build and validate API snapshot
+        if: matrix.node != 18
         run: node ./scripts/retry -- make api-snapshot
+      - name: Build and validate API snapshot (skip undici-http-handler)
+        if: matrix.node == 18
+        run: |
+          node ./scripts/retry -- yarn build --filter '!@smithy/undici-http-handler'
+          node scripts/validation/api-snapshot-validation.js --write
+          git diff --exit-code api-snapshot/
       - name: Run unit tests
+        if: matrix.node != 18
         run: node ./scripts/retry -- yarn test
+      - name: Run unit tests (skip undici-http-handler)
+        if: matrix.node == 18
+        run: node ./scripts/retry -- yarn g:vitest run -c vitest.config.mts --exclude='**/undici-http-handler/**'
       - name: Run integration tests
         run: |
           yarn config set enableImmutableInstalls false

--- a/scripts/validation/validate-deps-used.js
+++ b/scripts/validation/validate-deps-used.js
@@ -28,6 +28,13 @@ async function validate(packageDir) {
   const declared = new Set(Object.keys(pkgJson.dependencies || {}));
   const used = new Set();
 
+  // If none of the dist folders exist, the package has not been built.
+  // Skip rather than report every declared dep as unused.
+  const distFolders = ["dist-cjs", "dist-es", "dist-types"];
+  if (!distFolders.some((d) => fs.existsSync(path.join(packageDir, d)))) {
+    return [];
+  }
+
   // Scan compiled JS.
   for (const dist of ["dist-cjs", "dist-es"]) {
     const distDir = path.join(packageDir, dist);


### PR DESCRIPTION
Experiment (if successful) to be added in https://github.com/smithy-lang/smithy-typescript/pull/2049