### PR TITLE
fix(codegen): exclude RequestCompressionTrait from schema generation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitFilterIndex.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaTraitFilterIndex.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.ProtocolDefinitionTrait;
+import software.amazon.smithy.model.traits.RequestCompressionTrait;
 import software.amazon.smithy.model.traits.RequiresLengthTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
@@ -50,7 +51,9 @@ public final class SchemaTraitFilterIndex implements KnowledgeIndex {
 
     private static final Set<ShapeId> EXCLUDED_TRAITS = SetUtils.of(
         // excluded due to special schema handling.
-        TimestampFormatTrait.ID
+        TimestampFormatTrait.ID,
+        // excluded because AddCompressionDependency handles it via middleware plugin.
+        RequestCompressionTrait.ID
     );
 
     /**


### PR DESCRIPTION
The trait is already handled by AddCompressionDependency which injects
the compression middleware plugin directly during codegen.

