### PR TITLE
fix(core/retry): limit Retry-After header delay in deprecated StandardRetryStrategy

### DIFF
--- a/.changeset/olive-fishes-compete.md
+++ b/.changeset/olive-fishes-compete.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+add upper bound for Retry-After delay in deprecated StandardRetryStrategy

--- a/packages/core/src/submodules/retry/middleware-retry/retry-pre-sra-deprecated/StandardRetryStrategy.ts
+++ b/packages/core/src/submodules/retry/middleware-retry/retry-pre-sra-deprecated/StandardRetryStrategy.ts
@@ -150,8 +150,8 @@ const getDelayFromRetryAfterHeader = (response: unknown): number | undefined => 
   const retryAfter = response.headers[retryAfterHeaderName];
 
   const retryAfterSeconds = Number(retryAfter);
-  if (!Number.isNaN(retryAfterSeconds)) return retryAfterSeconds * 1000;
+  if (!Number.isNaN(retryAfterSeconds)) return Math.min(retryAfterSeconds * 1000, 20_000);
 
   const retryAfterDate = new Date(retryAfter);
-  return retryAfterDate.getTime() - Date.now();
+  return Math.min(retryAfterDate.getTime() - Date.now(), 20_000);
 };


### PR DESCRIPTION
*Issue #, if available:*
Internal P441716414

*Description of changes:*
Adds an upper bound for server-side Retry-After delay value.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
