### PR TITLE
feat(core/cbor): string caches for CBOR serde performance

### DIFF
--- a/.changeset/spotty-grapes-fly.md
+++ b/.changeset/spotty-grapes-fly.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+CBOR performance improvements

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -7,3 +7,6 @@
 *.log
 package-lock.json
 !*.d.ts
+.cbor-perf-worker.cjs
+scripts/baseline/node_modules/
+scripts/baseline/package-lock.json

--- a/packages/core/planning/cbor.md
+++ b/packages/core/planning/cbor.md
@@ -1,0 +1,123 @@
+# CBOR Performance Benchmarks
+
+Script: `yarn test:cbor:perf` in core.
+
+## Test Cases
+
+| Test Case                          | Data Size | Repetitions | CBOR Cumulative | JSON Cumulative | CBOR/JSON Size |
+| ---------------------------------- | --------: | ----------: | --------------: | --------------: | -------------: |
+| `string`                           |    413 kb |          60 |           25 mb |           25 mb |           1.00 |
+| `list<string(0,180)>`              |    477 kb |          60 |           29 mb |           29 mb |           0.99 |
+| `list<float>`                      |    270 kb |          60 |           16 mb |           40 mb |           0.40 |
+| `list<double>`                     |    270 kb |          60 |           16 mb |           42 mb |           0.38 |
+| `list<int>`                        |    253 kb |          60 |           15 mb |           27 mb |           0.55 |
+| `list<long int>`                   |    250 kb |          60 |           15 mb |           33 mb |           0.46 |
+| `list<long long int>`              |    450 kb |          60 |           27 mb |           66 mb |           0.41 |
+| `map<string(0,30), string(0,450)>` |    453 kb |          60 |           27 mb |           27 mb |           0.99 |
+| `map<string(0,30), long int>`      |     37 kb |          60 |            2 mb |            3 mb |           0.75 |
+| `list<struct> PutMetricData-like`  |    363 kb |          60 |           22 mb |           28 mb |           0.79 |
+| `struct PutMetricData realistic`   |    1.7 mb |          60 |          101 mb |          130 mb |           0.78 |
+| `list<struct> non-ASCII keys`      |    399 kb |          60 |           24 mb |           29 mb |           0.83 |
+
+## Benchmark Results
+
+### Baseline: @smithy/core (npm)
+
+| Test Case                          | CBOR ser | CBOR de | CBOR ser ms | CBOR de ms | JSON ser ms | JSON de ms |
+| ---------------------------------- | -------: | ------: | ----------: | ---------: | ----------: | ---------: |
+| `string`                           |  517mb/s | 369mb/s |       48 ms |      67 ms |       72 ms |      31 ms |
+| `list<string(0,180)>`              |  724mb/s | 991mb/s |       39 ms |      29 ms |       39 ms |      16 ms |
+| `list<float>`                      |  181mb/s | 295mb/s |       90 ms |      55 ms |      212 ms |     178 ms |
+| `list<double>`                     |  150mb/s | 294mb/s |      108 ms |      55 ms |      242 ms |     173 ms |
+| `list<int>`                        |   96mb/s | 165mb/s |      159 ms |      92 ms |       99 ms |      96 ms |
+| `list<long int>`                   |  211mb/s | 280mb/s |       71 ms |      54 ms |      129 ms |     107 ms |
+| `list<long long int>`              |  160mb/s | 112mb/s |      169 ms |     240 ms |      362 ms |     260 ms |
+| `map<string(0,30), string(0,450)>` |  725mb/s | 676mb/s |       37 ms |      40 ms |       42 ms |      23 ms |
+| `map<string(0,30), long int>`      |  228mb/s | 104mb/s |       10 ms |      22 ms |       10 ms |      14 ms |
+| `list<struct> PutMetricData-like`  |  154mb/s |  78mb/s |      142 ms |     281 ms |       88 ms |     153 ms |
+| `struct PutMetricData realistic`   |  174mb/s |  88mb/s |      581 ms |    1144 ms |      350 ms |     566 ms |
+| `list<struct> non-ASCII keys`      |  128mb/s |  86mb/s |      188 ms |     279 ms |       71 ms |     105 ms |
+
+CBOR timing ratio (lower is better):
+
+| Test Case                          | CBOR ser ratio | CBOR de ratio |
+| ---------------------------------- | -------------: | ------------: |
+| `string`                           |           0.66 |          2.16 |
+| `list<string(0,180)>`              |           1.00 |          1.84 |
+| `list<float>`                      |           0.42 |          0.31 |
+| `list<double>`                     |           0.45 |          0.32 |
+| `list<int>`                        |           1.61 |          0.96 |
+| `list<long int>`                   |           0.55 |          0.50 |
+| `list<long long int>`              |           0.47 |          0.92 |
+| `map<string(0,30), string(0,450)>` |           0.88 |          1.74 |
+| `map<string(0,30), long int>`      |           0.95 |          1.52 |
+| `list<struct> PutMetricData-like`  |           1.61 |          1.84 |
+| `struct PutMetricData realistic`   |           1.66 |          2.02 |
+| `list<struct> non-ASCII keys`      |           2.65 |          2.66 |
+
+### June 2026 optimizations
+
+| Test Case                          | CBOR ser |  CBOR de | CBOR ser ms | CBOR de ms | JSON ser ms | JSON de ms |
+| ---------------------------------- | -------: | -------: | ----------: | ---------: | ----------: | ---------: |
+| `string`                           |  683mb/s |  369mb/s |       36 ms |      67 ms |       72 ms |      31 ms |
+| `list<string(0,180)>`              |  761mb/s | 1264mb/s |       38 ms |      23 ms |       39 ms |      16 ms |
+| `list<float>`                      |  275mb/s |  408mb/s |       59 ms |      40 ms |      212 ms |     178 ms |
+| `list<double>`                     |  273mb/s |  408mb/s |       59 ms |      40 ms |      242 ms |     173 ms |
+| `list<int>`                        |   92mb/s |  173mb/s |      165 ms |      88 ms |       99 ms |      96 ms |
+| `list<long int>`                   |  203mb/s |  300mb/s |       74 ms |      50 ms |      129 ms |     107 ms |
+| `list<long long int>`              |  310mb/s |  187mb/s |       87 ms |     145 ms |      362 ms |     260 ms |
+| `map<string(0,30), string(0,450)>` |  796mb/s |  824mb/s |       34 ms |      33 ms |       42 ms |      23 ms |
+| `map<string(0,30), long int>`      |  232mb/s |  108mb/s |        9 ms |      20 ms |       10 ms |      14 ms |
+| `list<struct> PutMetricData-like`  |  232mb/s |  149mb/s |       94 ms |     146 ms |       88 ms |     153 ms |
+| `struct PutMetricData realistic`   |  253mb/s |  157mb/s |      398 ms |     643 ms |      350 ms |     566 ms |
+| `list<struct> non-ASCII keys`      |  289mb/s |   87mb/s |       83 ms |     276 ms |       71 ms |     105 ms |
+
+CBOR timing ratio (lower is better):
+
+| Test Case                          | CBOR ser ratio | CBOR de ratio |
+| ---------------------------------- | -------------: | ------------: |
+| `string`                           |           0.50 |          2.16 |
+| `list<string(0,180)>`              |           0.97 |          1.44 |
+| `list<float>`                      |           0.28 |          0.22 |
+| `list<double>`                     |           0.24 |          0.23 |
+| `list<int>`                        |           1.67 |          0.92 |
+| `list<long int>`                   |           0.57 |          0.47 |
+| `list<long long int>`              |           0.24 |          0.56 |
+| `map<string(0,30), string(0,450)>` |           0.81 |          1.43 |
+| `map<string(0,30), long int>`      |           0.90 |          1.43 |
+| `list<struct> PutMetricData-like`  |           1.07 |          0.95 |
+| `struct PutMetricData realistic`   |           1.14 |          1.14 |
+| `list<struct> non-ASCII keys`      |           1.17 |          2.63 |
+
+- **Integer encoding without BigInt**: integers > 32 bits are written as two
+  `setUint32` calls instead of allocating a `BigInt` for `setBigUint64`.
+  Tightened `ensureSpace` checks avoid redundant capacity calculations per
+  loop iteration.
+
+- **Generational string caches**: short strings
+  are cached as encoded/decoded values with 2048 capacity. Each `serialize()`/`deserialize()`
+  call advances a generation counter. Eviction is only allowed if the inhabitant is from a prior
+  generation.
+  - This handles two common categories of data:
+    - Data containing repeated shapes have their keys (and values, if enumerable) cached.
+    - Maps with many arbitrary string keys/values are prevented from thrashing the cache within in a single
+      generation.
+
+## June 2026 CBOR incremental diff against baseline
+
+Blank deltas are <5% diff.
+
+| Test Case                         | Δ ser throughput |     Δ ser time | Δ de throughput |       Δ de time |
+| --------------------------------- | ---------------: | -------------: | --------------: | --------------: |
+| string                            |             +32% |   48ms -> 36ms |                 |                 |
+| list\<string(0,180)>              |                  |                |            +28% |    29ms -> 23ms |
+| list\<float>                      |             +52% |   90ms -> 59ms |            +38% |    55ms -> 40ms |
+| list\<double>                     |             +82% |  108ms -> 59ms |            +39% |    55ms -> 40ms |
+| list\<int>                        |                  |                |             +5% |    92ms -> 88ms |
+| list\<long int>                   |                  |                |             +7% |    54ms -> 50ms |
+| list\<long long int>              |             +94% |  169ms -> 87ms |            +67% |  240ms -> 145ms |
+| map\<string(0,30), string(0,450)> |             +10% |   37ms -> 34ms |            +22% |    40ms -> 33ms |
+| map\<string(0,30), long int>      |                  |                |                 |                 |
+| list\<struct> PutMetricData-like  |             +51% |  142ms -> 94ms |            +92% |  281ms -> 146ms |
+| struct PutMetricData realistic    |             +45% | 581ms -> 398ms |            +78% | 1144ms -> 643ms |
+| list\<struct> non-ASCII keys      |            +126% |  188ms -> 83ms |                 |                 |

--- a/packages/core/scripts/baseline/package.json
+++ b/packages/core/scripts/baseline/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "@smithy/core": "3.25.0"
+  }
+}

--- a/packages/core/scripts/cbor-perf.mjs
+++ b/packages/core/scripts/cbor-perf.mjs
@@ -1,262 +1,258 @@
-import { fromBase64, toBase64 } from "@smithy/util-base64";
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import * as SmithyCbor from "../dist-cjs/submodules/cbor/index.js";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const coreDir = resolve(__dirname, "..");
+const baselineDir = resolve(__dirname, "baseline");
+const workerPaths = {
+  current: resolve(coreDir, ".cbor-perf-worker.cjs"),
+  baseline: resolve(baselineDir, ".cbor-perf-worker.cjs"),
+};
 
-/**
- * Control the test data size with this scalar.
- */
+if (!existsSync(resolve(baselineDir, "node_modules"))) {
+  console.log("Installing baseline dependencies...");
+  execSync("npm install", { cwd: baselineDir, stdio: "inherit" });
+}
+
+const cborRequires = {
+  current: `require(${JSON.stringify(resolve(coreDir, "dist-cjs/submodules/cbor/index.js"))})`,
+  baseline: `require("@smithy/core/cbor")`,
+};
+const base64Requires = {
+  current: `require(${JSON.stringify(resolve(coreDir, "dist-cjs/submodules/serde/index.js"))})`,
+  baseline: `require("@smithy/core/serde")`,
+};
+
 const DATA_SCALAR = 5;
+const SCALE = (3 * 100) / DATA_SCALAR;
 
-const tests = [
+const testDefs = [
   {
     name: "string",
-    data: (() => {
-      const buffer = [];
-      for (let i = 0; i < 3400 * DATA_SCALAR; ++i) {
-        buffer[i] = Math.random() + "";
-      }
-      return buffer.join("代码");
-    })(),
-    run: true,
-  },
-  {
-    name: "list<char>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 9000 * DATA_SCALAR; ++i) {
-        list[i] = "abcdefghijklmnopqrstuvwxyz"[(Math.random() * 26) | 0];
-      }
-      return list;
-    })(),
-    run: false,
+    gen: `(() => { const b=[]; for(let i=0;i<3400*${DATA_SCALAR};++i) b[i]=Math.random()+""; return b.join("代码"); })()`,
   },
   {
     name: "list<string(0,180)>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 900 * DATA_SCALAR; ++i) {
-        list[i] = "string".repeat((Math.random() * 35) | 0);
-      }
-      return list;
-    })(),
-    run: true,
-  },
-  {
-    name: "list<float(0,1)>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 6000 * DATA_SCALAR; ++i) {
-        list[i] = Math.random() * 2 - 1;
-      }
-      return list;
-    })(),
-    run: false,
+    gen: `(() => { const l=[]; for(let i=0;i<900*${DATA_SCALAR};++i) l[i]="string".repeat((Math.random()*35)|0); return l; })()`,
   },
   {
     name: "list<float>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 6000 * DATA_SCALAR; ++i) {
-        list[i] = Math.random() * 3.4e38;
-      }
-      return list;
-    })(),
-    run: true,
+    gen: `(() => { const l=[]; for(let i=0;i<6000*${DATA_SCALAR};++i) l[i]=Math.random()*3.4e38; return l; })()`,
   },
   {
     name: "list<double>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 6000 * DATA_SCALAR; ++i) {
-        list[i] = Math.random() * Number.MAX_VALUE;
-      }
-      return list;
-    })(),
-    run: true,
+    gen: `(() => { const l=[]; for(let i=0;i<6000*${DATA_SCALAR};++i) l[i]=Math.random()*Number.MAX_VALUE; return l; })()`,
   },
-  {
-    name: "byte[]",
-    data: (() => {
-      const list = new Uint8Array(100000 * DATA_SCALAR);
-      for (let i = 0; i < list.length; ++i) {
-        list[i] = ((Math.random() * 20000) | 0) % 255;
-      }
-      return list;
-    })(),
-    run: true,
-  },
+  // {
+  //   name: "byte[]",
+  //   gen: `(() => { const l=new Uint8Array(${100000 * DATA_SCALAR}); for(let i=0;i<l.length;++i) l[i]=((Math.random()*20000)|0)%255; return l; })()`,
+  // },
   {
     name: "list<int>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 17000 * DATA_SCALAR; ++i) {
-        list[i] = ((Math.random() * 20000) | 0) - 10000;
-      }
-      return list;
-    })(),
-    run: true,
+    gen: `(() => { const l=[]; for(let i=0;i<17000*${DATA_SCALAR};++i) l[i]=((Math.random()*20000)|0)-10000; return l; })()`,
   },
   {
     name: "list<long int>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 10000 * DATA_SCALAR; ++i) {
-        list[i] = Math.floor(Math.random() * 0x7fffffff * 2 - 0x7fffffff);
-      }
-      return list;
-    })(),
-    run: true,
+    gen: `(() => { const l=[]; for(let i=0;i<10000*${DATA_SCALAR};++i) l[i]=Math.floor(Math.random()*0x7fffffff*2-0x7fffffff); return l; })()`,
   },
   {
     name: "list<long long int>",
-    data: (() => {
-      const list = [];
-      for (let i = 0; i < 10000 * DATA_SCALAR; ++i) {
-        list[i] = Math.floor(-18446744073709551615 + ((Math.random() * 2 * 18446744073709551615) | 0));
-      }
-      return list;
-    })(),
-    run: true,
-  },
-  {
-    name: "map<int, char>",
-    data: (() => {
-      const map = {};
-      for (let i = 0; i < 2000 * DATA_SCALAR; ++i) {
-        map[i] = "abcdefg"[(Math.random() * 5.999) | 0];
-      }
-      return map;
-    })(),
-    run: false,
+    gen: `(() => { const l=[]; for(let i=0;i<10000*${DATA_SCALAR};++i) l[i]=Math.floor(-18446744073709551615+((Math.random()*2*18446744073709551615)|0)); return l; })()`,
   },
   {
     name: "map<string(0,30), string(0,450)>",
-    data: (() => {
-      const map = {};
-      for (let i = 0; i < 324 * DATA_SCALAR; ++i) {
-        map["key".repeat((Math.random() * 10) | 0) + i] = "key".repeat((Math.random() * 155) | 0) + i + Math.random();
-      }
-      return map;
-    })(),
-    run: true,
+    gen: `(() => { const m={}; for(let i=0;i<324*${DATA_SCALAR};++i) m["key".repeat((Math.random()*10)|0)+i]="key".repeat((Math.random()*155)|0)+i+Math.random(); return m; })()`,
   },
   {
     name: "map<string(0,30), long int>",
-    data: (() => {
-      const map = {};
-      for (let i = 0; i < 324 * DATA_SCALAR; ++i) {
-        map["key".repeat((Math.random() * 10) | 0) + i] = Math.floor(Math.random() * 0x7fffffff * 2 - 0x7fffffff);
-      }
-      return map;
-    })(),
-    run: true,
+    gen: `(() => { const m={}; for(let i=0;i<324*${DATA_SCALAR};++i) m["key".repeat((Math.random()*10)|0)+i]=Math.floor(Math.random()*0x7fffffff*2-0x7fffffff); return m; })()`,
   },
   {
     name: "list<struct> PutMetricData-like",
-    data: (() => {
-      const collection = [];
-      for (let i = 0; i < 600 * DATA_SCALAR; ++i) {
-        collection[i] = {
-          MetricData: [
-            {
-              MetricName: "PAGES_VISITED",
-              Dimensions: [
-                {
-                  Name: "UNIQUE_PAGES",
-                  Value: "URLS",
-                },
-              ],
-              Unit: "None",
-              Value: 1.0,
-            },
-          ],
-          Namespace: "SITE/TRAFFIC",
-        };
-      }
-      return collection;
-    })(),
-    run: true,
+    gen: `(() => { const c=[]; for(let i=0;i<600*${DATA_SCALAR};++i) c[i]={MetricData:[{MetricName:"PAGES_VISITED",Dimensions:[{Name:"UNIQUE_PAGES",Value:"URLS"}],Unit:"None",Value:1.0}],Namespace:"SITE/TRAFFIC"}; return c; })()`,
+  },
+  {
+    name: "struct PutMetricData realistic",
+    gen: `(() => {
+      const req = {Namespace:"MyApp/Production",MetricData:Array.from({length:20},(_,i)=>({MetricName:"RequestLatency_"+(i%5),Dimensions:[{Name:"Environment",Value:"prod"},{Name:"Region",Value:"us-east-1"},{Name:"ServiceName",Value:"AuthService"}],Timestamp:1718000000+i,Value:Math.random()*500,Unit:"Milliseconds",...(i%3===0?{StatisticValues:{SampleCount:100,Sum:4500.0+i,Minimum:1.2,Maximum:89.5}}:{})}))};
+      const c=[]; for(let i=0;i<80*${DATA_SCALAR};++i) c[i]=req; return c;
+    })()`,
+  },
+  {
+    name: "list<struct> non-ASCII keys",
+    gen: `(() => { const c=[]; for(let i=0;i<600*${DATA_SCALAR};++i) c[i]={"メトリック名":"PAGES_VISITED","ディメンション":[{"名前":"UNIQUE_PAGES","値":"URLS"}],"単位":"None","数値":1.0,"名前空間":"SITE/TRAFFIC"}; return c; })()`,
   },
 ];
 
-const { cbor } = SmithyCbor;
+/**
+ * @param {"cbor-encode"|"cbor-decode"|"json-encode"|"json-decode"} phase
+ * @param {"current"|"baseline"} impl
+ */
+function runPhase(testIdx, phase, impl) {
+  const t = testDefs[testIdx];
+  const isCbor = phase.startsWith("cbor");
+  const isEncode = phase.endsWith("encode");
+  const cwd = impl === "baseline" ? baselineDir : coreDir;
+
+  const script = `
+const { fromBase64, toBase64 } = ${base64Requires[impl]};
+const { cbor } = ${cborRequires[impl]};
 cbor.resizeEncodingBuffer(10_000_000);
 
-const SCALE = (3 * 100) / DATA_SCALAR;
-class Row {
-  constructor(data) {
-    Object.assign(this, data);
-  }
+const SCALE = ${SCALE};
+const name = ${JSON.stringify(t.name)};
+const data = ${t.gen};
+
+const cborSerialized = cbor.serialize(data);
+const jsonSerialized = name === "byte[]" ? JSON.stringify(toBase64(data)) : JSON.stringify(data);
+const bytes = cborSerialized.byteLength;
+const jsonBytes = Buffer.from(jsonSerialized).byteLength;
+
+// Warm up
+for (let i = 0; i < 50; i++) {
+  ${isCbor && isEncode ? "cbor.serialize(data);" : ""}
+  ${isCbor && !isEncode ? "cbor.deserialize(cborSerialized);" : ""}
+  ${!isCbor && isEncode ? 'if (name === "byte[]") JSON.stringify(toBase64(data)); else JSON.stringify(data);' : ""}
+  ${!isCbor && !isEncode ? 'if (name === "byte[]") fromBase64(JSON.parse(jsonSerialized)); else JSON.parse(jsonSerialized);' : ""}
 }
-const rows = {};
 
-for (const { name, data, run, nonScaling } of tests) {
-  if (!run) {
-    continue;
-  }
-  const scale = nonScaling ? 1 : SCALE;
+const a = performance.now();
+for (let i = 0; i < SCALE; i++) {
+  ${isCbor && isEncode ? "cbor.serialize(data);" : ""}
+  ${isCbor && !isEncode ? "cbor.deserialize(cborSerialized);" : ""}
+  ${!isCbor && isEncode ? 'if (name === "byte[]") JSON.stringify(toBase64(data)); else JSON.stringify(data);' : ""}
+  ${!isCbor && !isEncode ? 'if (name === "byte[]") fromBase64(JSON.parse(jsonSerialized)); else JSON.parse(jsonSerialized);' : ""}
+}
+const ms = performance.now() - a;
+console.log(JSON.stringify({ ms, bytes, jsonBytes }));
+`;
+  const wp = workerPaths[impl];
+  writeFileSync(wp, script);
+  const result = execFileSync("node", [wp], { cwd, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+  return JSON.parse(result.trim());
+}
 
-  const A = performance.now();
-  let cborSerialized;
-  {
-    for (let i = 0; i < scale; ++i) {
-      cborSerialized = cbor.serialize(data);
-    }
-  }
-  const B = performance.now();
-  let cborDeserialized;
-  {
-    for (let i = 0; i < scale; ++i) {
-      cborDeserialized = cbor.deserialize(cborSerialized);
-    }
-  }
-  const C = performance.now();
-  const D = performance.now();
-  const E = performance.now();
-  const F = performance.now();
-  const G = performance.now();
+function mdTable(headers, rows) {
+  const cols = headers.map((h, i) => {
+    const max = Math.max(h.length, ...rows.map((r) => String(r[i]).length));
+    return { width: max, align: i === 0 ? "l" : "r" };
+  });
+  const pad = (s, i) => {
+    const str = String(s);
+    const diff = cols[i].width - str.length;
+    return cols[i].align === "r" ? " ".repeat(diff) + str : str + " ".repeat(diff);
+  };
+  const line = (cells) => "| " + cells.map((c, i) => pad(c, i)).join(" | ") + " |";
+  const sep = "| " + cols.map((c) => (c.align === "r" ? "-".repeat(c.width - 1) + ":" : "-".repeat(c.width))).join(" | ") + " |";
+  return [line(headers), sep, ...rows.map((r) => line(r))].join("\n");
+}
 
-  let jsonSerialized;
-  {
-    for (let i = 0; i < scale; ++i) {
-      if (name === "byte[]") {
-        jsonSerialized = JSON.stringify(toBase64(data));
-      } else {
-        jsonSerialized = JSON.stringify(data);
-      }
-    }
-  }
-  const H = performance.now();
-  let jsonDeserialized;
-  {
-    for (let i = 0; i < scale; ++i) {
-      if (name === "byte[]") {
-        jsonDeserialized = fromBase64(JSON.parse(jsonSerialized));
-      } else {
-        jsonDeserialized = JSON.parse(jsonSerialized);
-      }
-    }
-  }
-  const I = performance.now();
-  const bytes = cborSerialized.byteLength;
-  const megabytes = (cborSerialized.byteLength * scale) / 1_000_000;
-  const num_fmt = (ms) => ((megabytes / ms) * 1000).toFixed(0) + "mb/s";
-  const jsonBytes = Buffer.from(jsonSerialized).byteLength;
+function buildTestCaseTable(results) {
+  const headers = ["Test Case", "Data Size", "Repetitions", "CBOR Cumulative", "JSON Cumulative", "CBOR/JSON Size"];
+  const rows = results.map((r) => [
+    "`" + r.name + "`",
+    r.bytes < 1e6 ? (r.bytes / 1e3).toFixed(0) + " kb" : (r.bytes / 1e6).toFixed(1) + " mb",
+    String(SCALE),
+    ((r.bytes * SCALE) / 1e6).toFixed(0) + " mb",
+    ((r.jsonBytes * SCALE) / 1e6).toFixed(0) + " mb",
+    (r.bytes / r.jsonBytes).toFixed(2),
+  ]);
+  return mdTable(headers, rows);
+}
+
+function buildBenchmarkTable(label, results) {
+  const perfHeaders = ["Test Case", "CBOR ser", "CBOR de", "CBOR ser ms", "CBOR de ms", "JSON ser ms", "JSON de ms"];
+  const perfRows = results.map((r) => [
+    "`" + r.name + "`",
+    r.cborEncFmt,
+    r.cborDecFmt,
+    r.cborEncMs.toFixed(0) + " ms",
+    r.cborDecMs.toFixed(0) + " ms",
+    r.jsonEncMs.toFixed(0) + " ms",
+    r.jsonDecMs.toFixed(0) + " ms",
+  ]);
+
+  const ratioHeaders = ["Test Case", "CBOR ser ratio", "CBOR de ratio"];
+  const ratioRows = results.map((r) => [
+    "`" + r.name + "`",
+    (r.cborEncMs / r.jsonEncMs).toFixed(2),
+    (r.cborDecMs / r.jsonDecMs).toFixed(2),
+  ]);
+
+  return `### ${label}\n\n` + mdTable(perfHeaders, perfRows) +
+    `\n\nCBOR timing ratio (lower is better):\n\n` + mdTable(ratioHeaders, ratioRows);
+}
+
+// Run JSON once as control
+process.stdout.write("JSON control");
+const jsonResults = [];
+for (let idx = 0; idx < testDefs.length; ++idx) {
   process.stdout.write(".");
-
-  rows[name] = new Row({
-    workload: `${(bytes < 1e6 ? bytes / 1e3 : bytes / 1e6).toFixed(0)}${bytes < 1e6 ? "kb" : "mb"} x ${scale}`,
-    cbor: ((bytes * scale) / 1e6).toFixed(0) + "mb",
-    json: ((jsonBytes * scale) / 1e6).toFixed(0) + "mb",
-    cbor_serde: [B - A, C - B].map(num_fmt).join(", "),
-    json_serde: [H - G, I - H].map(num_fmt).join(", "),
-    "cbor relative performance": [
-      (((H - G) / (B - A)) * 100).toFixed(0) + "% ->",
-      "<- " + (((I - H) / (C - B)) * 100).toFixed(0) + "%",
-      ((bytes / jsonBytes) * 100).toFixed(0) + "% payload",
-    ].join(", "),
+  jsonResults.push({
+    enc: runPhase(idx, "json-encode", "current"),
+    dec: runPhase(idx, "json-decode", "current"),
   });
 }
 
+// Run cbor baseline
+process.stdout.write("\nBaseline");
+const baselineResults = [];
+for (let idx = 0; idx < testDefs.length; ++idx) {
+  process.stdout.write(".");
+  baselineResults.push({
+    enc: runPhase(idx, "cbor-encode", "baseline"),
+    dec: runPhase(idx, "cbor-decode", "baseline"),
+  });
+}
+
+// Run cbor current
+process.stdout.write("\nCurrent");
+const currentResults = [];
+for (let idx = 0; idx < testDefs.length; ++idx) {
+  process.stdout.write(".");
+  currentResults.push({
+    enc: runPhase(idx, "cbor-encode", "current"),
+    dec: runPhase(idx, "cbor-decode", "current"),
+  });
+}
+
+function formatResults(cborData, jsonData) {
+  return testDefs.map((t, idx) => {
+    const bytes = cborData[idx].enc.bytes;
+    const jsonBytes = cborData[idx].enc.jsonBytes;
+    const megabytes = (bytes * SCALE) / 1e6;
+    const fmt = (ms) => ((megabytes / ms) * 1000).toFixed(0) + "mb/s";
+    return {
+      name: t.name,
+      bytes,
+      jsonBytes,
+      cborEncMs: cborData[idx].enc.ms,
+      cborDecMs: cborData[idx].dec.ms,
+      jsonEncMs: jsonData[idx].enc.ms,
+      jsonDecMs: jsonData[idx].dec.ms,
+      cborEncFmt: fmt(cborData[idx].enc.ms),
+      cborDecFmt: fmt(cborData[idx].dec.ms),
+      jsonEncFmt: fmt(jsonData[idx].enc.ms),
+      jsonDecFmt: fmt(jsonData[idx].dec.ms),
+    };
+  });
+}
+
+const baseFormatted = formatResults(baselineResults, jsonResults);
+const currentFormatted = formatResults(currentResults, jsonResults);
+
+console.log("\n## Test Cases\n");
+console.log(buildTestCaseTable(currentFormatted));
+console.log("\n## Benchmark Results\n");
+console.log(buildBenchmarkTable("Baseline: @smithy/core (npm)", baseFormatted));
 console.log("");
-console.table(rows);
+console.log(buildBenchmarkTable("Current: dist-cjs", currentFormatted));
+
+try {
+  unlinkSync(workerPaths.current);
+} catch {}
+try {
+  unlinkSync(workerPaths.baseline);
+} catch {}

--- a/packages/core/src/submodules/cbor/cbor-decode.ts
+++ b/packages/core/src/submodules/cbor/cbor-decode.ts
@@ -1,4 +1,4 @@
-import { nv, toUtf8 } from "@smithy/core/serde";
+import { nv } from "@smithy/core/serde";
 
 import {
   alloc,
@@ -32,12 +32,12 @@ import {
   type Uint64,
 } from "./cbor-types";
 
-const USE_TEXT_DECODER = typeof TextDecoder !== "undefined";
 const USE_BUFFER = typeof Buffer !== "undefined";
+const textDecoder = new TextDecoder();
 
 let payload = alloc(0);
+let isBuffer = false;
 let dataView = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
-const textDecoder = USE_TEXT_DECODER ? new TextDecoder() : null;
 
 /**
  * This number stores the last offset of any decoded segment.
@@ -52,6 +52,7 @@ let _offset: CborOffset = 0;
  */
 export function setPayload(bytes: Uint8Array) {
   payload = bytes;
+  isBuffer = USE_BUFFER && payload instanceof Buffer;
   dataView = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
 }
 
@@ -68,42 +69,60 @@ export function decode(at: Uint32, to: Uint32): CborValueType {
   const major = (payload[at] & 0b1110_0000) >> 5;
   const minor = payload[at] & 0b0001_1111;
 
+  if (minor === minorIndefinite && 2 <= major && major <= 5) {
+    return decodeIndefinite(at, to);
+  }
+
   switch (major) {
     case majorUint64:
     case majorNegativeInt64:
-    case majorTag:
+    case majorTag: {
       let unsignedInt: number | Uint64;
       let offset: number;
 
       if (minor < 24) {
         unsignedInt = minor;
-        offset = 1;
+        offset = 1 satisfies CborArgumentLengthOffset;
       } else {
         switch (minor) {
           case extendedOneByte:
+            if (to - at < (2 satisfies CborArgumentLengthOffset)) {
+              overflow(1);
+            }
+            unsignedInt = payload[at + 1];
+            offset = 2 satisfies CborArgumentLengthOffset;
+            break;
           case extendedFloat16:
+            if (to - at < (3 satisfies CborArgumentLengthOffset)) {
+              overflow(2);
+            }
+            unsignedInt = dataView.getUint16(at + 1);
+            offset = 3 satisfies CborArgumentLengthOffset;
+            break;
           case extendedFloat32:
+            if (to - at < (5 satisfies CborArgumentLengthOffset)) {
+              overflow(4);
+            }
+            unsignedInt = dataView.getUint32(at + 1);
+            offset = 5 satisfies CborArgumentLengthOffset;
+            break;
           case extendedFloat64:
-            const countLength: CborArgumentLength = minorValueToArgumentLength[minor];
-            const countOffset = (countLength + 1) as CborArgumentLengthOffset;
-            offset = countOffset;
-
-            if (to - at < countOffset) {
-              throw new Error(`countLength ${countLength} greater than remaining buf len.`);
+            if (to - at < (9 satisfies CborArgumentLengthOffset)) {
+              overflow(8);
             }
-            const countIndex = at + 1;
-            if (countLength === 1) {
-              unsignedInt = payload[countIndex];
-            } else if (countLength === 2) {
-              unsignedInt = dataView.getUint16(countIndex);
-            } else if (countLength === 4) {
-              unsignedInt = dataView.getUint32(countIndex);
-            } else {
-              unsignedInt = dataView.getBigUint64(countIndex);
+            // Avoid BigInt allocation when value fits in safe integer range (< 2^53).
+            {
+              const hi = dataView.getUint32(at + 1);
+              if (hi < 0x00200000) {
+                unsignedInt = hi * 4294967296 /** 2^32 */ + dataView.getUint32(at + 5);
+              } else {
+                unsignedInt = dataView.getBigUint64(at + 1);
+              }
             }
+            offset = 9 satisfies CborArgumentLengthOffset;
             break;
           default:
-            throw new Error(`unexpected minor value ${minor}.`);
+            unexpectedMinor(minor);
         }
       }
 
@@ -121,113 +140,39 @@ export function decode(at: Uint32, to: Uint32): CborValueType {
         return castBigInt(negativeInt);
       } else {
         /* major === majorTag */
-        if (minor === 2 || minor === 3) {
-          const length = decodeCount(at + offset, to);
-
-          let b = BigInt(0);
-          const start = at + offset + _offset;
-          for (let i = start; i < start + length; ++i) {
-            b = (b << BigInt(8)) | BigInt(payload[i]);
-          }
-          // the new offset is the sum of:
-          // 1. the local major offset (1)
-          // 2. the offset of the decoded count of the bigInteger
-          // 3. the length of the data bytes of the bigInteger
-          _offset = offset + _offset + length;
-          return minor === 3 ? -b - BigInt(1) : b;
-        } else if (minor === 4) {
-          const decimalFraction = decode(at + offset, to);
-          const [exponent, mantissa] = decimalFraction;
-          const normalizer = mantissa < 0 ? -1 : 1;
-          const mantissaStr = "0".repeat(Math.abs(exponent) + 1) + String(BigInt(normalizer) * BigInt(mantissa));
-
-          let numericString: string;
-          const sign = mantissa < 0 ? "-" : "";
-
-          numericString =
-            exponent === 0
-              ? mantissaStr
-              : mantissaStr.slice(0, mantissaStr.length + exponent) + "." + mantissaStr.slice(exponent);
-          numericString = numericString.replace(/^0+/g, "");
-          if (numericString === "") {
-            numericString = "0";
-          }
-          if (numericString[0] === ".") {
-            numericString = "0" + numericString;
-          }
-          numericString = sign + numericString;
-
-          // the new offset is the sum of:
-          // 1. the local major offset (1)
-          // 2. the offset of the decoded exponent mantissa pair
-          _offset = offset + _offset;
-          return nv(numericString);
-        } else {
-          const value = decode(at + offset, to);
-          const valueOffset = _offset;
-
-          _offset = offset + valueOffset;
-          return tag({ tag: castBigInt(unsignedInt), value });
-        }
+        return decodeTagValue(at, to, minor, unsignedInt, offset);
       }
+    }
     case majorUtf8String:
+      return decodeUtf8String(at, to);
     case majorMap:
+      return decodeMap(at, to);
     case majorList:
+      return decodeList(at, to);
     case majorUnstructuredByteString:
-      if (minor === minorIndefinite) {
-        switch (major) {
-          case majorUtf8String:
-            return decodeUtf8StringIndefinite(at, to);
-          case majorMap:
-            return decodeMapIndefinite(at, to);
-          case majorList:
-            return decodeListIndefinite(at, to);
-          case majorUnstructuredByteString:
-            return decodeUnstructuredByteStringIndefinite(at, to);
-        }
-      } else {
-        switch (major) {
-          case majorUtf8String:
-            return decodeUtf8String(at, to);
-          case majorMap:
-            return decodeMap(at, to);
-          case majorList:
-            return decodeList(at, to);
-          case majorUnstructuredByteString:
-            return decodeUnstructuredByteString(at, to);
-        }
-      }
+      return decodeUnstructuredByteString(at, to);
     default:
       return decodeSpecial(at, to);
   }
 }
 
-function bytesToUtf8(bytes: Uint8Array, at: number, to: number): string {
-  if (USE_BUFFER && bytes.constructor?.name === "Buffer") {
-    return (bytes as Buffer).toString("utf-8", at, to);
+function decodeIndefinite(at: Uint32, to: Uint32): CborValueType {
+  const major = (payload[at] & 0b1110_0000) >> 5;
+  const minor = payload[at] & 0b0001_1111;
+  if (minor === minorIndefinite) {
+    switch (major) {
+      case majorUtf8String:
+        return decodeUtf8StringIndefinite(at, to);
+      case majorMap:
+        return decodeMapIndefinite(at, to);
+      case majorList:
+        return decodeListIndefinite(at, to);
+      case majorUnstructuredByteString:
+        return decodeUnstructuredByteStringIndefinite(at, to);
+      default:
+    }
   }
-  if (textDecoder) {
-    return textDecoder!.decode(bytes.subarray(at, to));
-  }
-  return toUtf8(bytes.subarray(at, to));
 }
-
-function demote(bigInteger: bigint): number {
-  // cast is safe for string and array lengths, which do not
-  // exceed safe integer range.
-  const num = Number(bigInteger);
-  if (num < Number.MIN_SAFE_INTEGER || Number.MAX_SAFE_INTEGER < num) {
-    console.warn(new Error(`@smithy/core/cbor - truncating BigInt(${bigInteger}) to ${num} with loss of precision.`));
-  }
-  return num;
-}
-
-const minorValueToArgumentLength = {
-  [extendedOneByte]: 1,
-  [extendedFloat16]: 2,
-  [extendedFloat32]: 4,
-  [extendedFloat64]: 8,
-} as const;
 
 /**
  * @internal
@@ -239,63 +184,85 @@ export function bytesToFloat16(a: Uint8, b: Uint8): Float32 {
 
   const scalar = sign === 0 ? 1 : -1;
 
-  let exponentComponent: number;
-  let summation: number;
-
   if (exponent === 0b00000) {
-    if (fraction === 0b00000_00000) {
+    if (fraction === 0) {
       return 0;
-    } else {
-      exponentComponent = Math.pow(2, 1 - 15);
-      summation = 0;
     }
+    return scalar * (Math.pow(2, 1 - 15) * (fraction / 1024));
   } else if (exponent === 0b11111) {
-    if (fraction === 0b00000_00000) {
+    if (fraction === 0) {
       return scalar * Infinity;
-    } else {
-      return NaN;
     }
-  } else {
-    exponentComponent = Math.pow(2, exponent - 15);
-    summation = 1;
+    return NaN;
   }
 
-  summation += fraction / 1024;
-  return scalar * (exponentComponent * summation);
+  return scalar * (Math.pow(2, exponent - 15) * (1 + fraction / 1024));
 }
 
-function decodeCount(at: Uint32, to: Uint32): number {
-  const minor = payload[at] & 0b0001_1111;
-
-  if (minor < 24) {
-    _offset = 1;
-    return minor;
+/**
+ * Decodes map entries. Keys must be UTF-8 strings per Smithy specification.
+ */
+function decodeMap(at: Uint32, to: Uint32): CborMapType {
+  const mapDataLength = decodeCount(at, to);
+  if (mapDataLength < 15) {
+    return decodeMapSmall(at, to, mapDataLength);
   }
+  return decodeMapLarge(at, to, mapDataLength);
+}
 
-  if (
-    minor === extendedOneByte ||
-    minor === extendedFloat16 ||
-    minor === extendedFloat32 ||
-    minor === extendedFloat64
-  ) {
-    const countLength: CborArgumentLength = minorValueToArgumentLength[minor];
-    _offset = (countLength + 1) as CborArgumentLengthOffset;
-    if (to - at < _offset) {
-      throw new Error(`countLength ${countLength} greater than remaining buf len.`);
+/**
+ * Uses Object.create(null), which assigns values faster.
+ * Paid for by a single setPrototypeOf.
+ */
+function decodeMapLarge(at: Uint32, to: Uint32, mapDataLength: number): CborMapType {
+  const offset = _offset;
+  at += offset;
+  const base = at;
+  const map = Object.create(null) as CborMapType;
+  for (let i = 0; i < mapDataLength; ++i) {
+    const key = decodeUtf8String(at, to);
+    at += _offset;
+    const valMajor = (payload[at] & 0b1110_0000) >> 5;
+    if (valMajor === majorUtf8String) {
+      map[key] = decodeUtf8String(at, to);
+    } else {
+      map[key] = decode(at, to);
     }
-    const countIndex = at + 1;
-
-    if (countLength === 1) {
-      return payload[countIndex];
-    } else if (countLength === 2) {
-      return dataView.getUint16(countIndex);
-    } else if (countLength === 4) {
-      return dataView.getUint32(countIndex);
-    }
-    return demote(dataView.getBigUint64(countIndex));
+    at += _offset;
   }
+  _offset = offset + (at - base);
+  Object.setPrototypeOf(map, Object.prototype);
+  return map;
+}
 
-  throw new Error(`unexpected minor value ${minor}.`);
+function decodeMapSmall(at: Uint32, to: Uint32, mapDataLength: number): CborMapType {
+  const offset = _offset;
+  at += offset;
+  const base = at;
+  const map = {} as CborMapType;
+  for (let i = 0; i < mapDataLength; ++i) {
+    const key = decodeUtf8String(at, to);
+    at += _offset;
+    map[key] = decode(at, to);
+    at += _offset;
+  }
+  _offset = offset + (at - base);
+  return map;
+}
+
+function decodeList(at: Uint32, to: Uint32): CborListType {
+  const listDataLength = decodeCount(at, to);
+  const offset = _offset;
+  at += offset;
+  const base = at;
+  // perf: pre-allocate array length.
+  const list = Array(listDataLength);
+  for (let i = 0; i < listDataLength; ++i) {
+    list[i] = decode(at, to);
+    at += _offset;
+  }
+  _offset = offset + (at - base);
+  return list;
 }
 
 function decodeUtf8String(at: Uint32, to: Uint32): string {
@@ -303,11 +270,253 @@ function decodeUtf8String(at: Uint32, to: Uint32): string {
   const offset = _offset;
   at += offset;
   if (to - at < length) {
-    throw new Error(`string len ${length} greater than remaining buf len.`);
+    overflow(length);
   }
-  const value = bytesToUtf8(payload, at, at + length);
+  _offset = offset + length;
+  if (length < 24) {
+    return decodeUtf8StringCached(at, length);
+  }
+  if (isBuffer) {
+    return (payload as Buffer).toString("utf-8", at, at + length);
+  }
+  return textDecoder.decode(payload.subarray(at, at + length));
+}
+
+/**
+ * For short strings (< 24 bytes), cache decoded results keyed by byte content.
+ * Optimized for repeated property names in API responses.
+ */
+const stringCache: (string | undefined)[] = new Array(2048);
+/**
+ * Indicates the epoch in which the cache value at the same index was written.
+ */
+const stringCacheEpochs = new Uint16Array(2048);
+
+/**
+ * Global epoch indicator.
+ */
+let cacheEpoch = 0;
+
+/**
+ * @internal
+ */
+export function advanceDecodingEpoch() {
+  cacheEpoch = (cacheEpoch + 1) & 0b1111_1111_1111_1111;
+}
+
+function decodeUtf8StringCached(at: number, length: number): string {
+  let h = length;
+  for (let i = 0; i < length; ++i) {
+    h = (h * 31 + payload[at + i]) | 0;
+  }
+  const slot = (h >>> 0) & 2047;
+  const cached = stringCache[slot];
+
+  if (cached !== undefined) {
+    if (cached.length === length) {
+      let match = true;
+      for (let i = 0; i < length; ++i) {
+        if (cached.charCodeAt(i) !== payload[at + i]) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        stringCacheEpochs[slot] = cacheEpoch;
+        return cached;
+      }
+    }
+  }
+
+  const result = isBuffer
+    ? (payload as Buffer).toString("utf-8", at, at + length)
+    : textDecoder.decode(payload.subarray(at, at + length));
+
+  if (stringCacheEpochs[slot] !== cacheEpoch) {
+    // evict collision only if inhabitant is from a previous epoch.
+    stringCache[slot] = result;
+    stringCacheEpochs[slot] = cacheEpoch;
+  }
+
+  return result!;
+}
+
+function decodeUnstructuredByteString(at: Uint32, to: Uint32): CborUnstructuredByteStringType {
+  const length = decodeCount(at, to);
+  const offset = _offset;
+
+  at += offset;
+  if (to - at < length) {
+    overflow(length);
+  }
+
+  const value = payload.subarray(at, at + length);
   _offset = offset + length;
   return value;
+}
+
+function decodeTagValue(
+  at: Uint32,
+  to: Uint32,
+  minor: number,
+  unsignedInt: number | Uint64,
+  offset: number
+): CborValueType {
+  if (minor === 2 || minor === 3) {
+    const length = decodeCount(at + offset, to);
+
+    let b = BigInt(0);
+    const start = at + offset + _offset;
+    for (let i = start; i < start + length; ++i) {
+      b = (b << BigInt(8)) | BigInt(payload[i]);
+    }
+    // the new offset is the sum of:
+    // 1. the local major offset (1)
+    // 2. the offset of the decoded count of the bigInteger
+    // 3. the length of the data bytes of the bigInteger
+    _offset = offset + _offset + length;
+    return minor === 3 ? -b - BigInt(1) : b;
+  } else if (minor === 4) {
+    const decimalFraction = decode(at + offset, to);
+    const [exponent, mantissa] = decimalFraction;
+    const normalizer = mantissa < 0 ? -1 : 1;
+    const mantissaStr = "0".repeat(Math.abs(exponent) + 1) + String(BigInt(normalizer) * BigInt(mantissa));
+
+    let numericString: string;
+    const sign = mantissa < 0 ? "-" : "";
+
+    numericString =
+      exponent === 0
+        ? mantissaStr
+        : mantissaStr.slice(0, mantissaStr.length + exponent) + "." + mantissaStr.slice(exponent);
+    numericString = numericString.replace(/^0+/g, "");
+    if (numericString === "") {
+      numericString = "0";
+    }
+    if (numericString[0] === ".") {
+      numericString = "0" + numericString;
+    }
+    numericString = sign + numericString;
+
+    // the new offset is the sum of:
+    // 1. the local major offset (1)
+    // 2. the offset of the decoded exponent mantissa pair
+    _offset = offset + _offset;
+    return nv(numericString);
+  } else {
+    const value = decode(at + offset, to);
+    const valueOffset = _offset;
+
+    _offset = offset + valueOffset;
+    return tag({ tag: castBigInt(unsignedInt), value });
+  }
+}
+
+function decodeSpecial(at: Uint32, to: Uint32): CborValueType {
+  const minor = payload[at] & 0b0001_1111;
+  switch (minor) {
+    case specialTrue:
+    case specialFalse:
+      _offset = 1 satisfies CborArgumentLengthOffset;
+      return minor === specialTrue;
+    case specialNull:
+      _offset = 1 satisfies CborArgumentLengthOffset;
+      return null;
+    case specialUndefined:
+      // Note: the Smithy spec requires that undefined is
+      // instead deserialized to null.
+      _offset = 1 satisfies CborArgumentLengthOffset;
+      return null;
+    case extendedFloat16:
+      if (to - at < (3 satisfies CborArgumentLengthOffset)) {
+        throw new Error("incomplete float16 at end of buf.");
+      }
+      _offset = 3 satisfies CborArgumentLengthOffset;
+      return bytesToFloat16(payload[at + 1], payload[at + 2]);
+    case extendedFloat32:
+      if (to - at < (5 satisfies CborArgumentLengthOffset)) {
+        throw new Error("incomplete float32 at end of buf.");
+      }
+      _offset = 5 satisfies CborArgumentLengthOffset;
+      return dataView.getFloat32(at + 1);
+    case extendedFloat64:
+      if (to - at < (9 satisfies CborArgumentLengthOffset)) {
+        throw new Error("incomplete float64 at end of buf.");
+      }
+      _offset = 9 satisfies CborArgumentLengthOffset;
+      return dataView.getFloat64(at + 1);
+    default:
+      unexpectedMinor(minor);
+  }
+}
+
+function decodeCount(at: Uint32, to: Uint32): number {
+  const minor = payload[at] & 0b0001_1111;
+
+  if (minor < 24) {
+    _offset = 1 satisfies CborArgumentLengthOffset;
+    return minor;
+  }
+
+  switch (minor) {
+    case extendedOneByte:
+      if (to - at < (2 satisfies CborArgumentLengthOffset)) {
+        overflow(1);
+      }
+      _offset = 2 satisfies CborArgumentLengthOffset;
+      return payload[at + 1];
+    case extendedFloat16:
+      if (to - at < (3 satisfies CborArgumentLengthOffset)) {
+        overflow(2);
+      }
+      _offset = 3 satisfies CborArgumentLengthOffset;
+      return dataView.getUint16(at + 1);
+    case extendedFloat32:
+      if (to - at < (5 satisfies CborArgumentLengthOffset)) {
+        overflow(4);
+      }
+      _offset = 5 satisfies CborArgumentLengthOffset;
+      return dataView.getUint32(at + 1);
+    case extendedFloat64:
+      if (to - at < (9 satisfies CborArgumentLengthOffset)) {
+        overflow(8);
+      }
+      _offset = 9 satisfies CborArgumentLengthOffset;
+      return demote(dataView.getBigUint64(at + 1));
+    default:
+      unexpectedMinor(minor);
+  }
+}
+
+function decodeMapIndefinite(at: Uint32, to: Uint32): CborMapType {
+  at += 1;
+  const base = at;
+  const map = {} as CborMapType;
+  for (; at < to; ) {
+    if (payload[at] === 0b1111_1111) {
+      _offset = at - base + 2;
+      return map;
+    }
+    const key = decodeUtf8String(at, to);
+    at += _offset;
+    map[key] = decode(at, to);
+    at += _offset;
+  }
+  throw new Error("expected break marker.");
+}
+
+function decodeListIndefinite(at: Uint32, to: Uint32): CborListType {
+  at += 1;
+  const list = [] as CborListType;
+  for (const base = at; at < to; ) {
+    if (payload[at] === 0b1111_1111) {
+      _offset = at - base + 2;
+      return list;
+    }
+    list.push(decode(at, to));
+    at += _offset;
+  }
+  throw new Error("expected break marker.");
 }
 
 function decodeUtf8StringIndefinite(at: Uint32, to: Uint32): string {
@@ -318,12 +527,15 @@ function decodeUtf8StringIndefinite(at: Uint32, to: Uint32): string {
       const data = alloc(vector.length);
       data.set(vector, 0);
       _offset = at - base + 2;
-      return bytesToUtf8(data, 0, data.length);
+      if (USE_BUFFER) {
+        return (data as Buffer).toString("utf-8", 0, data.length);
+      }
+      return textDecoder.decode(data);
     }
     const major = (payload[at] & 0b1110_0000) >> 5;
     const minor = payload[at] & 0b0001_1111;
     if (major !== majorUtf8String) {
-      throw new Error(`unexpected major type ${major} in indefinite string.`);
+      unexpectedMajorInIndefiniteString(major);
     }
     if (minor === minorIndefinite) {
       throw new Error("nested indefinite string.");
@@ -336,20 +548,6 @@ function decodeUtf8StringIndefinite(at: Uint32, to: Uint32): string {
     }
   }
   throw new Error("expected break marker.");
-}
-
-function decodeUnstructuredByteString(at: Uint32, to: Uint32): CborUnstructuredByteStringType {
-  const length = decodeCount(at, to);
-  const offset = _offset;
-
-  at += offset;
-  if (to - at < length) {
-    throw new Error(`unstructured byte string len ${length} greater than remaining buf len.`);
-  }
-
-  const value = payload.subarray(at, at + length);
-  _offset = offset + length;
-  return value;
 }
 
 function decodeUnstructuredByteStringIndefinite(at: Uint32, to: Uint32): CborUnstructuredByteStringType {
@@ -367,7 +565,7 @@ function decodeUnstructuredByteStringIndefinite(at: Uint32, to: Uint32): CborUns
     const major = (payload[at] & 0b1110_0000) >> 5;
     const minor = payload[at] & 0b0001_1111;
     if (major !== majorUnstructuredByteString) {
-      throw new Error(`unexpected major type ${major} in indefinite string.`);
+      unexpectedMajorInIndefiniteString(major);
     }
     if (minor === minorIndefinite) {
       throw new Error("nested indefinite string.");
@@ -383,126 +581,6 @@ function decodeUnstructuredByteStringIndefinite(at: Uint32, to: Uint32): CborUns
   throw new Error("expected break marker.");
 }
 
-function decodeList(at: Uint32, to: Uint32): CborListType {
-  const listDataLength = decodeCount(at, to);
-  const offset = _offset;
-  at += offset;
-  const base = at;
-  // perf: pre-allocate array length.
-  const list = Array(listDataLength);
-  for (let i = 0; i < listDataLength; ++i) {
-    const item = decode(at, to);
-    const itemOffset = _offset;
-    list[i] = item;
-    at += itemOffset;
-  }
-  _offset = offset + (at - base);
-  return list;
-}
-
-function decodeListIndefinite(at: Uint32, to: Uint32): CborListType {
-  at += 1;
-  const list = [] as CborListType;
-  for (const base = at; at < to; ) {
-    if (payload[at] === 0b1111_1111) {
-      _offset = at - base + 2;
-      return list;
-    }
-    const item = decode(at, to);
-    const n = _offset;
-    at += n;
-    list.push(item);
-  }
-  throw new Error("expected break marker.");
-}
-
-function decodeMap(at: Uint32, to: Uint32): CborMapType {
-  const mapDataLength = decodeCount(at, to);
-  const offset = _offset;
-  at += offset;
-  const base = at;
-  const map = {} as CborMapType;
-  for (let i = 0; i < mapDataLength; ++i) {
-    if (at >= to) {
-      throw new Error("unexpected end of map payload.");
-    }
-    const major = (payload[at] & 0b1110_0000) >> 5;
-    if (major !== majorUtf8String) {
-      throw new Error(`unexpected major type ${major} for map key at index ${at}.`);
-    }
-    const key = decode(at, to);
-    at += _offset;
-    const value = decode(at, to);
-    at += _offset;
-    map[key] = value;
-  }
-  _offset = offset + (at - base);
-  return map;
-}
-
-function decodeMapIndefinite(at: Uint32, to: Uint32): CborMapType {
-  at += 1;
-  const base = at;
-  const map = {} as CborMapType;
-  for (; at < to; ) {
-    if (at >= to) {
-      throw new Error("unexpected end of map payload.");
-    }
-    if (payload[at] === 0b1111_1111) {
-      _offset = at - base + 2;
-      return map;
-    }
-    const major = (payload[at] & 0b1110_0000) >> 5;
-    if (major !== majorUtf8String) {
-      throw new Error(`unexpected major type ${major} for map key.`);
-    }
-    const key = decode(at, to);
-    at += _offset;
-    const value = decode(at, to);
-    at += _offset;
-    map[key] = value;
-  }
-  throw new Error("expected break marker.");
-}
-
-function decodeSpecial(at: Uint32, to: Uint32): CborValueType {
-  const minor = payload[at] & 0b0001_1111;
-  switch (minor) {
-    case specialTrue:
-    case specialFalse:
-      _offset = 1;
-      return minor === specialTrue;
-    case specialNull:
-      _offset = 1;
-      return null;
-    case specialUndefined:
-      // Note: the Smithy spec requires that undefined is
-      // instead deserialized to null.
-      _offset = 1;
-      return null;
-    case extendedFloat16:
-      if (to - at < 3) {
-        throw new Error("incomplete float16 at end of buf.");
-      }
-      _offset = 3;
-      return bytesToFloat16(payload[at + 1], payload[at + 2]);
-    case extendedFloat32:
-      if (to - at < 5) {
-        throw new Error("incomplete float32 at end of buf.");
-      }
-      _offset = 5;
-      return dataView.getFloat32(at + 1);
-    case extendedFloat64:
-      if (to - at < 9) {
-        throw new Error("incomplete float64 at end of buf.");
-      }
-      _offset = 9;
-      return dataView.getFloat64(at + 1);
-    default:
-      throw new Error(`unexpected minor value ${minor}.`);
-  }
-}
-
 function castBigInt(bigInt: bigint | number): number | bigint {
   if (typeof bigInt === "number") {
     return bigInt;
@@ -512,4 +590,26 @@ function castBigInt(bigInt: bigint | number): number | bigint {
     return num;
   }
   return bigInt;
+}
+
+function demote(bigInteger: bigint): number {
+  // cast is safe for string and array lengths, which do not
+  // exceed safe integer range.
+  const num = Number(bigInteger);
+  if (num < Number.MIN_SAFE_INTEGER || Number.MAX_SAFE_INTEGER < num) {
+    console.warn(new Error(`@smithy/core/cbor - truncating BigInt(${bigInteger}) to ${num} with loss of precision.`));
+  }
+  return num;
+}
+
+function overflow(n: number): never {
+  throw new Error(`length ${n} greater than remaining buf len.`);
+}
+
+function unexpectedMinor(minor: number): never {
+  throw new Error(`unexpected minor value ${minor}.`);
+}
+
+function unexpectedMajorInIndefiniteString(major: number): never {
+  throw new Error(`unexpected major type ${major} in indefinite string.`);
 }

--- a/packages/core/src/submodules/cbor/cbor-encode.ts
+++ b/packages/core/src/submodules/cbor/cbor-encode.ts
@@ -1,4 +1,4 @@
-import { NumericValue, fromUtf8 } from "@smithy/core/serde";
+import { NumericValue } from "@smithy/core/serde";
 
 import {
   alloc,
@@ -23,20 +23,206 @@ import {
 
 const USE_BUFFER = typeof Buffer !== "undefined";
 
+/**
+ * Encoder-side string cache: for short strings (≤ 23 chars),
+ * caches the fully encoded CBOR bytes (header + UTF-8) to skip
+ * Buffer.byteLength and Buffer.write on repeated calls.
+ * Uses epoch-based eviction: stale entries are overwritten on collision.
+ */
+const encodeStringCache = new Map<string, { epoch: number; bytes: Uint8Array }>();
+let encodeCacheEpoch: number = 0;
+let encodeCacheSaturated: boolean = false;
+
 const initialSize = 2048;
 let data: Uint8Array = alloc(initialSize);
 let dataView: DataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
 let cursor: number = 0;
 
-function ensureSpace(bytes: number) {
-  const remaining = data.byteLength - cursor;
-  if (remaining < bytes) {
-    if (cursor < 16_000_000) {
-      resize(Math.max(data.byteLength * 4, data.byteLength + bytes));
-    } else {
-      resize(data.byteLength + bytes + 16_000_000);
+/**
+ * @param _input - JS data object.
+ */
+export function encode(_input: any): void {
+  const encodeStack: any[] = [_input];
+
+  while (encodeStack.length) {
+    const input = encodeStack.pop();
+
+    if (typeof input === "string") {
+      const len = input.length;
+      if (USE_BUFFER) {
+        ensureSpace(len * 3 + 9);
+        if (len > 23) {
+          encodeHeader(majorUtf8String, Buffer.byteLength(input));
+          cursor += (data as Buffer).write(input, cursor);
+        } else {
+          encodeStringCached(input);
+        }
+      } else {
+        const maxBytes = len * 3;
+        ensureSpace(maxBytes + 9);
+        const headerPos = cursor;
+        const result = new TextEncoder().encodeInto(input, data.subarray(cursor + 9));
+        const byteLen = result.written!;
+        let headerSize: number;
+        if (byteLen < 24) {
+          headerSize = 1;
+        } else if (byteLen < 256 /** 2^8 */) {
+          headerSize = 2;
+        } else if (byteLen < 65536 /** 2^16 */) {
+          headerSize = 3;
+        } else if (byteLen < 4294967296 /** 2^32 */) {
+          headerSize = 5;
+        } else {
+          headerSize = 9;
+        }
+        if (headerSize < 9) {
+          data.copyWithin(headerPos + headerSize, headerPos + 9, headerPos + 9 + byteLen);
+        }
+        cursor = headerPos;
+        encodeInteger(majorUtf8String, byteLen);
+        cursor += byteLen;
+      }
+      continue;
     }
+
+    // Fast check: if we have at least 9 bytes, scalar encoding won't overflow.
+    if (data.byteLength - cursor < 9) {
+      ensureSpace(64);
+    }
+
+    if (typeof input === "number") {
+      if (Number.isInteger(input)) {
+        const nonNegative = input >= 0;
+        const major = nonNegative ? majorUint64 : majorNegativeInt64;
+        const value = nonNegative ? input : -input - 1;
+        if (value < 24) {
+          data[cursor++] = (major << 5) | value;
+        } else if (value < 256 /** 2^8 */) {
+          data[cursor++] = (major << 5) | 24;
+          data[cursor++] = value;
+        } else if (value < 65536 /** 2^16 */) {
+          data[cursor++] = (major << 5) | extendedFloat16;
+          data[cursor++] = value >> 8;
+          data[cursor++] = value & 0xff;
+        } else if (value < 4294967296 /** 2^32 */) {
+          data[cursor++] = (major << 5) | extendedFloat32;
+          dataView.setUint32(cursor, value);
+          cursor += 4;
+        } else {
+          // Safe integer > 32 bits: manual big-endian write avoids BigInt.
+          data[cursor++] = (major << 5) | extendedFloat64;
+          const hi = (value / 4294967296) /** 2^32 */ | 0;
+          const lo = (value - hi * 4294967296) /** 2^32 */ | 0;
+          dataView.setUint32(cursor, hi);
+          dataView.setUint32(cursor + 4, lo);
+          cursor += 8;
+        }
+        continue;
+      }
+      data[cursor++] = (majorSpecial << 5) | extendedFloat64;
+      dataView.setFloat64(cursor, input);
+      cursor += 8;
+      continue;
+    } else if (typeof input === "bigint") {
+      const nonNegative = input >= 0;
+      const major = nonNegative ? majorUint64 : majorNegativeInt64;
+      const value = nonNegative ? input : -input - BigInt(1);
+      if (value < BigInt("18446744073709551616")) {
+        const n = Number(value);
+        if (n < 4294967296 /** 2^32 */) {
+          encodeInteger(major, n);
+        } else {
+          data[cursor++] = (major << 5) | extendedFloat64;
+          dataView.setBigUint64(cursor, value);
+          cursor += 8;
+        }
+      } else {
+        // refer to https://www.rfc-editor.org/rfc/rfc8949.html#name-bignums
+        const binaryBigInt = value.toString(2);
+        const bigIntBytes = new Uint8Array(Math.ceil(binaryBigInt.length / 8));
+        let b = value;
+        let i = 0;
+        while (bigIntBytes.byteLength - ++i >= 0) {
+          bigIntBytes[bigIntBytes.byteLength - i] = Number(b & BigInt(255));
+          b >>= BigInt(8);
+        }
+        ensureSpace(bigIntBytes.byteLength * 2 + 16);
+        data[cursor++] = nonNegative ? 0b110_00010 : 0b110_00011;
+        encodeHeader(majorUnstructuredByteString, bigIntBytes.byteLength);
+        data.set(bigIntBytes, cursor);
+        cursor += bigIntBytes.byteLength;
+      }
+      continue;
+    } else if (input === null) {
+      data[cursor++] = (majorSpecial << 5) | specialNull;
+      continue;
+    } else if (typeof input === "boolean") {
+      data[cursor++] = (majorSpecial << 5) | (input ? specialTrue : specialFalse);
+      continue;
+    } else if (typeof input === "undefined") {
+      // Note: Smithy spec requires that undefined not be serialized
+      // though the CBOR spec includes it.
+      throw new Error("@smithy/core/cbor: client may not serialize undefined value.");
+    } else if (Array.isArray(input)) {
+      encodeInteger(majorList, input.length);
+      // Pre-allocate space for the array items (9 bytes max per numeric item).
+      ensureSpace(input.length * 9 + 64);
+      for (let i = input.length - 1; i >= 0; --i) {
+        encodeStack.push(input[i]);
+      }
+      continue;
+    } else if (typeof input.byteLength === "number") {
+      ensureSpace(input.length * 2 + 9);
+      encodeInteger(majorUnstructuredByteString, input.length);
+      data.set(input, cursor);
+      cursor += input.byteLength;
+      continue;
+    } else if (typeof input === "object") {
+      if (input instanceof NumericValue) {
+        const decimalIndex = input.string.indexOf(".");
+        const exponent = decimalIndex === -1 ? 0 : decimalIndex - input.string.length + 1;
+        const mantissa = BigInt(input.string.replace(".", ""));
+
+        data[cursor++] = 0b110_00100; // major 6, tag 4.
+        encodeInteger(majorList, 2);
+        encodeStack.push(mantissa);
+        encodeStack.push(exponent);
+        continue;
+      }
+      if (input[tagSymbol]) {
+        if ("tag" in input && "value" in input) {
+          encodeStack.push(input.value);
+          encodeHeader(majorTag, input.tag);
+          continue;
+        } else {
+          throw new Error(
+            "tag encountered with missing fields, need 'tag' and 'value', found: " + JSON.stringify(input)
+          );
+        }
+      }
+      const keys = Object.keys(input);
+      const len = keys.length;
+      encodeInteger(majorMap, len);
+      // Encode map keys inline, push values in reverse order for stack processing.
+      // We need to process entries in order, but stack is LIFO.
+      // Strategy: encode all keys now (forward), collect values, push values in reverse.
+      for (let i = len - 1; i >= 0; --i) {
+        encodeStack.push(input[keys[i]]);
+        encodeStack.push(keys[i]);
+      }
+      continue;
+    }
+
+    throw new Error(`data type ${input?.constructor?.name ?? typeof input} not compatible for encoding.`);
   }
+}
+
+/**
+ * @internal
+ */
+export function advanceEncodingEpoch() {
+  encodeCacheEpoch = (encodeCacheEpoch + 1) & 0b1111_1111_1111_1111;
+  encodeCacheSaturated = false;
 }
 
 /**
@@ -62,17 +248,74 @@ export function resize(size: number) {
   dataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
 }
 
+/**
+ * Encodes a short string (≤ 23 chars) using the cache, writing
+ * directly to the buffer on both hit and miss.
+ */
+function encodeStringCached(input: string): void {
+  const cached = encodeStringCache.get(input);
+  if (cached !== undefined) {
+    data.set(cached.bytes, cursor);
+    cursor += cached.bytes.length;
+    cached.epoch = encodeCacheEpoch;
+    return;
+  }
+
+  // Encode normally, then cache the result.
+  const start = cursor;
+  const byteLen = Buffer.byteLength(input);
+  encodeInteger(majorUtf8String, byteLen);
+  cursor += (data as Buffer).write(input, cursor);
+
+  const bytes = Uint8Array.prototype.slice.call(data, start, cursor);
+
+  // Evict stale entries if at capacity; skip if already saturated this epoch.
+  if (encodeStringCache.size >= 2048) {
+    if (encodeCacheSaturated) {
+      return;
+    }
+    let evicted = 0;
+    for (const [key, entry] of encodeStringCache) {
+      if (evicted >= 1024) {
+        break;
+      }
+      if (entry.epoch !== encodeCacheEpoch) {
+        encodeStringCache.delete(key);
+        evicted++;
+      }
+    }
+    if (evicted === 0) {
+      encodeCacheSaturated = true;
+      return;
+    }
+  }
+  if (encodeStringCache.size < 2048) {
+    encodeStringCache.set(input, { epoch: encodeCacheEpoch, bytes });
+  }
+}
+
+function ensureSpace(bytes: number) {
+  const remaining = data.byteLength - cursor;
+  if (remaining < bytes) {
+    if (cursor < 16_000_000) {
+      resize(Math.max(data.byteLength * 4, data.byteLength + bytes));
+    } else {
+      resize(data.byteLength + bytes + 16_000_000);
+    }
+  }
+}
+
 function encodeHeader(major: CborMajorType, value: Uint64 | number): void {
   if (value < 24) {
     data[cursor++] = (major << 5) | (value as number);
-  } else if (value < 1 << 8) {
+  } else if (value < 256 /** 2^8 */) {
     data[cursor++] = (major << 5) | 24;
     data[cursor++] = value as number;
-  } else if (value < 1 << 16) {
+  } else if (value < 65536 /** 2^16 */) {
     data[cursor++] = (major << 5) | extendedFloat16;
     dataView.setUint16(cursor, value as number);
     cursor += 2;
-  } else if (value < 2 ** 32) {
+  } else if (value < 4294967296 /** 2^32 */) {
     data[cursor++] = (major << 5) | extendedFloat32;
     dataView.setUint32(cursor, value as number);
     cursor += 4;
@@ -84,156 +327,30 @@ function encodeHeader(major: CborMajorType, value: Uint64 | number): void {
 }
 
 /**
- * @param _input - JS data object.
+ * Encode a non-negative integer header without BigInt allocation.
+ * For values up to Number.MAX_SAFE_INTEGER, avoids the BigInt path entirely.
  */
-export function encode(_input: any): void {
-  const encodeStack = [_input];
-
-  while (encodeStack.length) {
-    const input = encodeStack.pop();
-
-    ensureSpace(typeof input === "string" ? input.length * 4 : 64);
-
-    if (typeof input === "string") {
-      if (USE_BUFFER) {
-        encodeHeader(majorUtf8String, Buffer.byteLength(input));
-        cursor += (data as Buffer).write(input, cursor);
-      } else {
-        const bytes = fromUtf8(input);
-        encodeHeader(majorUtf8String, bytes.byteLength);
-        data.set(bytes, cursor);
-        cursor += bytes.byteLength;
-      }
-      continue;
-    } else if (typeof input === "number") {
-      if (Number.isInteger(input)) {
-        const nonNegative = input >= 0;
-        const major = nonNegative ? majorUint64 : majorNegativeInt64;
-        const value = nonNegative ? input : -input - 1;
-        if (value < 24) {
-          data[cursor++] = (major << 5) | value;
-        } else if (value < 256 /* 2 ** 8 */) {
-          data[cursor++] = (major << 5) | 24;
-          data[cursor++] = value;
-        } else if (value < 65536 /* 2 ** 16 */) {
-          data[cursor++] = (major << 5) | extendedFloat16;
-          data[cursor++] = (value as number) >> 8;
-          data[cursor++] = value as number & 0b1111_1111;
-        } else if (value < 4294967296 /* 2 ** 32 */) {
-          data[cursor++] = (major << 5) | extendedFloat32;
-          dataView.setUint32(cursor, value);
-          cursor += 4;
-        } else {
-          data[cursor++] = (major << 5) | extendedFloat64;
-          dataView.setBigUint64(cursor, BigInt(value));
-          cursor += 8;
-        }
-        continue;
-      }
-      data[cursor++] = (majorSpecial << 5) | extendedFloat64;
-      dataView.setFloat64(cursor, input);
-      cursor += 8;
-      continue;
-    } else if (typeof input === "bigint") {
-      const nonNegative = input >= 0;
-      const major = nonNegative ? majorUint64 : majorNegativeInt64;
-      const value = nonNegative ? input : -input - BigInt(1);
-      const n = Number(value);
-      if (n < 24) {
-        data[cursor++] = (major << 5) | n;
-      } else if (n < 256 /* 2 ** 8 */) {
-        data[cursor++] = (major << 5) | 24;
-        data[cursor++] = n;
-      } else if (n < 65536 /* 2 ** 16 */) {
-        data[cursor++] = (major << 5) | extendedFloat16;
-        data[cursor++] = n >> 8;
-        data[cursor++] = n & 0b1111_1111;
-      } else if (n < 4294967296 /* 2 ** 32 */) {
-        data[cursor++] = (major << 5) | extendedFloat32;
-        dataView.setUint32(cursor, n);
-        cursor += 4;
-      } else if (value < BigInt("18446744073709551616")) {
-        data[cursor++] = (major << 5) | extendedFloat64;
-        dataView.setBigUint64(cursor, value);
-        cursor += 8;
-      } else {
-        // refer to https://www.rfc-editor.org/rfc/rfc8949.html#name-bignums
-        const binaryBigInt = value.toString(2);
-        const bigIntBytes = new Uint8Array(Math.ceil(binaryBigInt.length / 8));
-        let b = value;
-        let i = 0;
-        while (bigIntBytes.byteLength - ++i >= 0) {
-          bigIntBytes[bigIntBytes.byteLength - i] = Number(b & BigInt(255));
-          b >>= BigInt(8);
-        }
-        ensureSpace(bigIntBytes.byteLength * 2);
-        data[cursor++] = nonNegative ? 0b110_00010 : 0b110_00011;
-
-        if (USE_BUFFER) {
-          encodeHeader(majorUnstructuredByteString, Buffer.byteLength(bigIntBytes));
-        } else {
-          encodeHeader(majorUnstructuredByteString, bigIntBytes.byteLength);
-        }
-        data.set(bigIntBytes, cursor);
-        cursor += bigIntBytes.byteLength;
-      }
-      continue;
-    } else if (input === null) {
-      data[cursor++] = (majorSpecial << 5) | specialNull;
-      continue;
-    } else if (typeof input === "boolean") {
-      data[cursor++] = (majorSpecial << 5) | (input ? specialTrue : specialFalse);
-      continue;
-    } else if (typeof input === "undefined") {
-      // Note: Smithy spec requires that undefined not be serialized
-      // though the CBOR spec includes it.
-      throw new Error("@smithy/core/cbor: client may not serialize undefined value.");
-    } else if (Array.isArray(input)) {
-      for (let i = input.length - 1; i >= 0; --i) {
-        encodeStack.push(input[i]);
-      }
-      encodeHeader(majorList, input.length);
-      continue;
-    } else if (typeof input.byteLength === "number") {
-      ensureSpace(input.length * 2);
-      encodeHeader(majorUnstructuredByteString, input.length);
-      data.set(input, cursor);
-      cursor += input.byteLength;
-      continue;
-    } else if (typeof input === "object") {
-      if (input instanceof NumericValue) {
-        const decimalIndex = input.string.indexOf(".");
-        const exponent = decimalIndex === -1 ? 0 : decimalIndex - input.string.length + 1;
-        const mantissa = BigInt(input.string.replace(".", ""));
-
-        data[cursor++] = 0b110_00100; // major 6, tag 4.
-
-        encodeStack.push(mantissa);
-        encodeStack.push(exponent);
-        encodeHeader(majorList, 2);
-        continue;
-      }
-      if (input[tagSymbol]) {
-        if ("tag" in input && "value" in input) {
-          encodeStack.push(input.value);
-          encodeHeader(majorTag, input.tag);
-          continue;
-        } else {
-          throw new Error(
-            "tag encountered with missing fields, need 'tag' and 'value', found: " + JSON.stringify(input)
-          );
-        }
-      }
-      const keys = Object.keys(input);
-      for (let i = keys.length - 1; i >= 0; --i) {
-        const key = keys[i];
-        encodeStack.push(input[key]);
-        encodeStack.push(key);
-      }
-      encodeHeader(majorMap, keys.length);
-      continue;
-    }
-
-    throw new Error(`data type ${input?.constructor?.name ?? typeof input} not compatible for encoding.`);
+function encodeInteger(major: number, value: number): void {
+  if (value < 24) {
+    data[cursor++] = (major << 5) | value;
+  } else if (value < 256 /** 2^8 */) {
+    data[cursor++] = (major << 5) | 24;
+    data[cursor++] = value;
+  } else if (value < 65536 /** 2^16 */) {
+    data[cursor++] = (major << 5) | extendedFloat16;
+    data[cursor++] = value >> 8;
+    data[cursor++] = value & 0xff;
+  } else if (value < 4294967296 /** 2^32 */) {
+    data[cursor++] = (major << 5) | extendedFloat32;
+    dataView.setUint32(cursor, value);
+    cursor += 4;
+  } else {
+    // Safe integer > 32 bits: manual 8-byte big-endian write avoids BigInt allocation.
+    data[cursor++] = (major << 5) | extendedFloat64;
+    const hi = (value / 4294967296) /** 2^32 */ | 0;
+    const lo = (value - hi * 4294967296) /** 2^32 */ | 0;
+    dataView.setUint32(cursor, hi);
+    dataView.setUint32(cursor + 4, lo);
+    cursor += 8;
   }
 }

--- a/packages/core/src/submodules/cbor/cbor.ts
+++ b/packages/core/src/submodules/cbor/cbor.ts
@@ -1,5 +1,5 @@
-import { decode, setPayload } from "./cbor-decode";
-import { encode, resize, toUint8Array } from "./cbor-encode";
+import { advanceDecodingEpoch, decode, setPayload } from "./cbor-decode";
+import { advanceEncodingEpoch, encode, resize, toUint8Array } from "./cbor-encode";
 
 /**
  * This implementation is synchronous and only implements the parts of CBOR
@@ -13,10 +13,12 @@ import { encode, resize, toUint8Array } from "./cbor-encode";
  */
 export const cbor = {
   deserialize(payload: Uint8Array): any {
+    advanceDecodingEpoch();
     setPayload(payload);
     return decode(0, payload.length);
   },
   serialize(input: any): Uint8Array {
+    advanceEncodingEpoch();
     try {
       encode(input);
       return toUint8Array();

--- a/packages/core/src/submodules/client/smithy-client/get-value-from-text-node.spec.ts
+++ b/packages/core/src/submodules/client/smithy-client/get-value-from-text-node.spec.ts
@@ -51,4 +51,26 @@ describe("getValueFromTextNode", () => {
     expect(output.keyWithoutTextNodeAtAnyLevel).toBe(input.keyWithoutTextNodeAtAnyLevel);
     expect(output.keyWithTextNodeAtLevel2.keyWithTextNode).toBe(valueInsideTextNode);
   });
+
+  it("can be called on null proto objects", () => {
+    const nullObject = Object.create(null);
+
+    const keyWithTextNode = Object.create(null);
+    keyWithTextNode["#text"] = valueInsideTextNode;
+
+    const keyWithoutTextNode = Object.create(null);
+    keyWithoutTextNode.key = "value";
+
+    nullObject.key = "value";
+    nullObject.keyWithoutTextNode = keyWithoutTextNode;
+    nullObject.keyWithTextNode = keyWithTextNode;
+
+    expect(getValueFromTextNode(nullObject)).toEqual({
+      key: "value",
+      keyWithTextNode: "valueInsideTextNode",
+      keyWithoutTextNode: {
+        key: "value",
+      },
+    });
+  });
 });

--- a/packages/core/src/submodules/client/smithy-client/get-value-from-text-node.ts
+++ b/packages/core/src/submodules/client/smithy-client/get-value-from-text-node.ts
@@ -6,12 +6,14 @@
  */
 export const getValueFromTextNode = (obj: any) => {
   const textNodeName = "#text";
+
   for (const key in obj) {
-    if (obj.hasOwnProperty(key) && obj[key][textNodeName] !== undefined) {
+    if (Object.prototype.hasOwnProperty.call(obj, key) && obj[key][textNodeName] !== undefined) {
       obj[key] = obj[key][textNodeName];
     } else if (typeof obj[key] === "object" && obj[key] !== null) {
       obj[key] = getValueFromTextNode(obj[key]);
     }
   }
+
   return obj;
 };

--- a/packages/core/src/submodules/config/defaults-mode/resolveDefaultsModeConfig.spec.ts
+++ b/packages/core/src/submodules/config/defaults-mode/resolveDefaultsModeConfig.spec.ts
@@ -8,7 +8,6 @@ import {
   AWS_REGION_ENV,
   DEFAULTS_MODE_OPTIONS,
   ENV_IMDS_DISABLED,
-  IMDS_REGION_PATH,
 } from "./constants";
 import { NODE_DEFAULTS_MODE_CONFIG_OPTIONS } from "./defaultsModeConfig";
 import { resolveDefaultsModeConfig } from "./resolveDefaultsModeConfig";
@@ -94,6 +93,7 @@ describe("resolveDefaultsModeConfig", () => {
 
     it("should return standard when IMDS is unreachable", async () => {
       // No env vars set, IMDS will fail (no server running), should fall back to standard
+      process.env.AWS_EC2_METADATA_DISABLED = "true";
       expect(await resolveDefaultsModeConfig({ region: "us-west-1", defaultsMode: "auto" })()).toBe("standard");
     });
   });

--- a/testbed/bundlers/runner/bundler-output-analysis.cjs
+++ b/testbed/bundlers/runner/bundler-output-analysis.cjs
@@ -50,6 +50,7 @@ function findGlobalBufferRefs(code) {
 
   const polyfillRanges = collectPolyfillRanges(ast);
   const guardedRanges = collectGuardedRanges(ast);
+  addGuardedCallTargets(ast, guardedRanges);
   const typeofArgPositions = collectTypeofArgPositions(ast);
 
   // Scope-aware walk: track local declarations to distinguish global Buffer.
@@ -266,6 +267,62 @@ function collectTypeofArgPositions(ast) {
     },
   });
   return positions;
+}
+
+/**
+ * Finds functions for which every call site is within a guarded range,
+ * and adds their bodies to the guarded ranges array.
+ */
+function addGuardedCallTargets(ast, guardedRanges) {
+  // Map function name -> function node (body range)
+  const funcDefs = new Map();
+  // Map function name -> array of call site nodes
+  const callSites = new Map();
+
+  walk.simple(ast, {
+    FunctionDeclaration(node) {
+      if (node.id && node.id.type === IDENTIFIER) {
+        funcDefs.set(node.id.name, node);
+      }
+    },
+    VariableDeclarator(node) {
+      if (
+        node.id.type === IDENTIFIER &&
+        node.init &&
+        (node.init.type === FUNCTION_EXPRESSION || node.init.type === ARROW_FUNCTION_EXPRESSION)
+      ) {
+        funcDefs.set(node.id.name, node.init);
+      }
+    },
+    CallExpression(node) {
+      if (node.callee.type === IDENTIFIER) {
+        if (!callSites.has(node.callee.name)) {
+          callSites.set(node.callee.name, []);
+        }
+        callSites.get(node.callee.name).push(node);
+      }
+    },
+  });
+
+  function isInGuardedRange(node) {
+    for (let i = 0; i < guardedRanges.length; ++i) {
+      const r = guardedRanges[i];
+      if (node.start >= r.start && node.end <= r.end) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  for (const [name, fnNode] of funcDefs) {
+    const sites = callSites.get(name);
+    if (!sites || sites.length === 0) {
+      continue;
+    }
+    if (sites.every(isInGuardedRange)) {
+      guardedRanges.push({ start: fnNode.start, end: fnNode.end });
+    }
+  }
 }
 
 function extractBindings(pattern, scope) {


### PR DESCRIPTION
- changes the cbor benchmark to run tasks in workers. This prevents v8 optimization from being distracted by things not being measured.

Previously, JSON serde and CBOR serde were mixed in the process. Now, each worker only runs one of: JSON ser, JSON de, CBOR ser, CBOR de.

- plus performance optimizations described in cbor.md in the diff.