### PR TITLE
fix(codegen): swap ser/de generation for event streams

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -119,8 +119,8 @@ public class EventStreamGenerator {
             new TreeSet<>((a, b) -> Objects.compare(a.getRight(), b.getRight(), StructureShape::compareTo));
 
         for (OperationShape operation : operations) {
-            if (hasEventStreamInput(context, operation)) {
-                UnionShape eventsUnion = getEventStreamInputShape(context, operation);
+            if (hasEventStreamOutput(context, operation)) {
+                UnionShape eventsUnion = getEventStreamOutputShape(context, operation);
                 eventUnionsToSerialize.add(eventsUnion);
                 eventsUnion
                     .members()
@@ -180,8 +180,8 @@ public class EventStreamGenerator {
         TreeSet<StructureShape> eventShapesToUnmarshall = new TreeSet<>();
 
         for (OperationShape operation : operations) {
-            if (hasEventStreamOutput(context, operation)) {
-                UnionShape eventsUnion = getEventStreamOutputShape(context, operation);
+            if (hasEventStreamInput(context, operation)) {
+                UnionShape eventsUnion = getEventStreamInputShape(context, operation);
                 eventUnionsToDeserialize.add(eventsUnion);
                 Set<StructureShape> eventShapes = eventsUnion
                     .members()


### PR DESCRIPTION
Hi! Maybe I'm just missing something here, but serialization generation for event streams is backwards? It generates a serializer for input streams and a deserializer for output streams. The generated code doesn't compile because the wrong function exists:

`[build:types] src/protocols/Aws_restJson1.ts(62,21): error TS2552: Cannot find name 'de_ServerInputStream'. Did you mean 'se_ServerInputStream'?`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
