### PR TITLE
docs(undici-http-handler): add migrating from NodeHttpHandler section

### DIFF
--- a/.changeset/perfect-bottles-kick.md
+++ b/.changeset/perfect-bottles-kick.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+Add a "Migrating from NodeHttpHandler" section to theundici-http-handler README that maps each NodeHttpHandler option toits undici Dispatcher equivalent, with a before/after example.

--- a/.changeset/perfect-bottles-kick.md
+++ b/.changeset/perfect-bottles-kick.md
@@ -2,4 +2,4 @@
 "@smithy/undici-http-handler": patch
 ---
 
-Add a "Migrating from NodeHttpHandler" section to theundici-http-handler README that maps each NodeHttpHandler option toits undici Dispatcher equivalent, with a before/after example.
+Add a "Migrating from NodeHttpHandler" section to the undici-http-handler README that maps each NodeHttpHandler option to its undici Dispatcher equivalent, with a before/after example.

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -113,6 +113,45 @@ The `NodeHttpHandler` is configured with top-level timeout fields and
 `http.Agent`/`https.Agent` instances, whereas `UndiciHttpHandler` is configured
 with a single undici `Dispatcher` (or `Agent.Options`).
 
+### Before / After example
+
+This shows the most commonly configured options. See [Option mapping](#option-mapping) below for the complete list.
+
+```js
+// Before: NodeHttpHandler
+import { Agent as HttpsAgent } from "node:https";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+
+new NodeHttpHandler({
+  connectionTimeout: 3000,
+  requestTimeout: 5000,
+  socketTimeout: 4000,
+  httpsAgent: new HttpsAgent({
+    maxSockets: 50,
+    keepAlive: true,
+    keepAliveMsecs: 1000,
+  }),
+});
+```
+
+```js
+// After: UndiciHttpHandler
+import { UndiciHttpHandler } from "@smithy/undici-http-handler";
+
+new UndiciHttpHandler({
+  dispatcher: {
+    connections: 50, // maxSockets
+    headersTimeout: 5000, // requestTimeout
+    bodyTimeout: 4000, // socketTimeout (inactivity during a request)
+    connect: {
+      timeout: 3000, // connectionTimeout
+      keepAlive: true, // http(s)Agent.keepAlive
+      keepAliveInitialDelay: 1000, // http(s)Agent.keepAliveMsecs
+    },
+  },
+});
+```
+
 ### Option mapping
 
 The sections below map each `NodeHttpHandler` option to its undici equivalent.
@@ -247,43 +286,6 @@ import { UndiciHttpHandler } from "@smithy/undici-http-handler";
 import { EnvHttpProxyAgent } from "undici";
 
 new UndiciHttpHandler({ dispatcher: new EnvHttpProxyAgent() });
-```
-
-### Before / after example
-
-```js
-// Before: NodeHttpHandler
-import { Agent as HttpsAgent } from "node:https";
-import { NodeHttpHandler } from "@smithy/node-http-handler";
-
-new NodeHttpHandler({
-  connectionTimeout: 3000,
-  requestTimeout: 5000,
-  socketTimeout: 4000,
-  httpsAgent: new HttpsAgent({
-    maxSockets: 50,
-    keepAlive: true,
-    keepAliveMsecs: 1000,
-  }),
-});
-```
-
-```js
-// After: UndiciHttpHandler
-import { UndiciHttpHandler } from "@smithy/undici-http-handler";
-
-new UndiciHttpHandler({
-  dispatcher: {
-    connections: 50,
-    headersTimeout: 5000, // requestTimeout
-    bodyTimeout: 4000, // socketTimeout (inactivity during a request)
-    connect: {
-      timeout: 3000, // connectionTimeout
-      keepAlive: true, // http(s)Agent.keepAlive
-      keepAliveInitialDelay: 1000, // http(s)Agent.keepAliveMsecs
-    },
-  },
-});
 ```
 
 ## Benchmarks

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -145,8 +145,11 @@ the same stalled-request cases.
 #### `httpAgent` / `httpsAgent`
 
 Maps to `dispatcher`. A single undici `Dispatcher` handles both `http:` and
-`https:`; there is no separate agent per protocol. The nested agent options map
-as follows:
+`https:`; there is no separate agent per protocol.
+
+If you previously passed a third-party proxy agent (e.g. `proxy-agent`, `https-proxy-agent`) here, use undici's built-in `ProxyAgent` as the `dispatcher` instead — see [Proxies](#proxies).
+
+The nested agent options map as follows:
 
 - `keepAlive` (`true`) — default behavior. undici pools and reuses
   connections by default. Set [`dispatcher.pipelining: 0`][undici-client-options]
@@ -179,9 +182,17 @@ unavailable:
   by `keepAliveTimeout` / `keepAliveMaxTimeout` instead.
 - `scheduling` — undici uses its own pool scheduling and does not expose a
   free-socket ordering option (`'fifo'` / `'lifo'`).
+- `proxyEnv` — Node's built-in env-var proxy support (Node 24+, gated behind
+  `NODE_USE_ENV_PROXY`), not a classic `http.Agent` option. undici reads the
+  same `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` variables via its
+  `EnvHttpProxyAgent` dispatcher — see [Proxies](#proxies).
 - `defaultPort` / `protocol` — no per-dispatcher setting. undici derives the
   origin (scheme, host, port) from the request URL, so there is nothing to
   default.
+
+> **Note:** `proxyEnv`, `defaultPort`, and `protocol` are not classic
+> `http.Agent` options — they come from Node's built-in proxy support (Node 24+,
+> gated behind `NODE_USE_ENV_PROXY`) and are unavailable on older Node versions.
 
 #### `throwOnRequestTimeout`
 
@@ -197,10 +208,46 @@ this warning.
 
 Maps to `logger`. Passed at the top level, same as `NodeHttpHandler`.
 
-> **Note:** undici also has a `keepAliveTimeout` option, but it has no
-> `NodeHttpHandler` counterpart. It controls how long an _idle_ pooled socket
-> (with no active requests) is kept open for reuse — a different concept from
-> `socketTimeout`, which guards against inactivity during an in-flight request.
+### Proxies
+
+`NodeHttpHandler` has no built-in proxy support, so proxy use typically meant
+installing a third-party agent (e.g. `proxy-agent`, `https-proxy-agent`,
+`hpagent`) and passing it as `httpAgent`/`httpsAgent`:
+
+```js
+// Before: NodeHttpHandler with a third-party proxy agent
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { HttpsProxyAgent } from "https-proxy-agent";
+
+const proxyAgent = new HttpsProxyAgent("http://localhost:8080");
+
+new NodeHttpHandler({
+  httpsAgent: proxyAgent,
+});
+```
+
+undici ships a `ProxyAgent` (a `Dispatcher`), so you no longer need a
+third-party dependency. Pass it as the `dispatcher`:
+
+```js
+// After: UndiciHttpHandler with undici's built-in ProxyAgent
+import { UndiciHttpHandler } from "@smithy/undici-http-handler";
+import { ProxyAgent } from "undici";
+
+const dispatcher = new ProxyAgent("http://localhost:8080");
+
+new UndiciHttpHandler({ dispatcher });
+```
+
+To pick up the standard `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` environment
+variables automatically, use `EnvHttpProxyAgent` instead:
+
+```js
+import { UndiciHttpHandler } from "@smithy/undici-http-handler";
+import { EnvHttpProxyAgent } from "undici";
+
+new UndiciHttpHandler({ dispatcher: new EnvHttpProxyAgent() });
+```
 
 ### Before / after example
 

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -113,21 +113,66 @@ The `NodeHttpHandler` is configured with top-level timeout fields and
 `http.Agent`/`https.Agent` instances, whereas `UndiciHttpHandler` is configured
 with a single undici `Dispatcher` (or `Agent.Options`).
 
-The table below maps each `NodeHttpHandler` option to its
-undici equivalent.
+### Option mapping
 
-| `NodeHttpHandler` option          | `UndiciHttpHandler` equivalent                         | Notes                                                                                                                                                                                                                  |
-| --------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `connectionTimeout`               | `dispatcher.connect.timeout`                           | Time allowed for the connect (and TLS) phase.                                                                                                                                                                          |
-| `requestTimeout`                  | `dispatcher.headersTimeout` / `dispatcher.bodyTimeout` | undici splits this into time-to-headers and time-between-body-chunks. The per-request `requestTimeout` option also sets both.                                                                                          |
-| `socketTimeout`                   | `dispatcher.bodyTimeout` / `dispatcher.headersTimeout` | Node's `socketTimeout` fires on socket inactivity during an in-flight request. undici's `bodyTimeout` (time between body chunks) and `headersTimeout` (time waiting for headers) cover the same stalled-request cases. |
-| `httpAgent` / `httpsAgent`        | `dispatcher`                                           | A single undici `Dispatcher` handles both `http:` and `https:`; there is no separate agent per protocol.                                                                                                               |
-| `httpAgent.maxSockets`            | `dispatcher.connections`                               | Maximum connections undici opens per origin. undici defaults to unlimited; `NodeHttpHandler` defaults to `50`.                                                                                                         |
-| `httpAgent.keepAlive` (`true`)    | (default)                                              | undici pools and reuses connections by default. Set `dispatcher.pipelining: 0` to avoid reusing a connection for new requests.                                                                                         |
-| `httpAgent.keepAliveMsecs`        | `dispatcher.connect.keepAliveInitialDelay`             | TCP keep-alive probe delay (`socket.setKeepAlive`). Set `connect.keepAlive: true` to enable it on the undici connector.                                                                                                |
-| `throwOnRequestTimeout`           | (default)                                              | undici always throws on timeout; this handler surfaces it as a `TimeoutError`. There is no warning-only mode to opt out of.                                                                                            |
-| `socketAcquisitionWarningTimeout` | _no equivalent_                                        | undici manages its own connection pool queue and does not emit this warning.                                                                                                                                           |
-| `logger`                          | `logger`                                               | Passed at the top level, same as `NodeHttpHandler`.                                                                                                                                                                    |
+The sections below map each `NodeHttpHandler` option to its undici equivalent.
+When you pass plain options instead of a `Dispatcher` instance, the handler
+treats them as undici [`Agent.Options`][undici-agent-options], which extend
+[`Pool` options][undici-pool-options] and, in turn, [`Client`
+options][undici-client-options]; `connect.*` options come from
+[`ConnectOptions`][undici-connect-options].
+
+#### `connectionTimeout`
+
+Maps to [`dispatcher.connect.timeout`][undici-connect-options]. Time allowed for
+the connect (and TLS) phase.
+
+#### `requestTimeout`
+
+Maps to [`dispatcher.headersTimeout`][undici-client-options] and
+[`dispatcher.bodyTimeout`][undici-client-options]. undici splits this into
+time-to-headers and time-between-body-chunks. The per-request `requestTimeout`
+option also sets both.
+
+#### `socketTimeout`
+
+Maps to [`dispatcher.bodyTimeout`][undici-client-options] and
+[`dispatcher.headersTimeout`][undici-client-options]. Node's `socketTimeout`
+fires on socket inactivity during an in-flight request. undici's `bodyTimeout`
+(time between body chunks) and `headersTimeout` (time waiting for headers) cover
+the same stalled-request cases.
+
+#### `httpAgent` / `httpsAgent`
+
+Maps to `dispatcher`. A single undici `Dispatcher` handles both `http:` and
+`https:`; there is no separate agent per protocol. The nested agent options map
+as follows:
+
+- `keepAlive` (`true`) — default behavior. undici pools and reuses
+  connections by default. Set [`dispatcher.pipelining: 0`][undici-client-options]
+  to avoid reusing a connection for new requests.
+- `keepAliveMsecs` — maps to
+  [`dispatcher.connect.keepAliveInitialDelay`][undici-connect-options]. TCP
+  keep-alive probe delay (`socket.setKeepAlive`). Set `connect.keepAlive: true`
+  to enable it on the undici connector.
+- `maxSockets` — maps to
+  [`dispatcher.connections`][undici-pool-options]. Maximum connections undici
+  opens per origin. undici defaults to unlimited; `NodeHttpHandler` defaults to
+  `50`.
+
+#### `throwOnRequestTimeout`
+
+Default behavior. undici always throws on timeout; this handler surfaces it as a
+`TimeoutError`. There is no warning-only mode to opt out of.
+
+#### `socketAcquisitionWarningTimeout`
+
+No equivalent. undici manages its own connection pool queue and does not emit
+this warning.
+
+#### `logger`
+
+Maps to `logger`. Passed at the top level, same as `NodeHttpHandler`.
 
 > **Note:** undici also has a `keepAliveTimeout` option, but it has no
 > `NodeHttpHandler` counterpart. It controls how long an _idle_ pooled socket
@@ -188,3 +233,7 @@ results will vary depending on workload, network conditions, and environment.
 
 [undici]: https://undici.nodejs.org/
 [node-http-handler]: https://www.npmjs.com/package/@smithy/node-http-handler
+[undici-agent-options]: https://github.com/nodejs/undici/blob/main/docs/docs/api/Agent.md#parameter-agentoptions
+[undici-pool-options]: https://github.com/nodejs/undici/blob/main/docs/docs/api/Pool.md#parameter-pooloptions
+[undici-client-options]: https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md#parameter-clientoptions
+[undici-connect-options]: https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md#parameter-connectoptions

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://img.shields.io/npm/v/@smithy/undici-http-handler/latest.svg)](https://www.npmjs.com/package/@smithy/undici-http-handler)
 [![NPM downloads](https://img.shields.io/npm/dm/@smithy/undici-http-handler.svg)](https://www.npmjs.com/package/@smithy/undici-http-handler)
 
-Smithy-compatible HTTP handler backed by modern and high performance Node.js [undici][].
+Smithy-compatible HTTP handler backed by modern, high performance Node.js [undici][] client.
 
 ## Usage
 
@@ -104,6 +104,73 @@ client.listTables({}).then(console.log);
 > in your application — improvements in newer releases (HTTP parser, connection
 > pooling, etc.) will then apply to requests made through this handler.
 
+## Migrating from NodeHttpHandler
+
+`UndiciHttpHandler` does not accept the same options as
+[`NodeHttpHandler`][node-http-handler].
+
+The `NodeHttpHandler` is configured with top-level timeout fields and
+`http.Agent`/`https.Agent` instances, whereas `UndiciHttpHandler` is configured
+with a single undici `Dispatcher` (or `Agent.Options`).
+
+The table below maps each `NodeHttpHandler` option to its
+undici equivalent.
+
+| `NodeHttpHandler` option          | `UndiciHttpHandler` equivalent                         | Notes                                                                                                                                                                                                                  |
+| --------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connectionTimeout`               | `dispatcher.connect.timeout`                           | Time allowed for the connect (and TLS) phase.                                                                                                                                                                          |
+| `requestTimeout`                  | `dispatcher.headersTimeout` / `dispatcher.bodyTimeout` | undici splits this into time-to-headers and time-between-body-chunks. The per-request `requestTimeout` option also sets both.                                                                                          |
+| `socketTimeout`                   | `dispatcher.bodyTimeout` / `dispatcher.headersTimeout` | Node's `socketTimeout` fires on socket inactivity during an in-flight request. undici's `bodyTimeout` (time between body chunks) and `headersTimeout` (time waiting for headers) cover the same stalled-request cases. |
+| `httpAgent` / `httpsAgent`        | `dispatcher`                                           | A single undici `Dispatcher` handles both `http:` and `https:`; there is no separate agent per protocol.                                                                                                               |
+| `httpAgent.maxSockets`            | `dispatcher.connections`                               | Maximum connections undici opens per origin. undici defaults to unlimited; `NodeHttpHandler` defaults to `50`.                                                                                                         |
+| `httpAgent.keepAlive` (`true`)    | (default)                                              | undici pools and reuses connections by default. Set `dispatcher.pipelining: 0` to avoid reusing a connection for new requests.                                                                                         |
+| `httpAgent.keepAliveMsecs`        | `dispatcher.connect.keepAliveInitialDelay`             | TCP keep-alive probe delay (`socket.setKeepAlive`). Set `connect.keepAlive: true` to enable it on the undici connector.                                                                                                |
+| `throwOnRequestTimeout`           | (default)                                              | undici always throws on timeout; this handler surfaces it as a `TimeoutError`. There is no warning-only mode to opt out of.                                                                                            |
+| `socketAcquisitionWarningTimeout` | _no equivalent_                                        | undici manages its own connection pool queue and does not emit this warning.                                                                                                                                           |
+| `logger`                          | `logger`                                               | Passed at the top level, same as `NodeHttpHandler`.                                                                                                                                                                    |
+
+> **Note:** undici also has a `keepAliveTimeout` option, but it has no
+> `NodeHttpHandler` counterpart. It controls how long an _idle_ pooled socket
+> (with no active requests) is kept open for reuse — a different concept from
+> `socketTimeout`, which guards against inactivity during an in-flight request.
+
+### Before / after example
+
+```js
+// Before: NodeHttpHandler
+import { Agent as HttpsAgent } from "node:https";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+
+new NodeHttpHandler({
+  connectionTimeout: 3000,
+  requestTimeout: 5000,
+  socketTimeout: 4000,
+  httpsAgent: new HttpsAgent({
+    maxSockets: 50,
+    keepAlive: true,
+    keepAliveMsecs: 1000,
+  }),
+});
+```
+
+```js
+// After: UndiciHttpHandler
+import { UndiciHttpHandler } from "@smithy/undici-http-handler";
+
+new UndiciHttpHandler({
+  dispatcher: {
+    connections: 50,
+    headersTimeout: 5000, // requestTimeout
+    bodyTimeout: 4000, // socketTimeout (inactivity during a request)
+    connect: {
+      timeout: 3000, // connectionTimeout
+      keepAlive: true, // http(s)Agent.keepAlive
+      keepAliveInitialDelay: 1000, // http(s)Agent.keepAliveMsecs
+    },
+  },
+});
+```
+
 ## Benchmarks
 
 Our benchmark spin up a local HTTP server and runs two scenarios:
@@ -120,3 +187,4 @@ We recommend running benchmarks for your own use case on your own setup, as
 results will vary depending on workload, network conditions, and environment.
 
 [undici]: https://undici.nodejs.org/
+[node-http-handler]: https://www.npmjs.com/package/@smithy/node-http-handler

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -104,6 +104,21 @@ client.listTables({}).then(console.log);
 > in your application — improvements in newer releases (HTTP parser, connection
 > pooling, etc.) will then apply to requests made through this handler.
 
+## Benchmarks
+
+Our benchmark spin up a local HTTP server and runs two scenarios:
+
+- **10 sequential GETs** – measures per-request latency when requests are issued
+  one after another.
+- **50 concurrent GETs** – measures throughput under parallel load using
+  `Promise.all`.
+
+The results show UndiciHttpHandler spends **35%-45%** less time in request handling
+as compared to NodeHttpHandler from `@smithy/node-http-handler`.
+
+We recommend running benchmarks for your own use case on your own setup, as
+results will vary depending on workload, network conditions, and environment.
+
 ## Migrating from NodeHttpHandler
 
 `UndiciHttpHandler` does not accept the same options as
@@ -287,21 +302,6 @@ import { EnvHttpProxyAgent } from "undici";
 
 new UndiciHttpHandler({ dispatcher: new EnvHttpProxyAgent() });
 ```
-
-## Benchmarks
-
-Our benchmark spin up a local HTTP server and runs two scenarios:
-
-- **10 sequential GETs** – measures per-request latency when requests are issued
-  one after another.
-- **50 concurrent GETs** – measures throughput under parallel load using
-  `Promise.all`.
-
-The results show UndiciHttpHandler spends **35%-45%** less time in request handling
-as compared to NodeHttpHandler from `@smithy/node-http-handler`.
-
-We recommend running benchmarks for your own use case on your own setup, as
-results will vary depending on workload, network conditions, and environment.
 
 [undici]: https://undici.nodejs.org/
 [node-http-handler]: https://www.npmjs.com/package/@smithy/node-http-handler

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -159,6 +159,29 @@ as follows:
   [`dispatcher.connections`][undici-pool-options]. Maximum connections undici
   opens per origin. undici defaults to unlimited; `NodeHttpHandler` defaults to
   `50`.
+- `agentKeepAliveTimeoutBuffer` — maps to
+  [`dispatcher.keepAliveTimeoutThreshold`][undici-client-options]. Both subtract
+  a buffer (in ms) from the server's `keep-alive: timeout=...` hint so the client
+  closes the socket slightly before the server does. undici defaults to `2000`.
+- `timeout` — maps mainly to [`dispatcher.connect.timeout`][undici-connect-options]
+  for the connect phase. Node's Agent `timeout` is the default socket timeout for
+  created sockets; undici covers the in-flight side with `headersTimeout` /
+  `bodyTimeout` (see `requestTimeout` and `socketTimeout` above).
+
+The following agent options have no direct dispatcher equivalent. undici manages
+the connection pool differently, so these knobs are either unnecessary or
+unavailable:
+
+- `maxTotalSockets` — undici caps connections per origin (`connections`), not
+  globally. The closest option is [`dispatcher.maxOrigins`][undici-agent-options],
+  which limits how many origins receive requests, not the total socket count.
+- `maxFreeSockets` — undici has no idle-socket count cap. Idle sockets are reaped
+  by `keepAliveTimeout` / `keepAliveMaxTimeout` instead.
+- `scheduling` — undici uses its own pool scheduling and does not expose a
+  free-socket ordering option (`'fifo'` / `'lifo'`).
+- `defaultPort` / `protocol` — no per-dispatcher setting. undici derives the
+  origin (scheme, host, port) from the request URL, so there is nothing to
+  default.
 
 #### `throwOnRequestTimeout`
 
@@ -237,3 +260,5 @@ results will vary depending on workload, network conditions, and environment.
 [undici-pool-options]: https://github.com/nodejs/undici/blob/main/docs/docs/api/Pool.md#parameter-pooloptions
 [undici-client-options]: https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md#parameter-clientoptions
 [undici-connect-options]: https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md#parameter-connectoptions
+[undici-env-proxy-agent]: https://github.com/nodejs/undici/blob/main/docs/docs/api/EnvHttpProxyAgent.md
+[undici-proxy-agent]: https://github.com/nodejs/undici/blob/main/docs/docs/api/ProxyAgent.md

--- a/packages/undici-http-handler/package.json
+++ b/packages/undici-http-handler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smithy/undici-http-handler",
   "version": "2.0.1",
-  "description": "Smithy-compatible HTTP handler backed by modern and high performance Node.js undici",
+  "description": "Smithy-compatible HTTP handler backed by modern, high performance Node.js undici client",
   "scripts": {
     "build": "concurrently 'yarn:build:types' 'yarn:build:es:cjs'",
     "build:es:cjs": "yarn g:tsc -p tsconfig.es.json && node ../../scripts/inline undici-http-handler",


### PR DESCRIPTION
*Issue #, if available:*

Requests from slack

*Description of changes:*

Add a "Migrating from NodeHttpHandler" section to the undici-http-handler README that maps each NodeHttpHandler option to its undici Dispatcher equivalent, with a before/after example.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
