### PR TITLE
fix(core/retry): use natural binding for setTimeout call

### DIFF
--- a/.changeset/red-islands-sing.md
+++ b/.changeset/red-islands-sing.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix call to setTimeout in DefaultRateLimiter, browser compatibility

--- a/packages/core/src/submodules/retry/util-retry/DefaultRateLimiter.ts
+++ b/packages/core/src/submodules/retry/util-retry/DefaultRateLimiter.ts
@@ -41,7 +41,9 @@ export class DefaultRateLimiter implements RateLimiter {
   /**
    * Only used in testing.
    */
-  private static setTimeoutFn = setTimeout;
+  // Wrapped in an arrow to preserve `this` binding — browsers throw
+  // "Illegal invocation" if setTimeout is called with our class as `this` instead of window or undefined.
+  private static setTimeoutFn = (fn: Function, delay: number) => setTimeout(fn, delay);
 
   // User configurable constants
   private readonly beta: number;


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

assigning the `setTimeout` ref to a static method causes an illegal invocation in browsers. `setTimeout` can only be called when bound to window (interface) or undefined in browsers.