### PR TITLE
fix(scripts): update release script to use latest node LTS

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
           cache: "yarn"
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
*Issue #, if available:*

We dropped support for node 18 in undici-http-handler in https://github.com/smithy-lang/smithy-typescript/pull/2049, but it's release failed as our release scripts run on node 18.

<details>
<summary>Error Logs</summary>

```console
@smithy/undici-http-handler:build
cache miss, executing 79bea6ffcf1ebe78
[build:types] yarn run build:types exited with code 0
[build:es:cjs] /home/runner/work/smithy-typescript/smithy-typescript/node_modules/undici/lib/web/webidl/index.js:537
[build:es:cjs] webidl.is.File = webidl.util.MakeTypeAssertion(File)
[build:es:cjs]                                                ^
[build:es:cjs] 
[build:es:cjs] ReferenceError: File is not defined
[build:es:cjs]     at Object.<anonymous> (/home/runner/work/smithy-typescript/smithy-typescript/node_modules/undici/lib/web/webidl/index.js:537:48)
[build:es:cjs]     at Module._compile (node:internal/modules/cjs/loader:1364:14)
[build:es:cjs]     at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
[build:es:cjs]     at Module.load (node:internal/modules/cjs/loader:1203:32)
[build:es:cjs]     at Module._load (node:internal/modules/cjs/loader:1019:12)
[build:es:cjs]     at Module.require (node:internal/modules/cjs/loader:1231:19)
[build:es:cjs]     at require (node:internal/modules/helpers:177:18)
[build:es:cjs]     at Object.<anonymous> (/home/runner/work/smithy-typescript/smithy-typescript/node_modules/undici/lib/web/fetch/util.js:12:20)
[build:es:cjs]     at Module._compile (node:internal/modules/cjs/loader:1364:14)
[build:es:cjs]     at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
[build:es:cjs] 
[build:es:cjs] Node.js v18.20.8
[build:es:cjs] yarn run build:es:cjs exited with code 1
xyz:build
@smithy/fetch-http-handler:stage-release
@smithy/smithy-rpcv2-cbor:build
@aws-smithy/server-common:stage-release
@aws-smithy/server-node:stage-release
@aws-smithy/server-apigateway:stage-release
@smithy/signature-v4a:stage-release
@smithy/middleware-apply-body-checksum:stage-release
@smithy/experimental-identity-and-auth:stage-release
@smithy/smithy-rpcv2-cbor-schema:build
xyz-schema:build
@smithy/snapshot-testing:stage-release
Error: @smithy/undici-http-handler#build: command (/home/runner/work/smithy-typescript/smithy-typescript/packages/undici-http-handler) /tmp/xfs-b7d05f33/yarn run build exited (1)
 ERROR  @smithy/undici-http-handler#build: command (/home/runner/work/smithy-typescript/smithy-typescript/packages/undici-http-handler) /tmp/xfs-b7d05f33/yarn run build exited (1)
```

</details>

Details: https://github.com/smithy-lang/smithy-typescript/actions/runs/26656932784/job/78569400180

*Description of changes:*

Update release script to use latest node LTS

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
