### PR TITLE
fix(undici-http-handler): route event streams through shared dispatcher

### DIFF
--- a/.changeset/strong-coats-joke.md
+++ b/.changeset/strong-coats-joke.md
@@ -1,0 +1,5 @@
+---
+"@smithy/undici-http-handler": minor
+---
+
+Route event streams through the shared dispatcher instead of a dedicated isolated Client

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { HttpRequest } from "@smithy/core/protocols";
-import { Agent, Pool, buildConnector, type Dispatcher } from "undici";
+import { Agent, buildConnector, type Dispatcher } from "undici";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { UndiciHttpHandler } from "./undici-http-handler";
@@ -443,20 +443,20 @@ describe("UndiciHttpHandler", () => {
   });
 
   describe("event stream (isEventStream)", () => {
-    it("makes a successful request with an isolated client", async () => {
+    it("makes a successful request", async () => {
       handler = new UndiciHttpHandler();
       const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
       expect(response.statusCode).toBe(200);
     });
 
-    it("does not use the shared dispatcher for event stream requests", async () => {
+    it("routes event streams through the shared internal dispatcher", async () => {
       const sharedAgentRequestSpy = vi.spyOn(Agent.prototype, "request");
       handler = new UndiciHttpHandler();
-      // Internal Agent is in use here, so the isolated client path applies.
-      // Event stream goes through an isolated Client instead of the shared Agent.
+      // Event streams are routed through the shared Agent like normal requests,
+      // rather than through a dedicated isolated Client.
       const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
       expect(response.statusCode).toBe(200);
-      expect(sharedAgentRequestSpy).not.toHaveBeenCalled();
+      expect(sharedAgentRequestSpy).toHaveBeenCalled();
     });
 
     it("routes event streams through caller-provided dispatcher", async () => {
@@ -495,12 +495,14 @@ describe("UndiciHttpHandler", () => {
       expect(mockDispatcher.request).toHaveBeenCalledOnce();
     });
 
-    it("uses isolated client for event streams when Agent.Options were provided", async () => {
-      // Agent.Options means the handler created the Agent internally, so
-      // an isolated client should still be used for event streams.
+    it("routes event streams through the shared Agent when Agent.Options were provided", async () => {
+      // Agent.Options means the handler created the Agent internally. The event
+      // stream still goes through that shared Agent.
+      const sharedAgentRequestSpy = vi.spyOn(Agent.prototype, "request");
       handler = new UndiciHttpHandler({ dispatcher: { connections: 2 } });
       const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
       expect(response.statusCode).toBe(200);
+      expect(sharedAgentRequestSpy).toHaveBeenCalled();
     });
 
     it("uses the shared dispatcher when isEventStream is false", async () => {
@@ -519,7 +521,7 @@ describe("UndiciHttpHandler", () => {
       expect(mockDispatcher.request).toHaveBeenCalledOnce();
     });
 
-    it("destroys isolated client when abort signal is already aborted", async () => {
+    it("throws AbortError for an event stream when the abort signal is already aborted", async () => {
       handler = new UndiciHttpHandler();
       const controller = new AbortController();
       controller.abort();
@@ -531,7 +533,7 @@ describe("UndiciHttpHandler", () => {
       ).rejects.toThrow("Request aborted");
     });
 
-    it("destroys isolated client on request error", async () => {
+    it("rejects an event stream request on connection error", async () => {
       handler = new UndiciHttpHandler();
       // Use a port that nothing is listening on to trigger a connection error.
       const badRequest = Object.assign(
@@ -547,7 +549,7 @@ describe("UndiciHttpHandler", () => {
       await expect(handler.handle(badRequest, { isEventStream: true })).rejects.toThrow();
     });
 
-    it("appends query string to path with isolated client", async () => {
+    it("appends query string to path for event streams", async () => {
       handler = new UndiciHttpHandler();
       const { response } = await handler.handle(
         createMockRequest({
@@ -560,7 +562,7 @@ describe("UndiciHttpHandler", () => {
       expect(response.headers["x-url"]).toContain("foo=bar");
     });
 
-    it("propagates Agent.Options 'connect' to the isolated Client for event streams", async () => {
+    it("applies Agent.Options 'connect' to event stream requests", async () => {
       const connect = vi.fn(((opts: any, cb: any) => {
         // Delegate to undici's default connector so the request still completes.
         const real = buildConnector({});
@@ -571,24 +573,6 @@ describe("UndiciHttpHandler", () => {
       const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
       expect(response.statusCode).toBe(200);
       expect(connect).toHaveBeenCalled();
-    });
-
-    it("strips Agent/Pool-only options ('connections', 'factory', 'maxRedirections', 'interceptors') from isolated Client", async () => {
-      // 'connections' would throw on Client.Options but is valid on Agent/Pool;
-      // verify the handler does not propagate it to the isolated Client.
-      handler = new UndiciHttpHandler({
-        dispatcher: {
-          connections: 4,
-          maxRedirections: 0,
-          factory: ((origin: any, opts: any) => {
-            // Should not be called for the isolated Client.
-            return new Pool(origin, opts);
-          }) as any,
-        } as any,
-      });
-
-      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
-      expect(response.statusCode).toBe(200);
     });
   });
 

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { HttpRequest } from "@smithy/core/protocols";
-import { Agent, buildConnector, type Dispatcher } from "undici";
+import { Agent, type Dispatcher } from "undici";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { UndiciHttpHandler } from "./undici-http-handler";
@@ -440,140 +440,6 @@ describe("UndiciHttpHandler", () => {
       handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
       handler.destroy();
       expect(mockDispatcher.destroy).toHaveBeenCalled();
-    });
-  });
-
-  describe("event stream (isEventStream)", () => {
-    it("makes a successful request", async () => {
-      handler = new UndiciHttpHandler();
-      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
-      expect(response.statusCode).toBe(200);
-    });
-
-    it("routes event streams through the shared internal dispatcher", async () => {
-      const sharedAgentRequestSpy = vi.spyOn(Agent.prototype, "request");
-      handler = new UndiciHttpHandler();
-      // Event streams are routed through the shared Agent like normal requests,
-      // rather than through a dedicated isolated Client.
-      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
-      expect(response.statusCode).toBe(200);
-      expect(sharedAgentRequestSpy).toHaveBeenCalled();
-    });
-
-    it("routes event streams through caller-provided dispatcher", async () => {
-      const mockDispatcher = {
-        request: vi.fn().mockResolvedValue({
-          statusCode: 200,
-          headers: {},
-          body: null,
-        }),
-        close: vi.fn(),
-        destroy: vi.fn(),
-      } as unknown as Dispatcher;
-
-      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
-      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
-      expect(response.statusCode).toBe(200);
-      // When caller supplies a Dispatcher, event streams go through it so
-      // proxy / mock / pool-sizing decisions are honored.
-      expect(mockDispatcher.request).toHaveBeenCalledOnce();
-    });
-
-    it("routes event streams through caller-provided dispatcher set via updateHttpClientConfig", async () => {
-      const mockDispatcher = {
-        request: vi.fn().mockResolvedValue({
-          statusCode: 200,
-          headers: {},
-          body: null,
-        }),
-        destroy: vi.fn(),
-        close: vi.fn().mockResolvedValue(undefined),
-      } as unknown as Dispatcher;
-
-      handler = new UndiciHttpHandler();
-      handler.updateHttpClientConfig("dispatcher", mockDispatcher);
-      await handler.handle(createMockRequest(), { isEventStream: true });
-      expect(mockDispatcher.request).toHaveBeenCalledOnce();
-    });
-
-    it("routes event streams through the shared Agent when Agent.Options were provided", async () => {
-      // Agent.Options means the handler created the Agent internally. The event
-      // stream still goes through that shared Agent.
-      const sharedAgentRequestSpy = vi.spyOn(Agent.prototype, "request");
-      handler = new UndiciHttpHandler({ dispatcher: { connections: 2 } });
-      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
-      expect(response.statusCode).toBe(200);
-      expect(sharedAgentRequestSpy).toHaveBeenCalled();
-    });
-
-    it("uses the shared dispatcher when isEventStream is false", async () => {
-      const mockDispatcher = {
-        request: vi.fn().mockResolvedValue({
-          statusCode: 200,
-          headers: {},
-          body: null,
-        }),
-        close: vi.fn(),
-        destroy: vi.fn(),
-      } as unknown as Dispatcher;
-
-      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
-      await handler.handle(createMockRequest(), { isEventStream: false });
-      expect(mockDispatcher.request).toHaveBeenCalledOnce();
-    });
-
-    it("throws AbortError for an event stream when the abort signal is already aborted", async () => {
-      handler = new UndiciHttpHandler();
-      const controller = new AbortController();
-      controller.abort();
-      await expect(
-        handler.handle(createMockRequest(), {
-          abortSignal: controller.signal as any,
-          isEventStream: true,
-        })
-      ).rejects.toThrow("Request aborted");
-    });
-
-    it("rejects an event stream request on connection error", async () => {
-      handler = new UndiciHttpHandler();
-      // Use a port that nothing is listening on to trigger a connection error.
-      const badRequest = Object.assign(
-        new HttpRequest({
-          protocol: "http:",
-          hostname: "127.0.0.1",
-          port: 1,
-          method: "GET",
-          path: "/",
-          headers: {},
-        })
-      );
-      await expect(handler.handle(badRequest, { isEventStream: true })).rejects.toThrow();
-    });
-
-    it("appends query string to path for event streams", async () => {
-      handler = new UndiciHttpHandler();
-      const { response } = await handler.handle(
-        createMockRequest({
-          path: "/echo",
-          query: { foo: "bar" },
-        }),
-        { isEventStream: true }
-      );
-      expect(response.statusCode).toBe(200);
-      expect(response.headers["x-url"]).toContain("foo=bar");
-    });
-
-    it("applies Agent.Options 'connect' to event stream requests", async () => {
-      const connect = vi.fn(((opts: any, cb: any) => {
-        // Delegate to undici's default connector so the request still completes.
-        const real = buildConnector({});
-        return real(opts, cb);
-      }) as any);
-
-      handler = new UndiciHttpHandler({ dispatcher: { connect } });
-      const { response } = await handler.handle(createMockRequest(), { isEventStream: true });
-      expect(response.statusCode).toBe(200);
-      expect(connect).toHaveBeenCalled();
     });
   });
 

--- a/packages/undici-http-handler/src/undici-http-handler.spec.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.spec.ts
@@ -94,6 +94,7 @@ describe("UndiciHttpHandler", () => {
 
   afterEach(() => {
     handler?.destroy();
+    vi.restoreAllMocks();
   });
 
   describe("handle", () => {

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -91,8 +91,6 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
     request: HttpRequest,
     { abortSignal, requestTimeout }: HttpHandlerOptions = {}
   ): Promise<{ response: HttpResponse }> {
-    const dispatcher = this.getOrCreateDispatcher();
-
     if (abortSignal?.aborted) {
       throw buildAbortError(abortSignal);
     }
@@ -143,7 +141,7 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
         statusCode,
         headers: responseHeaders,
         body: responseBody,
-      } = await dispatcher.request({
+      } = await this.getOrCreateDispatcher().request({
         origin,
         path,
         method: request.method as Dispatcher.HttpMethod,

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -1,7 +1,7 @@
 import type { Readable } from "node:stream";
 import { HttpResponse, buildQueryString, type HttpHandler, type HttpRequest } from "@smithy/core/protocols";
 import type { HttpHandlerOptions, Logger } from "@smithy/types";
-import { Agent, Client, Dispatcher } from "undici";
+import { Agent, Dispatcher } from "undici";
 
 import { buildAbortError } from "./build-abort-error";
 
@@ -30,25 +30,6 @@ const isDispatcher = (value: unknown): value is Dispatcher => {
 };
 
 /**
- * Keys present on Agent.Options or Pool.Options that are not valid on
- * Client.Options. We strip these when propagating the caller's options
- * to an isolated Client used for event streams.
- */
-const AGENT_AND_POOL_ONLY_OPTION_KEYS = ["factory", "maxRedirections", "connections", "interceptors"] as const;
-
-/**
- * Returns a Client.Options-compatible subset of the given Agent.Options by
- * removing keys that only apply to Agent or Pool.
- */
-const toClientOptions = (options: Agent.Options): Client.Options => {
-  const result: Record<string, unknown> = { ...options };
-  for (const key of AGENT_AND_POOL_ONLY_OPTION_KEYS) {
-    delete result[key];
-  }
-  return result as Client.Options;
-};
-
-/**
  * Options for the UndiciHttpHandler.
  *
  * @public
@@ -71,11 +52,17 @@ export interface UndiciHttpHandlerOptions {
 }
 
 /**
- * This is derived from the smithyContext object. This signals to the UndiciHttpHandler
- * that the shared connection pool should not be used. The event stream should
- * have its own dedicated connection.
+ * This is derived from the smithyContext object. It signals to the
+ * UndiciHttpHandler that the request carries an event stream.
  *
- * This does not apply to WebSocket event streams, since there is no pooling.
+ * Event streams are routed through the shared dispatcher just like normal
+ * requests. With HTTP/2 (`allowH2`, the default for the internally-managed
+ * Agent) streams are multiplexed over a single connection, so a long-lived
+ * event stream does not occupy a dedicated socket. With HTTP/1.1, undici's
+ * Agent opens additional connections as needed (connections default to
+ * unlimited), so concurrent requests are not blocked. Callers who cap
+ * `connections` are making an explicit pool-sizing decision that is honored
+ * for event streams as well.
  *
  * @internal
  */
@@ -93,29 +80,15 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
   private config: { dispatcher?: Dispatcher; logger?: Logger };
 
   /**
-   * Tracks whether the current dispatcher was created internally by this
-   * handler (true) or supplied by the caller as a Dispatcher instance (false).
-   *
-   * When the caller supplied their own Dispatcher, event-stream requests
-   * are routed through it as well so that proxy settings, mock interceptors,
-   * and similar behaviors are honored. When we own the dispatcher, event
-   * streams get an isolated Client so a long-lived stream does not occupy
-   * a slot in the shared pool.
-   */
-  private isInternalDispatcher: boolean = true;
-
-  /**
-   * Options used to construct the internally-managed Agent, retained so they
-   * can be propagated to isolated Clients created for event streams. This
-   * preserves caller-configured TLS, connect, and timeout settings on the
-   * dedicated event-stream connection.
+   * Options used to construct the internally-managed Agent, retained so the
+   * Agent can be created lazily on the first request. This preserves
+   * caller-configured TLS, connect, and timeout settings.
    */
   private internalAgentOptions?: Agent.Options;
 
   constructor(options?: UndiciHttpHandlerOptions) {
     if (options?.dispatcher && isDispatcher(options.dispatcher)) {
       this.config = { ...options, dispatcher: options.dispatcher };
-      this.isInternalDispatcher = false;
     } else if (options?.dispatcher) {
       // Caller passed Agent.Options — store them and defer Agent creation
       // until the first request, so we don't pay for an unused dispatcher
@@ -135,20 +108,15 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
 
   public async handle(
     request: HttpRequest,
-    { abortSignal, requestTimeout, isEventStream }: HttpHandlerOptions & EventStreamSignal = {}
+    { abortSignal, requestTimeout }: HttpHandlerOptions & EventStreamSignal = {}
   ): Promise<{ response: HttpResponse }> {
-    // Use an isolated client for event streams only when the dispatcher is
-    // internally managed. If the caller supplied their own Dispatcher, route
-    // event streams through it as well so proxy settings, mock interceptors,
-    // and pool sizing decisions made by the caller are preserved.
-    const useIsolatedClient = isEventStream && this.isInternalDispatcher;
-    const isolatedClient = useIsolatedClient ? this.createIsolatedClient(request) : undefined;
-    const dispatcher = isolatedClient ?? this.getOrCreateDispatcher();
+    /**
+     * Event streams are routed through the shared dispatcher just like normal
+     * requests — see {@link EventStreamSignal} for the rationale.
+     */
+    const dispatcher = this.getOrCreateDispatcher();
 
     if (abortSignal?.aborted) {
-      if (isolatedClient) {
-        isolatedClient.destroy();
-      }
       throw buildAbortError(abortSignal);
     }
 
@@ -235,20 +203,8 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
         body: responseBody,
       });
 
-      // Close the isolated client once the response body stream closes.
-      if (isolatedClient) {
-        (responseBody as Readable).once("close", () => {
-          isolatedClient.close();
-        });
-      }
-
       return { response: httpResponse };
     } catch (err: any) {
-      // Ensure the isolated client is cleaned up on errors.
-      if (isolatedClient) {
-        isolatedClient.destroy();
-      }
-
       if (err?.code === "UND_ERR_ABORTED") {
         // Preserve the abort reason from the signal as `cause` so callers can
         // distinguish user-provided abort reasons from undici's generic abort.
@@ -306,7 +262,6 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
       }
 
       this.config.dispatcher = value;
-      this.isInternalDispatcher = false;
       this.internalAgentOptions = undefined;
       return;
     }
@@ -320,7 +275,6 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
 
       this.internalAgentOptions = { allowH2: true, ...(value as Agent.Options) };
       this.config.dispatcher = undefined;
-      this.isInternalDispatcher = true;
       return;
     }
 
@@ -331,36 +285,6 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
 
   public httpHandlerConfigs(): { dispatcher?: Dispatcher; logger?: Logger } {
     return { ...this.config };
-  }
-
-  /**
-   * Creates a one-off undici Client for an event stream request.
-   * This mirrors NodeHttp2Handler's isolated session behavior — the event stream
-   * gets its own dedicated connection that isn't shared with the connection pool.
-   *
-   * Caller-provided Agent.Options (TLS, connect, timeouts, etc.) are propagated
-   * to the isolated Client. Agent/Pool-only keys are stripped. `pipelining` is
-   * forced to 0 so the dedicated connection is not pipelined.
-   */
-  private createIsolatedClient(request: HttpRequest): Client {
-    const port = request.port ? `:${request.port}` : "";
-    let origin: string;
-    if (request.username != null || request.password != null) {
-      const username = request.username ?? "";
-      const password = request.password ?? "";
-      origin = `${request.protocol}//${username}:${password}@${request.hostname}${port}`;
-    } else {
-      origin = `${request.protocol}//${request.hostname}${port}`;
-    }
-
-    const baseOptions: Client.Options = this.internalAgentOptions
-      ? toClientOptions(this.internalAgentOptions)
-      : { allowH2: true };
-
-    return new Client(origin, {
-      ...baseOptions,
-      pipelining: 0, // no pipelining — dedicated connection
-    });
   }
 
   private getOrCreateDispatcher(): Dispatcher {

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -52,25 +52,6 @@ export interface UndiciHttpHandlerOptions {
 }
 
 /**
- * This is derived from the smithyContext object. It signals to the
- * UndiciHttpHandler that the request carries an event stream.
- *
- * Event streams are routed through the shared dispatcher just like normal
- * requests. With HTTP/2 (`allowH2`, the default for the internally-managed
- * Agent) streams are multiplexed over a single connection, so a long-lived
- * event stream does not occupy a dedicated socket. With HTTP/1.1, undici's
- * Agent opens additional connections as needed (connections default to
- * unlimited), so concurrent requests are not blocked. Callers who cap
- * `connections` are making an explicit pool-sizing decision that is honored
- * for event streams as well.
- *
- * @internal
- */
-type EventStreamSignal = {
-  isEventStream?: boolean;
-};
-
-/**
  * An HTTP handler that uses undici instead of Node.js native http/https modules.
  * Smithy-compatible request handler backed by undici.
  *
@@ -108,12 +89,8 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
 
   public async handle(
     request: HttpRequest,
-    { abortSignal, requestTimeout }: HttpHandlerOptions & EventStreamSignal = {}
+    { abortSignal, requestTimeout }: HttpHandlerOptions = {}
   ): Promise<{ response: HttpResponse }> {
-    /**
-     * Event streams are routed through the shared dispatcher just like normal
-     * requests — see {@link EventStreamSignal} for the rationale.
-     */
     const dispatcher = this.getOrCreateDispatcher();
 
     if (abortSignal?.aborted) {


### PR DESCRIPTION
*Issue #, if available:*

Refs: https://github.com/smithy-lang/smithy-typescript/pull/2076#discussion_r3421948130

*Description of changes:*

Previously event streams over the internally-managed Agent were given a
dedicated isolated Client to keep a long-lived stream out of the shared
connection pool. Route them through the shared dispatcher instead, like
normal requests.

With HTTP/2 (the default allowH2) streams multiplex over a single
connection, and with HTTP/1.1 undici opens additional connections as
needed (unlimited by default), so a long-lived stream does not block
other traffic. Callers who cap `connections` make an explicit
pool-sizing decision that is now honored for event streams too.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
