### PR TITLE
fix(node-http-handler): make compatible with patches to the http/https default export objects

### DIFF
--- a/.changeset/light-ants-join.md
+++ b/.changeset/light-ants-join.md
@@ -1,0 +1,6 @@
+---
+"@smithy/credential-provider-imds": patch
+"@smithy/node-http-handler": patch
+---
+
+import node:http,https,http2 using default export object (writable)

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,49 @@ module.exports = {
       files: ["packages/*/src/**/*.ts"],
       excludedFiles: ["packages/*/src/**/*.spec.ts"],
       rules: {
+        "@typescript-eslint/no-restricted-imports": [
+          "error",
+          {
+            paths: [
+              {
+                name: "http",
+                importNames: ["Agent", "ClientRequest", "CloseEvent", "IncomingMessage", "METHODS", "MessageEvent", "OutgoingMessage", "STATUS_CODES", "Server", "ServerResponse", "WebSocket", "_connectionListener", "createServer", "get", "globalAgent", "maxHeaderSize", "request", "setMaxIdleHTTPParsers", "validateHeaderName", "validateHeaderValue"],
+                allowTypeImports: true,
+                message: "Use a default import so runtime HTTP request interception keeps working.",
+              },
+              {
+                name: "node:http",
+                importNames: ["Agent", "ClientRequest", "CloseEvent", "IncomingMessage", "METHODS", "MessageEvent", "OutgoingMessage", "STATUS_CODES", "Server", "ServerResponse", "WebSocket", "_connectionListener", "createServer", "get", "globalAgent", "maxHeaderSize", "request", "setMaxIdleHTTPParsers", "validateHeaderName", "validateHeaderValue"],
+                allowTypeImports: true,
+                message: "Use a default import so runtime HTTP request interception keeps working.",
+              },
+              {
+                name: "https",
+                importNames: ["Agent", "Server", "createServer", "get", "globalAgent", "request"],
+                allowTypeImports: true,
+                message: "Use a default import so runtime HTTP request interception keeps working.",
+              },
+              {
+                name: "node:https",
+                importNames: ["Agent", "Server", "createServer", "get", "globalAgent", "request"],
+                allowTypeImports: true,
+                message: "Use a default import so runtime HTTP request interception keeps working.",
+              },
+              {
+                name: "http2",
+                importNames: ["Http2ServerRequest", "Http2ServerResponse", "connect", "constants", "createSecureServer", "createServer", "getDefaultSettings", "getPackedSettings", "getUnpackedSettings", "performServerHandshake", "sensitiveHeaders"],
+                allowTypeImports: true,
+                message: "Use a default import so runtime HTTP request interception keeps working.",
+              },
+              {
+                name: "node:http2",
+                importNames: ["Http2ServerRequest", "Http2ServerResponse", "connect", "constants", "createSecureServer", "createServer", "getDefaultSettings", "getPackedSettings", "getUnpackedSettings", "performServerHandshake", "sensitiveHeaders"],
+                allowTypeImports: true,
+                message: "Use a default import so runtime HTTP request interception keeps working.",
+              },
+            ],
+          },
+        ],
         "no-restricted-imports": [
           "error",
           {

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ test-integration:
 	make static-analysis;
 	make api-snapshot;
 	make test-browser;
+	node ./packages/node-http-handler/test/node-http-handler.interception.mjs
 	yarn g:vitest run -c vitest.config.integ.mts;
 	make test-types;
 	make test-bundlers;

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -1,12 +1,14 @@
-import { request, type IncomingMessage, type RequestOptions } from "node:http";
+import type { IncomingMessage, RequestOptions } from "node:http";
 import { ProviderError } from "@smithy/core/config";
+
+import { node_http } from "./node-http";
 
 /**
  * @internal
  */
 export function httpRequest(options: RequestOptions): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const req = request({
+    const req = node_http.request({
       method: "GET",
       ...options,
       // Node.js http module doesn't accept hostname with square brackets

--- a/packages/credential-provider-imds/src/remoteProvider/node-http.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/node-http.ts
@@ -1,0 +1,3 @@
+import node_http from "node:http";
+
+export { node_http };

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -1,11 +1,12 @@
 import type { Agent as hAgentType, request as hRequestType } from "node:http";
-import { Agent as hsAgent, request as hsRequest, type RequestOptions } from "node:https";
+import type { RequestOptions, Agent as hsAgentType } from "node:https";
 import { HttpResponse, buildQueryString, type HttpHandler, type HttpRequest } from "@smithy/core/protocols";
 import type { HttpHandlerOptions, Logger, NodeHttpHandlerOptions, Provider } from "@smithy/types";
 
 import { buildAbortError } from "./build-abort-error";
 import { NODEJS_TIMEOUT_ERROR_CODES } from "./constants";
 import { getTransformedHeaders } from "./get-transformed-headers";
+import { node_https } from "./node-https";
 import { setConnectionTimeout } from "./set-connection-timeout";
 import { setRequestTimeout } from "./set-request-timeout";
 import { setSocketKeepAlive } from "./set-socket-keep-alive";
@@ -18,7 +19,7 @@ export { NodeHttpHandlerOptions };
 interface ResolvedNodeHttpHandlerConfig extends Omit<NodeHttpHandlerOptions, "httpAgent" | "httpsAgent"> {
   httpAgentProvider: () => Promise<hAgentType>;
   httpAgent?: hAgentType;
-  httpsAgent: hsAgent;
+  httpsAgent: hsAgentType;
 }
 
 /**
@@ -69,7 +70,7 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
    * @returns timestamp of last emitted warning.
    */
   public static checkSocketUsage(
-    agent: hAgentType | hsAgent,
+    agent: hAgentType | hsAgentType,
     socketWarningTimestamp: number,
     logger: Logger = console
   ): number {
@@ -195,7 +196,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         // Because awaiting 100-continue desynchronizes the request and request body transmission,
         // such requests must be offloaded to a separate Agent instance.
         // Additional logic will exist on the client using this handler to determine whether to add the header at all.
-        agent = new (isSSL ? hsAgent : hAgent!)({
+        agent = new (isSSL ? node_https.Agent : hAgent!)({
           keepAlive: false,
           // This is an explicit value matching the default (Infinity).
           // This should allow the connection to close cleanly after making the single request.
@@ -249,7 +250,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
       };
 
       // create the http request
-      const requestFunc = isSSL ? hsRequest : hRequest!;
+      const requestFunc = isSSL ? node_https.request : hRequest!;
 
       const req = requestFunc(nodeHttpsOptions, (res) => {
         const httpResponse = new HttpResponse({
@@ -356,7 +357,8 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
       socketAcquisitionWarningTimeout,
       throwOnRequestTimeout,
       httpAgentProvider: async () => {
-        const { Agent, request } = await import("node:http");
+        const node_http = await import("node:http");
+        const { Agent, request } = node_http.default ?? node_http;
         hRequest = request;
         hAgent = Agent;
 
@@ -367,11 +369,11 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         return new hAgent({ keepAlive, maxSockets, ...httpAgent });
       },
       httpsAgent: (() => {
-        if (httpsAgent instanceof hsAgent || typeof (httpsAgent as hsAgent)?.destroy === "function") {
+        if (httpsAgent instanceof node_https.Agent || typeof (httpsAgent as hsAgentType)?.destroy === "function") {
           this.externalAgent = true;
-          return httpsAgent as hsAgent;
+          return httpsAgent as hsAgentType;
         }
-        return new hsAgent({ keepAlive, maxSockets, ...httpsAgent });
+        return new node_https.Agent({ keepAlive, maxSockets, ...httpsAgent });
       })(),
       logger,
     };

--- a/packages/node-http-handler/src/node-http.spec.ts
+++ b/packages/node-http-handler/src/node-http.spec.ts
@@ -1,0 +1,11 @@
+import node_http from "node:http";
+import { describe, test as it } from "vitest";
+
+/**
+ * @deprecated for tests only. Runtime import of node:http is async.
+ */
+export { node_http };
+
+describe("placeholder", () => {
+  it("", () => {});
+});

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -1,11 +1,14 @@
-import { constants, type ClientSessionOptions, type SecureClientSessionOptions } from "node:http2";
+import type { ClientSessionOptions, SecureClientSessionOptions } from "node:http2";
 import { HttpResponse, buildQueryString, type HttpHandler, type HttpRequest } from "@smithy/core/protocols";
 import type { HttpHandlerOptions, Provider, RequestContext } from "@smithy/types";
 
 import { buildAbortError } from "./build-abort-error";
 import { getTransformedHeaders } from "./get-transformed-headers";
+import { node_http2 } from "./node-http2";
 import { NodeHttp2ConnectionManager } from "./node-http2-connection-manager";
 import { writeRequestBody } from "./write-request-body";
+
+const { constants } = node_http2;
 
 /**
  * Represents the http2 options that can be passed to a node http2 client.

--- a/packages/node-http-handler/src/node-http2.ts
+++ b/packages/node-http-handler/src/node-http2.ts
@@ -1,0 +1,3 @@
+import node_http2 from "node:http2";
+
+export { node_http2 };

--- a/packages/node-http-handler/src/node-https.ts
+++ b/packages/node-http-handler/src/node-https.ts
@@ -1,0 +1,3 @@
+import node_https from "node:https";
+
+export { node_https };

--- a/packages/node-http-handler/src/server.mock.ts
+++ b/packages/node-http-handler/src/server.mock.ts
@@ -1,18 +1,17 @@
 import { readFileSync } from "node:fs";
-import { createServer as createHttp2Server, type Http2Server } from "node:http2";
-import {
-  createServer as createHttpServer,
-  type Server as HttpServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
-import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import type { Http2Server } from "node:http2";
+import type { Server as HttpServer, IncomingMessage, ServerResponse } from "node:http";
+import type { Server as HttpsServer } from "node:https";
 import { join } from "node:path";
 import { Readable } from "node:stream";
 import type { HeaderBag, HttpResponse, NodeJsRuntimeBlobTypes } from "@smithy/types";
 
+import { node_http2 } from "./node-http2";
+import { node_http } from "./node-http.spec";
+import { node_https } from "./node-https";
 import { timing } from "./timing";
 
+const { createServer: createHttpsServer } = node_https;
 const fixturesDir = join(__dirname, "..", "fixtures");
 
 const setResponseHeaders = (response: ServerResponse, headers: HeaderBag) => {
@@ -66,13 +65,11 @@ export const createMockHttpsServer = (): HttpsServer => {
 };
 
 export const createMockHttpServer = (): HttpServer => {
-  const server = createHttpServer();
-  return server;
+  return node_http.createServer();
 };
 
 export const createMockHttp2Server = (): Http2Server => {
-  const server = createHttp2Server();
-  return server;
+  return node_http2.createServer();
 };
 
 export const createMirrorResponseFunction =

--- a/packages/node-http-handler/test/node-http-handler.interception.mjs
+++ b/packages/node-http-handler/test/node-http-handler.interception.mjs
@@ -1,0 +1,65 @@
+/**
+ * This test is in mjs because we do not want the transform applied by any test framework
+ * to interfere with the assertions.
+ */
+import http from "node:http";
+import https from "node:https";
+import { NodeHttpHandler } from "../dist-cjs/index.js";
+import { HttpRequest } from "@smithy/core/protocols";
+
+const originalHttpRequest = http.request;
+const originalHttpsRequest = https.request;
+
+let failures = 0;
+
+// Test http interception
+{
+  let called = false;
+  http.request = function (...args) {
+    called = true;
+    throw new Error("intercepted");
+  };
+
+  try {
+    const handler = new NodeHttpHandler();
+    await handler.handle(
+      new HttpRequest({ protocol: "http:", hostname: "localhost", method: "GET", path: "/", headers: {} })
+    );
+  } catch {}
+
+  http.request = originalHttpRequest;
+
+  if (called) {
+    console.log("✅ http.request interception works");
+  } else {
+    console.log("❌ http.request interception FAILED");
+    failures++;
+  }
+}
+
+// Test https interception
+{
+  let called = false;
+  https.request = function (...args) {
+    called = true;
+    throw new Error("intercepted");
+  };
+
+  try {
+    const handler = new NodeHttpHandler();
+    await handler.handle(
+      new HttpRequest({ protocol: "https:", hostname: "localhost", method: "GET", path: "/", headers: {} })
+    );
+  } catch {}
+
+  https.request = originalHttpsRequest;
+
+  if (called) {
+    console.log("✅ https.request interception works");
+  } else {
+    console.log("❌ https.request interception FAILED");
+    failures++;
+  }
+}
+
+process.exit(failures);

--- a/packages/undici-http-handler/src/undici-http-handler.bench.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.bench.ts
@@ -1,4 +1,5 @@
 import { once } from "node:events";
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { createServer } from "node:http";
 import { HttpRequest } from "@smithy/core/protocols";
 import { NodeHttpHandler } from "@smithy/node-http-handler";

--- a/scripts/validation/eslint.js
+++ b/scripts/validation/eslint.js
@@ -35,7 +35,7 @@ function main() {
   }
 
   try {
-    const output = execFileSync("npx", ["eslint", "-c", eslintConfig, "--format", "json", ...globs], {
+    const output = execFileSync("npx", ["eslint", "--quiet", "-c", eslintConfig, "--format", "json", ...globs], {
       cwd: root,
       stdio: "pipe",
       encoding: "utf-8",
@@ -44,7 +44,7 @@ function main() {
     const errorCount = results.reduce((sum, r) => sum + r.errorCount, 0);
     if (errorCount > 0) {
       // Re-run with default formatter for readable output.
-      execFileSync("npx", ["eslint", "-c", eslintConfig, ...globs], {
+      execFileSync("npx", ["eslint", "--quiet", "-c", eslintConfig, ...globs], {
         cwd: root,
         stdio: "pipe",
         encoding: "utf-8",
@@ -64,7 +64,7 @@ function main() {
     } catch {}
     // Re-run with stylish output for readable errors.
     try {
-      execFileSync("npx", ["eslint", "-c", eslintConfig, ...globs], {
+      execFileSync("npx", ["eslint", "--quiet", "-c", eslintConfig, ...globs], {
         cwd: root,
         stdio: "pipe",
         encoding: "utf-8",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/smithy-lang/smithy-typescript/issues/2067

see also https://github.com/smithy-lang/smithy-typescript/pull/2054

*Description of changes:*

for node's http, https, and http2, import the writable default export object (same as require) so that instrumentation patches work with smithy clients
