### PR TITLE
fix(core/retry): move adaptive rate limiting to directly before requests

### DIFF
--- a/.changeset/eighty-jobs-laugh.md
+++ b/.changeset/eighty-jobs-laugh.md
@@ -1,0 +1,6 @@
+---
+"@smithy/types": patch
+"@smithy/core": patch
+---
+
+update adaptive rate limiter to execute directly prior to outgoing requests & retries

--- a/packages/core/src/submodules/retry/middleware-retry/configurations.spec.ts
+++ b/packages/core/src/submodules/retry/middleware-retry/configurations.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest"
 import { AdaptiveRetryStrategy } from "../util-retry/AdaptiveRetryStrategy";
 import { StandardRetryStrategy } from "../util-retry/StandardRetryStrategy";
 import { DEFAULT_MAX_ATTEMPTS } from "../util-retry/config";
+import { Retry } from "../util-retry/retries-2026-config";
 import {
   CONFIG_MAX_ATTEMPTS,
   ENV_MAX_ATTEMPTS,
@@ -46,6 +47,55 @@ describe(resolveRetryConfig.name, () => {
       const output = await resolveRetryConfig({ retryMode }).maxAttempts();
       expect(output).toStrictEqual(DEFAULT_MAX_ATTEMPTS);
     });
+
+    it("uses defaultMaxAttempts from defaults parameter when maxAttempts not provided", async () => {
+      const output = await resolveRetryConfig({ retryMode }, { defaultMaxAttempts: 5 }).maxAttempts();
+      expect(output).toStrictEqual(5);
+    });
+
+    it("prefers input maxAttempts over defaultMaxAttempts", async () => {
+      const output = await resolveRetryConfig({ maxAttempts: 2, retryMode }, { defaultMaxAttempts: 5 }).maxAttempts();
+      expect(output).toStrictEqual(2);
+    });
+  });
+
+  describe("defaults parameter", () => {
+    it("passes defaultBaseDelay to StandardRetryStrategy", async () => {
+      const { retryStrategy } = resolveRetryConfig({ retryMode: "standard" }, { defaultBaseDelay: 200 });
+      await retryStrategy();
+      expect(vi.mocked(StandardRetryStrategy)).toHaveBeenCalledWith({
+        maxAttempts: DEFAULT_MAX_ATTEMPTS,
+        baseDelay: 200,
+      });
+    });
+
+    it("passes defaultBaseDelay to AdaptiveRetryStrategy", async () => {
+      const { retryStrategy } = resolveRetryConfig({ retryMode: "adaptive" }, { defaultBaseDelay: 200 });
+      await retryStrategy();
+      const [, options] = vi.mocked(AdaptiveRetryStrategy).mock.calls[0];
+      expect(options).toEqual({ maxAttempts: DEFAULT_MAX_ATTEMPTS, baseDelay: 200 });
+    });
+
+    it("uses Retry.delay() as baseDelay when defaults not provided", async () => {
+      const { retryStrategy } = resolveRetryConfig({ retryMode: "standard" });
+      await retryStrategy();
+      expect(vi.mocked(StandardRetryStrategy)).toHaveBeenCalledWith({
+        maxAttempts: DEFAULT_MAX_ATTEMPTS,
+        baseDelay: Retry.delay(),
+      });
+    });
+
+    it("uses both defaultMaxAttempts and defaultBaseDelay together", async () => {
+      const { retryStrategy } = resolveRetryConfig(
+        { retryMode: "standard" },
+        { defaultMaxAttempts: 10, defaultBaseDelay: 500 }
+      );
+      await retryStrategy();
+      expect(vi.mocked(StandardRetryStrategy)).toHaveBeenCalledWith({
+        maxAttempts: 10,
+        baseDelay: 500,
+      });
+    });
   });
 
   describe("retryStrategy", () => {
@@ -63,7 +113,7 @@ describe(resolveRetryConfig.name, () => {
     describe("creates RetryStrategy if retryStrategy not present", () => {
       describe("StandardRetryStrategy", () => {
         describe("when retryMode=standard", () => {
-          describe("passes maxAttempts if present", () => {
+          describe("passes maxAttempts and baseDelay in options", () => {
             const retryMode = "standard";
             for (const maxAttempts of [1, 2, 3]) {
               it(`when maxAttempts=${maxAttempts}`, async () => {
@@ -71,15 +121,17 @@ describe(resolveRetryConfig.name, () => {
                 await retryStrategy();
                 expect(vi.mocked(StandardRetryStrategy)).toHaveBeenCalledTimes(1);
                 expect(vi.mocked(AdaptiveRetryStrategy)).not.toHaveBeenCalled();
-                const output = await vi.mocked(StandardRetryStrategy as any).mock.calls[0][0]();
-                expect(output).toStrictEqual(maxAttempts);
+                expect(vi.mocked(StandardRetryStrategy)).toHaveBeenCalledWith({
+                  maxAttempts,
+                  baseDelay: Retry.delay(),
+                });
               });
             }
           });
         });
 
         describe("when retryMode returns 'standard'", () => {
-          describe("passes maxAttempts if present", () => {
+          describe("passes maxAttempts and baseDelay in options", () => {
             beforeEach(() => {
               retryMode.mockResolvedValueOnce("standard");
             });
@@ -90,8 +142,10 @@ describe(resolveRetryConfig.name, () => {
                 expect(retryMode).toHaveBeenCalledTimes(1);
                 expect(vi.mocked(StandardRetryStrategy)).toHaveBeenCalledTimes(1);
                 expect(vi.mocked(AdaptiveRetryStrategy)).not.toHaveBeenCalled();
-                const output = await vi.mocked(StandardRetryStrategy as any).mock.calls[0][0]();
-                expect(output).toStrictEqual(maxAttempts);
+                expect(vi.mocked(StandardRetryStrategy)).toHaveBeenCalledWith({
+                  maxAttempts,
+                  baseDelay: Retry.delay(),
+                });
               });
             }
           });
@@ -100,7 +154,7 @@ describe(resolveRetryConfig.name, () => {
 
       describe("AdaptiveRetryStrategy", () => {
         describe("when retryMode=adaptive", () => {
-          describe("passes maxAttempts if present", () => {
+          describe("passes maxAttemptsProvider and options", () => {
             const retryMode = "adaptive";
             for (const maxAttempts of [1, 2, 3]) {
               it(`when maxAttempts=${maxAttempts}`, async () => {
@@ -108,15 +162,16 @@ describe(resolveRetryConfig.name, () => {
                 await retryStrategy();
                 expect(vi.mocked(StandardRetryStrategy)).not.toHaveBeenCalled();
                 expect(vi.mocked(AdaptiveRetryStrategy)).toHaveBeenCalledTimes(1);
-                const output = await vi.mocked(AdaptiveRetryStrategy as any).mock.calls[0][0]();
-                expect(output).toStrictEqual(maxAttempts);
+                const [provider, options] = vi.mocked(AdaptiveRetryStrategy).mock.calls[0];
+                expect(await (provider as Provider<number>)()).toStrictEqual(maxAttempts);
+                expect(options).toEqual({ maxAttempts, baseDelay: Retry.delay() });
               });
             }
           });
         });
 
         describe("when retryMode returns 'adaptive'", () => {
-          describe("passes maxAttempts if present", () => {
+          describe("passes maxAttemptsProvider and options", () => {
             beforeEach(() => {
               retryMode.mockResolvedValueOnce("adaptive");
             });
@@ -127,8 +182,9 @@ describe(resolveRetryConfig.name, () => {
                 expect(retryMode).toHaveBeenCalledTimes(1);
                 expect(vi.mocked(StandardRetryStrategy)).not.toHaveBeenCalled();
                 expect(vi.mocked(AdaptiveRetryStrategy)).toHaveBeenCalledTimes(1);
-                const output = await vi.mocked(AdaptiveRetryStrategy as any).mock.calls[0][0]();
-                expect(output).toStrictEqual(maxAttempts);
+                const [provider, options] = vi.mocked(AdaptiveRetryStrategy).mock.calls[0];
+                expect(await (provider as Provider<number>)()).toStrictEqual(maxAttempts);
+                expect(options).toEqual({ maxAttempts, baseDelay: Retry.delay() });
               });
             }
           });

--- a/packages/core/src/submodules/retry/middleware-retry/configurations.ts
+++ b/packages/core/src/submodules/retry/middleware-retry/configurations.ts
@@ -5,6 +5,7 @@ import type { Logger, Provider, RetryStrategy, RetryStrategyV2 } from "@smithy/t
 import { AdaptiveRetryStrategy } from "../util-retry/AdaptiveRetryStrategy";
 import { StandardRetryStrategy } from "../util-retry/StandardRetryStrategy";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE, RETRY_MODES } from "../util-retry/config";
+import { Retry } from "../util-retry/retries-2026-config";
 
 /**
  * @internal
@@ -86,21 +87,35 @@ export interface RetryResolvedConfig {
 /**
  * @internal
  */
-export const resolveRetryConfig = <T>(input: T & PreviouslyResolved & RetryInputConfig): T & RetryResolvedConfig => {
+export const resolveRetryConfig = <T>(
+  input: T & PreviouslyResolved & RetryInputConfig,
+  defaults?: { defaultMaxAttempts?: number; defaultBaseDelay?: number }
+): T & RetryResolvedConfig => {
   const { retryStrategy, retryMode } = input;
-  const maxAttempts = normalizeProvider(input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  const { defaultMaxAttempts = DEFAULT_MAX_ATTEMPTS, defaultBaseDelay = Retry.delay() } = defaults ?? {};
+  const maxAttemptsProvider = normalizeProvider(input.maxAttempts ?? defaultMaxAttempts);
 
   let controller: Promise<RetryStrategy | RetryStrategyV2> | undefined = retryStrategy
     ? Promise.resolve(retryStrategy)
     : undefined;
 
-  const getDefault = async () =>
-    (await normalizeProvider(retryMode)()) === RETRY_MODES.ADAPTIVE
-      ? new AdaptiveRetryStrategy(maxAttempts)
-      : new StandardRetryStrategy(maxAttempts);
+  const getDefault = async () => {
+    const maxAttempts = await maxAttemptsProvider();
+    const adaptive = (await normalizeProvider(retryMode)()) === RETRY_MODES.ADAPTIVE;
+    if (adaptive) {
+      return new AdaptiveRetryStrategy(maxAttemptsProvider, {
+        maxAttempts,
+        baseDelay: defaultBaseDelay,
+      });
+    }
+    return new StandardRetryStrategy({
+      maxAttempts,
+      baseDelay: defaultBaseDelay,
+    });
+  };
 
   return Object.assign(input, {
-    maxAttempts,
+    maxAttempts: maxAttemptsProvider,
     retryStrategy: () => (controller ??= getDefault()),
   });
 };

--- a/packages/core/src/submodules/retry/middleware-retry/retryMiddleware.ts
+++ b/packages/core/src/submodules/retry/middleware-retry/retryMiddleware.ts
@@ -85,9 +85,6 @@ export function bindRetryMiddleware(isStreamingPayload: IsStreamingPayload) {
             try {
               retryToken = await retryStrategy.refreshRetryTokenForRetry(retryToken, retryErrorInfo);
             } catch (refreshError) {
-              if (typeof refreshError.$backoff === "number") {
-                await cooldown(refreshError.$backoff);
-              }
               if (!lastError.$metadata) {
                 lastError.$metadata = {};
               }
@@ -97,8 +94,13 @@ export function bindRetryMiddleware(isStreamingPayload: IsStreamingPayload) {
             }
             attempts = retryToken.getRetryCount();
             const delay = retryToken.getRetryDelay();
-            totalRetryDelay += delay;
-            await cooldown(delay);
+            totalRetryDelay += (retryToken?.$retryLog?.acquisitionDelay ?? 0) + delay;
+            if (delay > 0) {
+              // for internal V2 (SRA) retryStrategies, delay should be zero going forward.
+              // This cooldown is for backwards compatibility with a user-implemented strategy
+              // which returns a token with delay.
+              await cooldown(delay);
+            }
           }
         }
       } else {

--- a/packages/core/src/submodules/retry/util-retry/ConfiguredRetryStrategy.spec.ts
+++ b/packages/core/src/submodules/retry/util-retry/ConfiguredRetryStrategy.spec.ts
@@ -1,19 +1,29 @@
-import { describe, expect, test as it } from "vitest";
+import { describe, expect, test as it, vi } from "vitest";
 
 import { ConfiguredRetryStrategy } from "./ConfiguredRetryStrategy";
 
 describe(ConfiguredRetryStrategy.name, () => {
   it("allows setting a custom backoff function", async () => {
+    vi.useFakeTimers();
     const strategy = new ConfiguredRetryStrategy(5, (attempt) => attempt * 1000);
 
-    const token = await strategy.acquireInitialRetryToken("");
-    token.getRetryCount = () => 3;
+    let token = await strategy.acquireInitialRetryToken("");
 
-    const retryToken = await strategy.refreshRetryTokenForRetry(token, {
-      errorType: "TRANSIENT",
-    });
+    let retryTokenPromise = strategy.refreshRetryTokenForRetry(token, { errorType: "TRANSIENT" });
+    await vi.advanceTimersByTimeAsync(1000);
+    token = await retryTokenPromise;
+    expect(token.$retryLog?.acquisitionDelay).toBe(1000);
 
-    expect(retryToken.getRetryCount()).toBe(4);
-    expect(retryToken.getRetryDelay()).toBe(4000);
+    retryTokenPromise = strategy.refreshRetryTokenForRetry(token, { errorType: "TRANSIENT" });
+    await vi.advanceTimersByTimeAsync(2000);
+    token = await retryTokenPromise;
+    expect(token.$retryLog?.acquisitionDelay).toBe(2000);
+
+    retryTokenPromise = strategy.refreshRetryTokenForRetry(token, { errorType: "TRANSIENT" });
+    await vi.advanceTimersByTimeAsync(3000);
+    token = await retryTokenPromise;
+    expect(token.$retryLog?.acquisitionDelay).toBe(3000);
+
+    vi.useRealTimers();
   });
 });

--- a/packages/core/src/submodules/retry/util-retry/ConfiguredRetryStrategy.ts
+++ b/packages/core/src/submodules/retry/util-retry/ConfiguredRetryStrategy.ts
@@ -1,10 +1,4 @@
-import type {
-  Provider,
-  RetryBackoffStrategy,
-  RetryErrorInfo,
-  RetryStrategyV2,
-  StandardRetryToken,
-} from "@smithy/types";
+import type { Provider, RetryBackoffStrategy, RetryStrategyV2 } from "@smithy/types";
 
 import { StandardRetryStrategy } from "./StandardRetryStrategy";
 import { Retry } from "./retries-2026-config";
@@ -47,14 +41,11 @@ export class ConfiguredRetryStrategy extends StandardRetryStrategy implements Re
     } else {
       this.computeNextBackoffDelay = computeNextBackoffDelay;
     }
-  }
-
-  public async refreshRetryTokenForRetry(
-    tokenToRenew: StandardRetryToken,
-    errorInfo: RetryErrorInfo
-  ): Promise<StandardRetryToken> {
-    const token = await super.refreshRetryTokenForRetry(tokenToRenew, errorInfo);
-    token.getRetryDelay = () => this.computeNextBackoffDelay(token.getRetryCount());
-    return token;
+    this.retryBackoffStrategy.computeNextBackoffDelay = (completedAttempt: number): number => {
+      // Internally the computation is against the retry which had just completed.
+      // when calling the user-provided function we give the attempt number that will next occur.
+      const nextAttempt = completedAttempt + 1;
+      return this.computeNextBackoffDelay(nextAttempt);
+    };
   }
 }

--- a/packages/core/src/submodules/retry/util-retry/DefaultRetryToken.spec.ts
+++ b/packages/core/src/submodules/retry/util-retry/DefaultRetryToken.spec.ts
@@ -40,4 +40,17 @@ describe("defaultRetryToken", () => {
       });
     });
   });
+
+  describe("$retryLog", () => {
+    it("has acquisitionDelay initialized to 0", () => {
+      const retryToken = new DefaultRetryToken(0, 0, 0, false);
+      expect(retryToken.$retryLog.acquisitionDelay).toBe(0);
+    });
+
+    it("allows acquisitionDelay to be set", () => {
+      const retryToken = new DefaultRetryToken(0, 1, 10, false);
+      retryToken.$retryLog.acquisitionDelay = 500;
+      expect(retryToken.$retryLog.acquisitionDelay).toBe(500);
+    });
+  });
 });

--- a/packages/core/src/submodules/retry/util-retry/DefaultRetryToken.ts
+++ b/packages/core/src/submodules/retry/util-retry/DefaultRetryToken.ts
@@ -6,6 +6,9 @@ import { MAXIMUM_RETRY_DELAY } from "./constants";
  * @internal
  */
 export class DefaultRetryToken implements StandardRetryToken {
+  public $retryLog = {
+    acquisitionDelay: 0,
+  };
   public constructor(
     private readonly delay: number,
     private readonly count: number,

--- a/packages/core/src/submodules/retry/util-retry/StandardRetryStrategy.spec.ts
+++ b/packages/core/src/submodules/retry/util-retry/StandardRetryStrategy.spec.ts
@@ -63,6 +63,7 @@ describe(StandardRetryStrategy.name, () => {
             getRetryCount,
             getRetryCost: () => 0,
             getRetryDelay: () => 0,
+            $retryLog: { acquisitionDelay: 0 },
           }) as any
       );
       const retryStrategy = new StandardRetryStrategy(() => Promise.resolve(maxAttempts));
@@ -216,7 +217,7 @@ describe(StandardRetryStrategy.name, () => {
   });
 
   describe("long-poll token behavior", () => {
-    it("throws with $backoff when long-poll token has no capacity (code 3)", async () => {
+    it("throws when long-poll token has no capacity (code 3)", async () => {
       vi.mocked(DefaultRetryToken).mockImplementation(
         () =>
           ({
@@ -229,17 +230,12 @@ describe(StandardRetryStrategy.name, () => {
       const retryStrategy = new StandardRetryStrategy(maxAttempts);
       retryStrategy["capacity"] = 0;
       const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
-      try {
-        await retryStrategy.refreshRetryTokenForRetry(token, errorInfo);
-        fail("expected error");
-      } catch (error: any) {
-        expect(error.message).toBe("No retry token available");
-        // $backoff is 0 when Retry.v2026 is false, non-zero when true
-        expect(error.$backoff).toBe(0);
-      }
+      await expect(retryStrategy.refreshRetryTokenForRetry(token, errorInfo)).rejects.toThrow(
+        "No retry token available"
+      );
     });
 
-    it("throws with $backoff=0 when long-poll token fails for non-capacity reason (code 1)", async () => {
+    it("throws when long-poll token fails for non-capacity reason (code 1)", async () => {
       vi.mocked(DefaultRetryToken).mockImplementation(
         () =>
           ({
@@ -251,13 +247,9 @@ describe(StandardRetryStrategy.name, () => {
       );
       const retryStrategy = new StandardRetryStrategy(maxAttempts);
       const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
-      try {
-        await retryStrategy.refreshRetryTokenForRetry(token, { errorType: "CLIENT_ERROR" } as RetryErrorInfo);
-        fail("expected error");
-      } catch (error: any) {
-        expect(error.message).toBe("No retry token available");
-        expect(error.$backoff).toBe(0);
-      }
+      await expect(
+        retryStrategy.refreshRetryTokenForRetry(token, { errorType: "CLIENT_ERROR" } as RetryErrorInfo)
+      ).rejects.toThrow("No retry token available");
     });
 
     it("retries long-poll token even when retryCode is non-zero, if capacity exists", async () => {
@@ -269,6 +261,7 @@ describe(StandardRetryStrategy.name, () => {
             getRetryCost: () => 0,
             getRetryDelay: () => 0,
             isLongPoll: () => true,
+            $retryLog: { acquisitionDelay: 0 },
           }) as any
       );
       const retryStrategy = new StandardRetryStrategy(maxAttempts);
@@ -289,7 +282,7 @@ describe(StandardRetryStrategy.name, () => {
         Retry.v2026 = originalV2026;
       });
 
-      it("throws with non-zero $backoff for code 3", async () => {
+      it("sleeps and throws for code 3 (capacity exhausted)", async () => {
         vi.mocked(DefaultRetryToken).mockImplementation(
           () =>
             ({
@@ -305,13 +298,12 @@ describe(StandardRetryStrategy.name, () => {
         });
         retryStrategy["capacity"] = 0;
         const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
-        await expect(retryStrategy.refreshRetryTokenForRetry(token, errorInfo)).rejects.toMatchObject({
-          message: "No retry token available",
-          $backoff: 50, // b=1 * min(50 * 2^0, 20000) = 50
-        });
+        await expect(retryStrategy.refreshRetryTokenForRetry(token, errorInfo)).rejects.toThrow(
+          "No retry token available"
+        );
       });
 
-      it("throws with $backoff=0 for non-capacity code", async () => {
+      it("throws without sleeping for non-capacity code", async () => {
         vi.mocked(DefaultRetryToken).mockImplementation(
           () =>
             ({
@@ -325,10 +317,7 @@ describe(StandardRetryStrategy.name, () => {
         const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
         await expect(
           retryStrategy.refreshRetryTokenForRetry(token, { errorType: "CLIENT_ERROR" } as RetryErrorInfo)
-        ).rejects.toMatchObject({
-          message: "No retry token available",
-          $backoff: 0,
-        });
+        ).rejects.toThrow("No retry token available");
       });
     });
   });

--- a/packages/core/src/submodules/retry/util-retry/StandardRetryStrategy.ts
+++ b/packages/core/src/submodules/retry/util-retry/StandardRetryStrategy.ts
@@ -56,8 +56,8 @@ const refusal = {
 export class StandardRetryStrategy implements RetryStrategyV2 {
   public readonly mode: string = RETRY_MODES.STANDARD;
 
+  protected readonly retryBackoffStrategy: StandardRetryBackoffStrategy;
   private capacity: number = INITIAL_RETRY_TOKENS;
-  private readonly retryBackoffStrategy: StandardRetryBackoffStrategy;
   private readonly maxAttemptsProvider: Provider<number>;
   private readonly baseDelay: number;
 
@@ -113,19 +113,25 @@ export class StandardRetryStrategy implements RetryStrategyV2 {
          * that capacity is exhausted. Running out of attempts or having a
          * non-retryable error does *not* apply backoff.
          */
-        throw Object.assign(new Error("No retry token available"), {
-          $backoff: Retry.v2026 && retryCode === refusal.capacity && isLongPoll ? retryDelay : 0,
-        });
+        const longPollBackoff = Retry.v2026 && retryCode === refusal.capacity && isLongPoll ? retryDelay : 0;
+        if (longPollBackoff > 0) {
+          await new Promise((r) => setTimeout(r, longPollBackoff));
+        }
       } else {
         const capacityCost = this.getCapacityCost(errorType);
         this.capacity -= capacityCost;
 
-        return new DefaultRetryToken(
-          retryDelay,
+        const nextToken = new DefaultRetryToken(
+          0, // delay now happens in this method.
           token.getRetryCount() + 1,
           capacityCost,
           token.isLongPoll?.() ?? false
         );
+
+        await new Promise((r) => setTimeout(r, retryDelay));
+        nextToken.$retryLog.acquisitionDelay = retryDelay;
+
+        return nextToken;
       }
     }
 

--- a/packages/core/src/submodules/retry/util-retry/retries.integ.spec.ts
+++ b/packages/core/src/submodules/retry/util-retry/retries.integ.spec.ts
@@ -3,7 +3,7 @@ import { cbor } from "@smithy/core/cbor";
 import { HttpResponse } from "@smithy/protocol-http";
 import type { RetryErrorType, StandardRetryToken } from "@smithy/types";
 import { requireRequestsFrom } from "@smithy/util-test/src";
-import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
+import { afterAll, beforeAll, describe, expect, test as it, vi } from "vitest";
 import { XYZService } from "xyz";
 
 import { DefaultRetryBackoffStrategy } from "./DefaultRetryBackoffStrategy";
@@ -160,10 +160,22 @@ describe("retries", () => {
 
 describe(StandardRetryStrategy.name, () => {
   const inline = (token: StandardRetryToken) => {
-    return [token.getRetryCount(), token.getRetryCost(), token.getRetryDelay(), token.isLongPoll?.()];
+    return [
+      token.getRetryCount(),
+      token.getRetryCost(),
+      token.$retryLog?.acquisitionDelay || token.getRetryDelay(),
+      token.isLongPoll?.(),
+    ];
   };
 
   describe("retry timings", () => {
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+
+    afterAll(() => {
+      vi.useRealTimers();
+    });
     const testCases: Array<{
       name: string;
       timings: [RetryErrorType, number, number | undefined, number, boolean][];
@@ -354,10 +366,11 @@ describe(StandardRetryStrategy.name, () => {
               const token = await retryStrategy.acquireInitialRetryToken(scope ?? "none");
               tokens.push(token);
             } else {
-              const token = await retryStrategy.refreshRetryTokenForRetry(tokens[i - 1], {
+              const retryTokenPromise = retryStrategy.refreshRetryTokenForRetry(tokens[i - 1], {
                 errorType: timings[i][0],
               });
-              tokens.push(token);
+              await vi.advanceTimersByTimeAsync(timings[i][3]);
+              tokens.push(await retryTokenPromise);
             }
 
             expect(inline(tokens[i])).toEqual(timings[i].slice(1));
@@ -500,6 +513,14 @@ describe("specification tests", () => {
   });
 
   describe("StandardRetryStrategy unit tests", () => {
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+
+    afterAll(() => {
+      vi.useRealTimers();
+    });
+
     for (const tc of specTestCases) {
       describe(tc.name, () => {
         let strategy: StandardRetryStrategy;
@@ -533,9 +554,11 @@ describe("specification tests", () => {
 
             if (outcome === "retry_request") {
               const errorType = errorTypeForResponse(step.response);
-              currentToken = await strategy.refreshRetryTokenForRetry(currentToken, { errorType });
+              const retryTokenPromise = strategy.refreshRetryTokenForRetry(currentToken, { errorType });
+              await vi.advanceTimersByTimeAsync(delay! * 1000);
+              currentToken = await retryTokenPromise;
               expect(strategy.getCapacity()).toEqual(retry_quota);
-              expect(currentToken.getRetryDelay()).toEqual(delay! * 1000);
+              expect(currentToken.$retryLog?.acquisitionDelay).toEqual(delay! * 1000);
               return;
             }
 

--- a/packages/types/src/retry.ts
+++ b/packages/types/src/retry.ts
@@ -87,11 +87,25 @@ export interface RetryStrategyOptions {
  */
 export interface RetryToken {
   /**
+   * Starts at 0 for the initial request, which is not a "retry" by definition.
+   * 1 indicates the first retry.
+   *
    * @returns the current count of retry.
    */
   getRetryCount(): number;
 
   /**
+   * RetryStrategies implemented by `@smithy/core` will return tokens with a
+   * delay of zero.
+   *
+   * This is because the RetryStrategy token acquisition methods took over the
+   * task of idling for the delay period. If a user-implemented retry token
+   * contains a delay, the default Smithy retry middleware will still honor it.
+   *
+   * That is to say, you may either sleep within the RetryStrategy methods for acquiring
+   * the token, OR return a token with a retry delay that will cause the retry middleware
+   * to sleep.
+   *
    * @returns the number of milliseconds to wait before retrying an action.
    */
   getRetryDelay(): number;
@@ -100,6 +114,15 @@ export interface RetryToken {
    * @returns whether the operation which generated this token is long polling.
    */
   isLongPoll?(): boolean;
+
+  /**
+   * Delays that have already been executed by the time the token
+   * is accessible. This is needed for the token handler to understand what has happened.
+   * @internal
+   */
+  $retryLog?: {
+    acquisitionDelay?: number;
+  };
 }
 
 /**
@@ -133,6 +156,9 @@ export interface RetryStrategyV2 {
    * either choose to allow another retry and send a new or updated token,
    * or reject the retry attempt and report the error either in an exception
    * or returning an error.
+   *
+   * This method should either delay internally and return a token with 0 delay, OR
+   * do not sleep and return a token with the desired delay duration.
    */
   refreshRetryTokenForRetry(tokenToRenew: RetryToken, errorInfo: RetryErrorInfo): Promise<RetryToken>;
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -299,6 +299,8 @@ public final class CodegenUtils {
                     }
                 } else if (value instanceof String) {
                     functionParametersList.add(String.format("%s: '%s'", key, value));
+                } else if (value instanceof Number) {
+                    functionParametersList.add(String.format("%s: %s", key, value));
                 } else if (value instanceof Boolean) {
                     functionParametersList.add(String.format("%s: %s", key, value));
                 } else if (value instanceof List) {


### PR DESCRIPTION
*Issue #, if available:*
JS-6872

*Description of changes:*

This moves the adaptive rate limiter to right before any request (initial or retry). 

Previously the rate limiter would fire after a request and before exponential backoff. Although this resulted in approximately the same amount of rate-limiting in aggregate, the ordering was incorrect.