### PR TITLE
chore(undici-http-handler): update benchmark to include Client Dispatcher

### DIFF
--- a/.changeset/beige-pens-sniff.md
+++ b/.changeset/beige-pens-sniff.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": patch
+---
+
+Add Client dispatcher benchmark

--- a/packages/undici-http-handler/README.md
+++ b/packages/undici-http-handler/README.md
@@ -106,15 +106,19 @@ client.listTables({}).then(console.log);
 
 ## Benchmarks
 
-Our benchmark spin up a local HTTP server and runs two scenarios:
+Our benchmark spins up a local HTTP server and runs two scenarios:
 
 - **10 sequential GETs** – measures per-request latency when requests are issued
   one after another.
 - **50 concurrent GETs** – measures throughput under parallel load using
   `Promise.all`.
 
-The results show UndiciHttpHandler spends **35%-45%** less time in request handling
+The results show UndiciHttpHandler spends **35%-50%** less time in request handling
 as compared to NodeHttpHandler from `@smithy/node-http-handler`.
+
+If your application only talks to a single origin, passing a `Client` as the
+dispatcher gives an additional **5%-20%** improvement over the default `Agent` by
+skipping per-origin routing.
 
 We recommend running benchmarks for your own use case on your own setup, as
 results will vary depending on workload, network conditions, and environment.

--- a/packages/undici-http-handler/src/undici-http-handler.bench.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.bench.ts
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import { createServer } from "node:http";
 import { HttpRequest } from "@smithy/core/protocols";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
-import { Agent } from "undici";
+import { Agent, Client } from "undici";
 import { afterAll, beforeAll, bench, describe } from "vitest";
 
 import { UndiciHttpHandler } from "./undici-http-handler";
@@ -69,6 +69,11 @@ const undiciDispatcher = new Agent({
 });
 const undiciHandler = new UndiciHttpHandler({ dispatcher: undiciDispatcher });
 
+// Client skips per-origin routing that Agent performs, giving lower overhead
+// when all requests go to the same origin.
+let undiciClientDispatcher: Client;
+let undiciClientHandler: UndiciHttpHandler;
+
 // ---------------------------------------------------------------------------
 // 4. Lifecycle
 // ---------------------------------------------------------------------------
@@ -79,15 +84,27 @@ beforeAll(async () => {
   const addr = server.address();
   port = typeof addr === "object" && addr !== null ? addr.port : 0;
 
-  // Warm up both handlers so first-request setup cost is excluded.
+  // Create Client after we know the port (Client requires a known origin).
+  undiciClientDispatcher = new Client(`http://127.0.0.1:${port}`, {
+    pipelining: 10,
+    bodyTimeout: 3000,
+    headersTimeout: 3000,
+    connect: { timeout: 3000 },
+  });
+  undiciClientHandler = new UndiciHttpHandler({ dispatcher: undiciClientDispatcher });
+
+  // Warm up all handlers so first-request setup cost is excluded.
   await drain((await nodeHandler.handle(makeRequest())).response);
   await drain((await undiciHandler.handle(makeRequest())).response);
+  await drain((await undiciClientHandler.handle(makeRequest())).response);
 });
 
 afterAll(() => {
   nodeHandler.destroy();
   undiciHandler.destroy();
+  undiciClientHandler.destroy();
   undiciDispatcher.destroy();
+  undiciClientDispatcher.destroy();
   server.close();
 });
 
@@ -109,6 +126,13 @@ describe("10 sequential GETs", () => {
       await drain(response);
     }
   });
+
+  bench("UndiciHttpHandler (Client)", async () => {
+    for (let i = 0; i < 10; i++) {
+      const { response } = await undiciClientHandler.handle(makeRequest());
+      await drain(response);
+    }
+  });
 });
 
 describe("50 concurrent GETs", () => {
@@ -123,6 +147,14 @@ describe("50 concurrent GETs", () => {
   bench("UndiciHttpHandler", async () => {
     const tasks = Array.from({ length: 50 }, async () => {
       const { response } = await undiciHandler.handle(makeRequest());
+      await drain(response);
+    });
+    await Promise.all(tasks);
+  });
+
+  bench("UndiciHttpHandler (Client)", async () => {
+    const tasks = Array.from({ length: 50 }, async () => {
+      const { response } = await undiciClientHandler.handle(makeRequest());
       await drain(response);
     });
     await Promise.all(tasks);


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Add UndiciHttpHandler with Client dispatcher to benchmarks to
demonstrate the additional performance gain when all requests target
a single origin. Update README benchmarks section.

I used lower and upper limits of values shown by re-running the benchmarks 4-5 times

Example output:
```console
  UndiciHttpHandler (Client) - src/undici-http-handler.bench.ts > 10 sequential GETs
    1.15x faster than UndiciHttpHandler
    1.80x faster than NodeHttpHandler

  UndiciHttpHandler (Client) - src/undici-http-handler.bench.ts > 50 concurrent GETs
    1.07x faster than UndiciHttpHandler
    1.40x faster than NodeHttpHandler
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
