### PR TITLE
fix(core): treat EAI_AGAIN as a transient error

### DIFF
--- a/.changeset/soft-bees-crash.md
+++ b/.changeset/soft-bees-crash.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Treat the Node.js DNS error code EAI_AGAIN as a transient (retryable) error

--- a/packages/core/src/submodules/retry/service-error-classification/constants.ts
+++ b/packages/core/src/submodules/retry/service-error-classification/constants.ts
@@ -54,4 +54,4 @@ export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "ECONNREFUSED", "EPIPE"
 /**
  * Node.js system error codes that indicate network error.
  */
-export const NODEJS_NETWORK_ERROR_CODES = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND"];
+export const NODEJS_NETWORK_ERROR_CODES = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN"];


### PR DESCRIPTION
*Description of changes:*

Adds the Node.js DNS error code `EAI_AGAIN` to `NODEJS_NETWORK_ERROR_CODES` so the standard retry strategy classifies it as transient and retries it.

`EAI_AGAIN` is the POSIX `getaddrinfo` code for a temporary name-resolution failure ("try again later"). It is the twin of `ENOTFOUND`, already in the array, emitted by the same syscall but signalling a recoverable resolver hiccup rather than a permanent lookup miss. These are common in containerized environments (ECS/Fargate, Kubernetes) during brief DNS resolver outages.

A changeset (patch) has been added.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
