### PR TITLE
chore(undici-http-handler): skip build/test/validation in node 18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
-.PHONY: build sync api-snapshot ct cti cwt cwti
+.PHONY: build build-packages sync api-snapshot ct cti cwt cwti
 
 build:
 	./gradlew clean build publishToMavenLocal
+
+# @smithy/undici-http-handler depends on undici@7, which requires Node.js >= 20.
+# Skip building it on older Node versions so the rest of the workspace still builds.
+build-packages:
+	@NODE_MAJOR=$$(node -p "parseInt(process.versions.node.split('.')[0], 10)"); \
+	if [ "$$NODE_MAJOR" -lt 20 ]; then \
+		yarn turbo run build --filter='!@smithy/undici-http-handler'; \
+	else \
+		yarn turbo run build; \
+	fi
 
 sync:
 	gh repo sync $$GITHUB_USERNAME/smithy-typescript -b main
@@ -40,8 +50,15 @@ bgt:
 gt:
 	make generate-protocol-tests
 
+# @smithy/undici-http-handler depends on undici@7, which requires Node.js >= 20.
+# Skip its tests on older Node versions so the rest of the unit tests still run.
 test-unit:
-	yarn g:vitest run -c vitest.config.mts
+	@NODE_MAJOR=$$(node -p "parseInt(process.versions.node.split('.')[0], 10)"); \
+	if [ "$$NODE_MAJOR" -lt 20 ]; then \
+		yarn g:vitest run -c vitest.config.mts --exclude '**/packages/undici-http-handler/**'; \
+	else \
+		yarn g:vitest run -c vitest.config.mts; \
+	fi
 
 test-browser:
 	yarn g:vitest run -c vitest.config.browser.mts

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "clean": "turbo run clean --force --parallel",
-    "build": "turbo run build",
+    "build": "make build-packages",
     "test": "make test-unit",
     "test:integration": "yarn build-test-packages && make test-integration",
     "test:protocols": "make generate-protocol-tests test-protocols benchmark",

--- a/scripts/validation/deps-used.js
+++ b/scripts/validation/deps-used.js
@@ -24,7 +24,17 @@ async function validate(packageDir) {
   if (!fs.existsSync(pkgJsonPath)) {
     return [];
   }
+
   const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+  if (pkgJson.name === "@smithy/undici-http-handler") {
+    const nodeMajorVersion = parseInt(process.versions.node.split(".")[0], 10);
+    // @smithy/undici-http-handler depends on undici@7, which requires Node.js >= 20.
+    // Skip validation, as the package isn't built.
+    if (nodeMajorVersion < 20) {
+      return [];
+    }
+  }
+
   const declared = new Set(Object.keys(pkgJson.dependencies || {}));
   const used = new Set();
 


### PR DESCRIPTION
Alternative to https://github.com/smithy-lang/smithy-typescript/pull/2050

Proposal to skip build/test/validation in node 18.
If approved, it'll be merged in https://github.com/smithy-lang/smithy-typescript/pull/2049