### PR TITLE
feat(server): add interceptor support to generated SSDK handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,15 @@ generate-protocol-tests:
 	yarn turbo run build -F="./private/*" --only
 	make test-protocols;
 
+generate-server-tests:
+	rm -rf ./smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test
+	./gradlew :smithy-typescript-codegen-test:build
+	rm -rf ./private/interceptor-example-ssdk
+	cp -r ./smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/interceptor-example/typescript-server-codegen/ ./private/interceptor-example-ssdk
+	node ./scripts/post-protocol-test-codegen
+	yarn
+	yarn turbo run build -F="./private/interceptor-example-ssdk"
+
 test-protocols:
 	(cd ./private/smithy-rpcv2-cbor && npx vitest run --globals && yarn test:index)
 	(cd ./private/smithy-rpcv2-cbor-schema && npx vitest run --globals && yarn test:index)

--- a/private/interceptor-example-ssdk/package.json
+++ b/private/interceptor-example-ssdk/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "interceptor-example-ssdk",
+  "description": "interceptor-example-ssdk server",
+  "version": "0.0.1",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
+    "prepack": "yarn run clean && yarn run build"
+  },
+  "main": "./dist-cjs/index.js",
+  "types": "./dist-types/index.d.ts",
+  "module": "./dist-es/index.js",
+  "sideEffects": false,
+  "dependencies": {
+    "@aws-crypto/sha256-browser": "5.2.0",
+    "@aws-crypto/sha256-js": "5.2.0",
+    "@aws-smithy/server-common": "workspace:^",
+    "@smithy/core": "workspace:^",
+    "@smithy/fetch-http-handler": "workspace:^",
+    "@smithy/node-http-handler": "workspace:^",
+    "@smithy/types": "workspace:^",
+    "tslib": "^2.6.2"
+  },
+  "devDependencies": {
+    "@tsconfig/node20": "20.1.8",
+    "@types/node": "^20.14.8",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "premove": "4.0.0",
+    "typescript": "~5.8.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "typesVersions": {
+    "<4.5": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*/**"
+  ],
+  "license": "Apache-2.0",
+  "private": true
+}

--- a/private/interceptor-example-ssdk/package.json
+++ b/private/interceptor-example-ssdk/package.json
@@ -16,11 +16,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "5.2.0",
-    "@aws-crypto/sha256-js": "5.2.0",
     "@aws-smithy/server-common": "workspace:^",
     "@smithy/core": "workspace:^",
-    "@smithy/fetch-http-handler": "workspace:^",
     "@smithy/node-http-handler": "workspace:^",
     "@smithy/types": "workspace:^",
     "tslib": "^2.6.2"

--- a/private/interceptor-example-ssdk/src/endpoint/EndpointParameters.ts
+++ b/private/interceptor-example-ssdk/src/endpoint/EndpointParameters.ts
@@ -1,0 +1,41 @@
+// smithy-typescript generated code
+import type { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
+
+/**
+ * @public
+ */
+export interface ClientInputEndpointParameters {
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
+}
+
+/**
+ * @public
+ */
+export type ClientResolvedEndpointParameters = Omit<ClientInputEndpointParameters, "endpoint"> & {
+  defaultSigningName: string;
+};
+
+/**
+ * @internal
+ */
+export const resolveClientEndpointParameters = <T>(
+  options: T & ClientInputEndpointParameters
+): T & ClientResolvedEndpointParameters => {
+  return Object.assign(options, {
+    defaultSigningName: "",
+  });
+};
+
+/**
+ * @internal
+ */
+export const commonParams = {
+  endpoint: { type: "builtInParams", name: "endpoint" },
+} as const;
+
+/**
+ * @internal
+ */
+export interface EndpointParameters extends __EndpointParameters {
+  endpoint?: string | undefined;
+}

--- a/private/interceptor-example-ssdk/src/endpoint/bdd.ts
+++ b/private/interceptor-example-ssdk/src/endpoint/bdd.ts
@@ -1,0 +1,24 @@
+// smithy-typescript generated code
+import { BinaryDecisionDiagram } from "@smithy/core/endpoints";
+
+const a={"ref":"endpoint"};
+const _data={
+  conditions: [
+    ["isSet",[a]]
+  ],
+  results: [
+    [-1],
+    [a,{}],
+    [-1,"(default endpointRuleSet) endpoint is not set - you must configure an endpoint."]
+  ]
+};
+
+const root = 2;
+const r = 100_000_000;
+const nodes = new Int32Array([
+  -1, 1, -1,
+  0, r + 1, r + 2,
+]);
+export const bdd = BinaryDecisionDiagram.from(
+  nodes, root, _data.conditions, _data.results
+);

--- a/private/interceptor-example-ssdk/src/endpoint/endpointResolver.ts
+++ b/private/interceptor-example-ssdk/src/endpoint/endpointResolver.ts
@@ -1,0 +1,26 @@
+// smithy-typescript generated code
+import { type EndpointParams, decideEndpoint, EndpointCache } from "@smithy/core/endpoints";
+import type { EndpointV2, Logger } from "@smithy/types";
+
+import { bdd } from "./bdd";
+import type { EndpointParameters } from "./EndpointParameters";
+
+const cache = new EndpointCache({
+  size: 50,
+  params: ["endpoint"],
+});
+
+/**
+ * @internal
+ */
+export const defaultEndpointResolver = (
+  endpointParams: EndpointParameters,
+  context: { logger?: Logger } = {}
+): EndpointV2 => {
+  return cache.get(endpointParams as EndpointParams, () =>
+    decideEndpoint(bdd, {
+      endpointParams: endpointParams as EndpointParams,
+      logger: context.logger,
+    })
+  );
+};

--- a/private/interceptor-example-ssdk/src/index.ts
+++ b/private/interceptor-example-ssdk/src/index.ts
@@ -1,0 +1,12 @@
+// smithy-typescript generated code
+/* eslint-disable */
+/**
+ * Minimal service used to generate a checked-in server SDK example for
+ * reviewing the interceptor pipeline emitted by the codegen.
+ *
+ * @packageDocumentation
+ */
+export * as Fakeprotocol from "./protocols/Fakeprotocol";
+export * from "./server/index";
+
+export * from "./models/models_0";

--- a/private/interceptor-example-ssdk/src/models/models_0.ts
+++ b/private/interceptor-example-ssdk/src/models/models_0.ts
@@ -1,0 +1,145 @@
+// smithy-typescript generated code
+import {
+  CompositeValidator as __CompositeValidator,
+  MultiConstraintValidator as __MultiConstraintValidator,
+  NoOpValidator as __NoOpValidator,
+  RequiredValidator as __RequiredValidator,
+  ValidationFailure as __ValidationFailure,
+} from "@aws-smithy/server-common";
+
+/**
+ * @public
+ */
+export interface GetItemInput {
+  id: string | undefined;
+}
+
+export namespace GetItemInput {
+  const memberValidators : {
+    id?: __MultiConstraintValidator<string>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: GetItemInput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "id": {
+            memberValidators["id"] = new __CompositeValidator<string>([
+              new __RequiredValidator(),
+            ]);
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("id").validate(obj.id, `${path}/id`),
+    ];
+  }
+}
+
+/**
+ * @public
+ */
+export interface GetItemOutput {
+  id?: string | undefined;
+  name?: string | undefined;
+}
+
+export namespace GetItemOutput {
+  const memberValidators : {
+    id?: __MultiConstraintValidator<string>,
+    name?: __MultiConstraintValidator<string>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: GetItemOutput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "id": {
+            memberValidators["id"] = new __NoOpValidator();
+            break;
+          }
+          case "name": {
+            memberValidators["name"] = new __NoOpValidator();
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("id").validate(obj.id, `${path}/id`),
+      ...getMemberValidator("name").validate(obj.name, `${path}/name`),
+    ];
+  }
+}
+
+/**
+ * @public
+ */
+export interface PingInput {
+  message?: string | undefined;
+}
+
+export namespace PingInput {
+  const memberValidators : {
+    message?: __MultiConstraintValidator<string>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: PingInput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "message": {
+            memberValidators["message"] = new __NoOpValidator();
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("message").validate(obj.message, `${path}/message`),
+    ];
+  }
+}
+
+/**
+ * @public
+ */
+export interface PingOutput {
+  message?: string | undefined;
+}
+
+export namespace PingOutput {
+  const memberValidators : {
+    message?: __MultiConstraintValidator<string>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: PingOutput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "message": {
+            memberValidators["message"] = new __NoOpValidator();
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("message").validate(obj.message, `${path}/message`),
+    ];
+  }
+}

--- a/private/interceptor-example-ssdk/src/protocols/Fakeprotocol.ts
+++ b/private/interceptor-example-ssdk/src/protocols/Fakeprotocol.ts
@@ -184,6 +184,18 @@ export const serializeFrameworkException = async (
         statusCode,
       });
     }
+    case "UnauthenticatedException": {
+      const statusCode: number = 401
+      let headers: any = map({}, isSerializableHeaderValue, {
+        'content-type': 'application/json',
+      });
+      let body: any;
+      return new __HttpResponse({
+        headers,
+        body,
+        statusCode,
+      });
+    }
     case "UnknownOperationException": {
       const statusCode: number = 404
       let headers: any = map({}, isSerializableHeaderValue, {

--- a/private/interceptor-example-ssdk/src/protocols/Fakeprotocol.ts
+++ b/private/interceptor-example-ssdk/src/protocols/Fakeprotocol.ts
@@ -1,0 +1,244 @@
+// smithy-typescript generated code
+import {
+  acceptMatches as __acceptMatches,
+  NotAcceptableException as __NotAcceptableException,
+  ServerSerdeContext,
+  SmithyFrameworkException as __SmithyFrameworkException,
+  UnsupportedMediaTypeException as __UnsupportedMediaTypeException,
+} from "@aws-smithy/server-common";
+import { isSerializableHeaderValue, map } from "@smithy/core/client";
+import { collectBody, HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
+import {
+  calculateBodyLength,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+} from "@smithy/core/serde";
+import {
+  type Endpoint as __Endpoint,
+  type ResponseMetadata as __ResponseMetadata,
+  SerdeContext as __SerdeContext,
+} from "@smithy/types";
+
+import { GetItemServerInput, GetItemServerOutput } from "../server/operations/GetItem";
+import { PingServerInput, PingServerOutput } from "../server/operations/Ping";
+
+export const deserializeGetItemRequest = async (
+  output: __HttpRequest,
+  context: __SerdeContext
+): Promise<GetItemServerInput> => {
+  const contentTypeHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'content-type');
+  if (contentTypeHeaderKey != null) {
+    const contentType = output.headers[contentTypeHeaderKey];
+    if (contentType !== undefined && contentType !== "application/json") {
+      throw new __UnsupportedMediaTypeException();
+    };
+  };
+  const acceptHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'accept');
+  if (acceptHeaderKey != null) {
+    const accept = output.headers[acceptHeaderKey];
+    if (!__acceptMatches(accept, "application/json")) {
+      throw new __NotAcceptableException();
+    };
+  };
+  const contents: any = map({
+  });
+  const pathRegex = new RegExp("/item/(?<id>[^/]+)");
+  const parsedPath = output.path.match(pathRegex);
+  if (parsedPath?.groups !== undefined) {
+    contents.id = decodeURIComponent(parsedPath.groups.id);
+  }
+  await collectBody(output.body, context);
+  return contents;
+};
+
+export const deserializePingRequest = async (
+  output: __HttpRequest,
+  context: __SerdeContext
+): Promise<PingServerInput> => {
+  const contentTypeHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'content-type');
+  if (contentTypeHeaderKey != null) {
+    const contentType = output.headers[contentTypeHeaderKey];
+    if (contentType !== undefined && contentType !== "application/json") {
+      throw new __UnsupportedMediaTypeException();
+    };
+  };
+  const acceptHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'accept');
+  if (acceptHeaderKey != null) {
+    const accept = output.headers[acceptHeaderKey];
+    if (!__acceptMatches(accept, "application/json")) {
+      throw new __NotAcceptableException();
+    };
+  };
+  const contents: any = map({
+  });
+  const data: Record<string, any> = __expectNonNull((__expectObject(await parseBody(output.body, context))), "body");
+  return contents;
+};
+
+export const serializeGetItemResponse = async (
+  input: GetItemServerOutput,
+  ctx: ServerSerdeContext
+): Promise<__HttpResponse> => {
+  const context: __SerdeContext = {
+    ...ctx,
+    endpoint: () => Promise.resolve({
+      protocol: '',
+      hostname: '',
+      path: '',
+    }),
+  };
+  let statusCode: number = 200
+  let headers: any = map({}, isSerializableHeaderValue, {
+    'content-type': 'application/json',
+  });
+  let body: any;
+  if (body && Object.keys(headers).map((str) => str.toLowerCase()).indexOf('content-length') === -1) {
+    const length = calculateBodyLength(body);
+    if (length !== undefined) {
+      headers = { ...headers, 'content-length': String(length) };
+    }
+  }
+  return new __HttpResponse({
+    headers,
+    body,
+    statusCode,
+  });
+};
+
+export const serializePingResponse = async (
+  input: PingServerOutput,
+  ctx: ServerSerdeContext
+): Promise<__HttpResponse> => {
+  const context: __SerdeContext = {
+    ...ctx,
+    endpoint: () => Promise.resolve({
+      protocol: '',
+      hostname: '',
+      path: '',
+    }),
+  };
+  let statusCode: number = 200
+  let headers: any = map({}, isSerializableHeaderValue, {
+    'content-type': 'application/json',
+  });
+  let body: any;
+  if (body && Object.keys(headers).map((str) => str.toLowerCase()).indexOf('content-length') === -1) {
+    const length = calculateBodyLength(body);
+    if (length !== undefined) {
+      headers = { ...headers, 'content-length': String(length) };
+    }
+  }
+  return new __HttpResponse({
+    headers,
+    body,
+    statusCode,
+  });
+};
+
+export const serializeFrameworkException = async (
+  input: __SmithyFrameworkException,
+  ctx: ServerSerdeContext
+): Promise<__HttpResponse> => {
+  const context: __SerdeContext = {
+    ...ctx,
+    endpoint: () => Promise.resolve({
+      protocol: '',
+      hostname: '',
+      path: '',
+    }),
+  };
+  switch (input.name) {
+    case "InternalFailure": {
+      const statusCode: number = 500
+      let headers: any = map({}, isSerializableHeaderValue, {
+        'content-type': 'application/json',
+      });
+      let body: any;
+      return new __HttpResponse({
+        headers,
+        body,
+        statusCode,
+      });
+    }
+    case "NotAcceptableException": {
+      const statusCode: number = 406
+      let headers: any = map({}, isSerializableHeaderValue, {
+        'content-type': 'application/json',
+      });
+      let body: any;
+      return new __HttpResponse({
+        headers,
+        body,
+        statusCode,
+      });
+    }
+    case "SerializationException": {
+      const statusCode: number = 400
+      let headers: any = map({}, isSerializableHeaderValue, {
+        'content-type': 'application/json',
+      });
+      let body: any;
+      return new __HttpResponse({
+        headers,
+        body,
+        statusCode,
+      });
+    }
+    case "UnknownOperationException": {
+      const statusCode: number = 404
+      let headers: any = map({}, isSerializableHeaderValue, {
+        'content-type': 'application/json',
+      });
+      let body: any;
+      return new __HttpResponse({
+        headers,
+        body,
+        statusCode,
+      });
+    }
+    case "UnsupportedMediaTypeException": {
+      const statusCode: number = 415
+      let headers: any = map({}, isSerializableHeaderValue, {
+        'content-type': 'application/json',
+      });
+      let body: any;
+      return new __HttpResponse({
+        headers,
+        body,
+        statusCode,
+      });
+    }
+  }
+}
+
+const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
+  httpStatusCode: output.statusCode,
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
+});
+
+// Encode Uint8Array data into string with utf-8.
+const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> => collectBody(streamBody, context).then(body => context.utf8Encoder(body))
+
+const parseBody = (streamBody: any, context: __SerdeContext): any => collectBodyString(streamBody, context).then(encoded => {
+  if (encoded.length) {
+    return JSON.parse(encoded);
+  }
+  return {};
+});
+
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
+  value.message = value.message ?? value.Message;
+  return value;
+}
+
+const parseErrorCode = (output: __HttpResponse, data: any): string | undefined => {
+  if (output.headers["x-error"]) {
+    return output.headers["x-error"];
+  }
+  if (data.code !== undefined) {
+    return data.code;
+  }
+}

--- a/private/interceptor-example-ssdk/src/server/InterceptorExampleService.ts
+++ b/private/interceptor-example-ssdk/src/server/InterceptorExampleService.ts
@@ -1,0 +1,152 @@
+// smithy-typescript generated code
+import {
+  httpbinding,
+  InternalFailureException as __InternalFailureException,
+  isFrameworkException as __isFrameworkException,
+  Mux as __Mux,
+  Operation as __Operation,
+  OperationInput as __OperationInput,
+  OperationOutput as __OperationOutput,
+  OperationSerializer as __OperationSerializer,
+  SerializationException as __SerializationException,
+  ServerSerdeContext as __ServerSerdeContext,
+  ServiceException as __ServiceException,
+  ServiceHandler as __ServiceHandler,
+  SmithyFrameworkException as __SmithyFrameworkException,
+  UnknownOperationException as __UnknownOperationException,
+  ValidationCustomizer as __ValidationCustomizer,
+  ValidationFailure as __ValidationFailure,
+} from "@aws-smithy/server-common";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
+import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
+import { NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";
+
+import { serializeFrameworkException } from "../protocols/Fakeprotocol";
+import { GetItem, GetItemSerializer, GetItemServerInput } from "./operations/GetItem";
+import { Ping, PingSerializer, PingServerInput } from "./operations/Ping";
+
+export type InterceptorExampleServiceOperations = "GetItem" | "Ping";
+export interface InterceptorExampleService<Context> {
+  GetItem: GetItem<Context>
+  Ping: Ping<Context>
+}
+const serdeContextBase = {
+  base64Encoder: toBase64,
+  base64Decoder: fromBase64,
+  utf8Encoder: toUtf8,
+  utf8Decoder: fromUtf8,
+  streamCollector: streamCollector,
+  requestHandler: new NodeHttpHandler(),
+  disableHostPrefix: true
+};
+async function handle<S, O extends keyof S & string, Context>(
+  request: __HttpRequest,
+  context: Context,
+  operationName: O,
+  serializer: __OperationSerializer<S, O, __ServiceException>,
+  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
+  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
+  validationCustomizer: __ValidationCustomizer<O>
+): Promise<__HttpResponse> {
+  let input;
+  try {
+    input = await serializer.deserialize(request, {
+      endpoint: () => Promise.resolve(request), ...serdeContextBase
+    });
+  } catch (error: unknown) {
+    if (__isFrameworkException(error)) {
+      return serializeFrameworkException(error, serdeContextBase);
+    };
+    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
+  }
+  try {
+    let validationFailures = validationFn(input);
+    if (validationFailures && validationFailures.length > 0) {
+      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
+      if (validationException) {
+        return serializer.serializeError(validationException, serdeContextBase);
+      }
+    }
+    let output = await operation(input, context);
+    return serializer.serialize(output, serdeContextBase);
+  } catch(error: unknown) {
+    if (serializer.isOperationError(error)) {
+      return serializer.serializeError(error, serdeContextBase);
+    }
+    console.log('Received an unexpected error', error);
+    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+  }
+}
+export class InterceptorExampleServiceHandler<Context> implements __ServiceHandler<Context> {
+  private readonly service: InterceptorExampleService<Context>;
+  private readonly mux: __Mux<"InterceptorExample", InterceptorExampleServiceOperations>;
+  private readonly serializerFactory: <T extends InterceptorExampleServiceOperations>(operation: T) => __OperationSerializer<InterceptorExampleService<Context>, T, __ServiceException>;
+  private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
+  private readonly validationCustomizer: __ValidationCustomizer<InterceptorExampleServiceOperations>;
+  /**
+   * Construct a InterceptorExampleService handler.
+   * @param service The {@link InterceptorExampleService} implementation that supplies the business logic for InterceptorExampleService
+   * @param mux The {@link __Mux} that determines which service and operation are being invoked by a given {@link __HttpRequest}
+   * @param serializerFactory A factory for an {@link __OperationSerializer} for each operation in InterceptorExampleService that
+   *                          handles deserialization of requests and serialization of responses
+   * @param serializeFrameworkException A function that can serialize {@link __SmithyFrameworkException}s
+   * @param validationCustomizer A {@link __ValidationCustomizer} for turning validation failures into {@link __SmithyFrameworkException}s
+   */
+  constructor(
+    service: InterceptorExampleService<Context>,
+    mux: __Mux<"InterceptorExample", InterceptorExampleServiceOperations>,
+    serializerFactory:<T extends InterceptorExampleServiceOperations>(op: T) => __OperationSerializer<InterceptorExampleService<Context>, T, __ServiceException>,
+    serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+    validationCustomizer: __ValidationCustomizer<InterceptorExampleServiceOperations>
+  ) {
+    this.service = service;
+    this.mux = mux;
+    this.serializerFactory = serializerFactory;
+    this.serializeFrameworkException = serializeFrameworkException;
+    this.validationCustomizer = validationCustomizer;
+  }
+  async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
+    const target = this.mux.match(request);
+    if (target === undefined) {
+      return this.serializeFrameworkException(new __UnknownOperationException(), serdeContextBase);
+    }
+    switch (target.operation) {
+      case "GetItem" : {
+        return handle(request, context, "GetItem", this.serializerFactory("GetItem"), this.service.GetItem, this.serializeFrameworkException, GetItemServerInput.validate, this.validationCustomizer);
+      }
+      case "Ping" : {
+        return handle(request, context, "Ping", this.serializerFactory("Ping"), this.service.Ping, this.serializeFrameworkException, PingServerInput.validate, this.validationCustomizer);
+      }
+    }
+  }
+}
+
+export const getInterceptorExampleServiceHandler = <Context>(service: InterceptorExampleService<Context>, customizer: __ValidationCustomizer<InterceptorExampleServiceOperations>): __ServiceHandler<Context, __HttpRequest, __HttpResponse> => {
+  const mux = new httpbinding.HttpBindingMux<"InterceptorExample", keyof InterceptorExampleService<Context>>([
+    new httpbinding.UriSpec<"InterceptorExample", "GetItem">(
+      'GET',
+      [
+        { type: 'path_literal', value: "item" },
+        { type: 'path' },
+      ],
+      [
+      ],
+      { service: "InterceptorExample", operation: "GetItem" }),
+    new httpbinding.UriSpec<"InterceptorExample", "Ping">(
+      'POST',
+      [
+        { type: 'path_literal', value: "ping" },
+      ],
+      [
+      ],
+      { service: "InterceptorExample", operation: "Ping" }),
+  ]);
+  const serFn: (op: InterceptorExampleServiceOperations) => __OperationSerializer<InterceptorExampleService<Context>, InterceptorExampleServiceOperations, __ServiceException> = (op) => {
+    switch (op) {
+      case "GetItem": return new GetItemSerializer();
+      case "Ping": return new PingSerializer();
+    }
+  };
+  return new InterceptorExampleServiceHandler(service, mux, serFn, serializeFrameworkException, customizer);
+}

--- a/private/interceptor-example-ssdk/src/server/InterceptorExampleService.ts
+++ b/private/interceptor-example-ssdk/src/server/InterceptorExampleService.ts
@@ -1,18 +1,22 @@
 // smithy-typescript generated code
 import {
+  AuthScheme as __AuthScheme,
+  Caller as __Caller,
+  ExecutionHook as __ExecutionHook,
+  FrameworkSteps as __FrameworkSteps,
   httpbinding,
   InternalFailureException as __InternalFailureException,
   isFrameworkException as __isFrameworkException,
   Mux as __Mux,
   Operation as __Operation,
-  OperationInput as __OperationInput,
-  OperationOutput as __OperationOutput,
   OperationSerializer as __OperationSerializer,
   SerializationException as __SerializationException,
+  ServerInterceptor as __ServerInterceptor,
   ServerSerdeContext as __ServerSerdeContext,
   ServiceException as __ServiceException,
   ServiceHandler as __ServiceHandler,
   SmithyFrameworkException as __SmithyFrameworkException,
+  UnauthenticatedException as __UnauthenticatedException,
   UnknownOperationException as __UnknownOperationException,
   ValidationCustomizer as __ValidationCustomizer,
   ValidationFailure as __ValidationFailure,
@@ -39,51 +43,18 @@ const serdeContextBase = {
   requestHandler: new NodeHttpHandler(),
   disableHostPrefix: true
 };
-async function handle<S, O extends keyof S & string, Context>(
-  request: __HttpRequest,
-  context: Context,
-  operationName: O,
-  serializer: __OperationSerializer<S, O, __ServiceException>,
-  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
-  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
-  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
-  validationCustomizer: __ValidationCustomizer<O>
-): Promise<__HttpResponse> {
-  let input;
-  try {
-    input = await serializer.deserialize(request, {
-      endpoint: () => Promise.resolve(request), ...serdeContextBase
-    });
-  } catch (error: unknown) {
-    if (__isFrameworkException(error)) {
-      return serializeFrameworkException(error, serdeContextBase);
-    };
-    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
-  }
-  try {
-    let validationFailures = validationFn(input);
-    if (validationFailures && validationFailures.length > 0) {
-      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
-      if (validationException) {
-        return serializer.serializeError(validationException, serdeContextBase);
-      }
-    }
-    let output = await operation(input, context);
-    return serializer.serialize(output, serdeContextBase);
-  } catch(error: unknown) {
-    if (serializer.isOperationError(error)) {
-      return serializer.serializeError(error, serdeContextBase);
-    }
-    console.log('Received an unexpected error', error);
-    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
-  }
-}
+const InterceptorExampleServiceHandlerValidators: { [K in InterceptorExampleServiceOperations]: (input: any) => __ValidationFailure[] } = {
+  "GetItem": GetItemServerInput.validate,
+  "Ping": PingServerInput.validate,
+};
 export class InterceptorExampleServiceHandler<Context> implements __ServiceHandler<Context> {
-  private readonly service: InterceptorExampleService<Context>;
   private readonly mux: __Mux<"InterceptorExample", InterceptorExampleServiceOperations>;
-  private readonly serializerFactory: <T extends InterceptorExampleServiceOperations>(operation: T) => __OperationSerializer<InterceptorExampleService<Context>, T, __ServiceException>;
+  private readonly service: InterceptorExampleService<Context>;
+  private readonly serializerFactory: <T extends InterceptorExampleServiceOperations>(op: T) => __OperationSerializer<InterceptorExampleService<Context>, T, __ServiceException>;
   private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
   private readonly validationCustomizer: __ValidationCustomizer<InterceptorExampleServiceOperations>;
+  private readonly interceptors: __ServerInterceptor<Context>[] = [];
+  private readonly authSchemes: __AuthScheme<Context>[] = [];
   /**
    * Construct a InterceptorExampleService handler.
    * @param service The {@link InterceptorExampleService} implementation that supplies the business logic for InterceptorExampleService
@@ -106,19 +77,158 @@ export class InterceptorExampleServiceHandler<Context> implements __ServiceHandl
     this.serializeFrameworkException = serializeFrameworkException;
     this.validationCustomizer = validationCustomizer;
   }
+  withAuth(...schemes: __AuthScheme<Context>[]): this {
+    this.authSchemes.push(...schemes);
+    return this;
+  }
+  addInterceptor(interceptor: __ServerInterceptor<Context>): this {
+    this.interceptors.unshift(interceptor);
+    return this;
+  }
+  addInterceptors(...interceptors: __ServerInterceptor<Context>[]): this {
+    this.interceptors.unshift(...[...interceptors].reverse());
+    return this;
+  }
   async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
-    const target = this.mux.match(request);
-    if (target === undefined) {
-      return this.serializeFrameworkException(new __UnknownOperationException(), serdeContextBase);
-    }
-    switch (target.operation) {
-      case "GetItem" : {
-        return handle(request, context, "GetItem", this.serializerFactory("GetItem"), this.service.GetItem, this.serializeFrameworkException, GetItemServerInput.validate, this.validationCustomizer);
+    const steps: __FrameworkSteps<Context> = {
+      route: (request) => this.mux.match(request)?.operation,
+      deserialize: async (operation, request) => {
+        try {
+          return await this.serializerFactory(operation as InterceptorExampleServiceOperations).deserialize(request, { endpoint: () => Promise.resolve(request), ...serdeContextBase });
+        } catch (error: unknown) {
+          if (__isFrameworkException(error)) {
+            throw error;
+          }
+          throw new __SerializationException();
+        }
+      },
+      validate: (operation, input) => {
+        const validationFailures = InterceptorExampleServiceHandlerValidators[operation as InterceptorExampleServiceOperations](input);
+        if (validationFailures && validationFailures.length > 0) {
+          const validationException = this.validationCustomizer({ operation: operation as InterceptorExampleServiceOperations }, validationFailures);
+          if (validationException) {
+            throw validationException;
+          }
+        }
+      },
+      invoke: (operation, input, context) => (this.service[operation as InterceptorExampleServiceOperations] as any)(input, context),
+      serialize: (operation, output) => this.serializerFactory(operation as InterceptorExampleServiceOperations).serialize(output as any, serdeContextBase),
+      serializeError: (operation, error) => {
+        if (operation === undefined) {
+          return undefined;
+        }
+        const serializer = this.serializerFactory(operation as InterceptorExampleServiceOperations);
+        return serializer.isOperationError(error) ? serializer.serializeError(error, serdeContextBase) : undefined;
+      },
+      serializeFrameworkException: (e) => this.serializeFrameworkException(e, serdeContextBase),
+    };
+
+    const convertError = (op: string | undefined, caught: unknown): Promise<__HttpResponse> => {
+      const modeled = steps.serializeError(op, caught);
+      if (modeled) {
+        return modeled;
       }
-      case "Ping" : {
-        return handle(request, context, "Ping", this.serializerFactory("Ping"), this.service.Ping, this.serializeFrameworkException, PingServerInput.validate, this.validationCustomizer);
+      if (__isFrameworkException(caught)) {
+        return steps.serializeFrameworkException(caught);
+      }
+      return steps.serializeFrameworkException(new __InternalFailureException());
+    };
+
+    const base = { request, context };
+    let operation: string | undefined;
+    let input: unknown;
+    let output: unknown;
+    let response: __HttpResponse | undefined;
+    let caller: __Caller | undefined;
+    let error: unknown;
+
+    const entered = new Set<__ServerInterceptor<Context>>();
+
+    try {
+      for (const interceptor of this.interceptors) {
+        if (interceptor.readBeforeExecution) {
+          interceptor.readBeforeExecution(base);
+        }
+        entered.add(interceptor);
+      }
+
+      let authScheme: string | undefined;
+      if (this.authSchemes.length > 0) {
+        for (const scheme of this.authSchemes) {
+          const result = await scheme.authenticate(request, context);
+          if (result) {
+            caller = result;
+            authScheme = scheme.name;
+            break;
+          }
+        }
+        if (!caller) {
+          throw new __UnauthenticatedException();
+        }
+        this.fireRead("readAfterAuthentication", () => ({ ...base, authScheme: authScheme!, caller: caller! }));
+      }
+
+      const req = this.fireModify<__HttpRequest, typeof base>("modifyBeforeDeserialization", request, (r) => ({ ...base, request: r }));
+
+      operation = steps.route(req);
+      if (!operation) {
+        throw new __UnknownOperationException();
+      }
+
+      input = await steps.deserialize(operation, req);
+      const inputHook = () => ({ ...base, operation: operation!, input });
+      this.fireRead("readAfterDeserialization", inputHook);
+      input = this.fireModify("modifyBeforeValidation", input, (v) => ({ ...base, operation: operation!, input: v }));
+      steps.validate(operation, input);
+      this.fireRead("readAfterValidation", inputHook);
+      this.fireRead("readBeforeInvocation", inputHook);
+      output = await steps.invoke(operation, input, context);
+      this.fireRead("readAfterInvocation", () => ({ ...base, operation: operation!, input, output }));
+      output = this.fireModify("modifyBeforeSerialization", output, (v) => ({ ...base, operation: operation!, input, output: v }));
+      response = await steps.serialize(operation, output);
+      this.fireRead("readAfterSerialization", () => ({ ...base, operation: operation!, input, output, response: response! }));
+    } catch (caught: unknown) {
+      error = caught;
+      response = await convertError(operation, caught);
+    }
+
+    try {
+      response = this.fireModify("modifyBeforeCompletion", response!, (v) => ({ ...base, operation: operation!, input, output, response: v }));
+    } catch (caught: unknown) {
+      error = caught;
+      response = await convertError(operation, caught);
+    }
+
+    const execHook: __ExecutionHook<Context> = { request, context, operation, input, output, response, error };
+    for (const interceptor of this.interceptors) {
+      if (entered.has(interceptor) && interceptor.readAfterExecution) {
+        try {
+          interceptor.readAfterExecution(execHook);
+        } catch (e) {
+          // readAfterExecution is best-effort and must not mask the response; ignore hook failures.
+        }
       }
     }
+
+    return response!;
+  }
+  private fireRead<H>(method: keyof __ServerInterceptor<Context>, buildHook: () => H): void {
+    for (const interceptor of this.interceptors) {
+      const fn = interceptor[method] as ((hook: H) => void) | undefined;
+      if (fn) {
+        fn.call(interceptor, buildHook());
+      }
+    }
+  }
+  private fireModify<V, H>(method: keyof __ServerInterceptor<Context>, initial: V, buildHook: (current: V) => H): V {
+    let current = initial;
+    for (const interceptor of this.interceptors) {
+      const fn = interceptor[method] as ((hook: H) => V) | undefined;
+      if (fn) {
+        current = fn.call(interceptor, buildHook(current));
+      }
+    }
+    return current;
   }
 }
 

--- a/private/interceptor-example-ssdk/src/server/index.ts
+++ b/private/interceptor-example-ssdk/src/server/index.ts
@@ -1,0 +1,3 @@
+// smithy-typescript generated code
+export * from "./operations";
+export * from "./InterceptorExampleService"

--- a/private/interceptor-example-ssdk/src/server/operations/GetItem.ts
+++ b/private/interceptor-example-ssdk/src/server/operations/GetItem.ts
@@ -1,19 +1,24 @@
 // smithy-typescript generated code
 import {
+  AuthScheme as __AuthScheme,
+  Caller as __Caller,
+  ExecutionHook as __ExecutionHook,
+  FrameworkSteps as __FrameworkSteps,
   httpbinding,
   InternalFailureException as __InternalFailureException,
   isFrameworkException as __isFrameworkException,
   Mux as __Mux,
   Operation as __Operation,
-  OperationInput as __OperationInput,
-  OperationOutput as __OperationOutput,
   OperationSerializer as __OperationSerializer,
   SerializationException as __SerializationException,
+  ServerInterceptor as __ServerInterceptor,
   ServerSerdeContext,
   ServerSerdeContext as __ServerSerdeContext,
   ServiceException as __ServiceException,
   ServiceHandler as __ServiceHandler,
   SmithyFrameworkException as __SmithyFrameworkException,
+  UnauthenticatedException as __UnauthenticatedException,
+  UnknownOperationException as __UnknownOperationException,
   ValidationCustomizer as __ValidationCustomizer,
   ValidationFailure as __ValidationFailure,
 } from "@aws-smithy/server-common";
@@ -80,51 +85,14 @@ const serdeContextBase = {
   requestHandler: new NodeHttpHandler(),
   disableHostPrefix: true
 };
-async function handle<S, O extends keyof S & string, Context>(
-  request: __HttpRequest,
-  context: Context,
-  operationName: O,
-  serializer: __OperationSerializer<S, O, __ServiceException>,
-  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
-  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
-  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
-  validationCustomizer: __ValidationCustomizer<O>
-): Promise<__HttpResponse> {
-  let input;
-  try {
-    input = await serializer.deserialize(request, {
-      endpoint: () => Promise.resolve(request), ...serdeContextBase
-    });
-  } catch (error: unknown) {
-    if (__isFrameworkException(error)) {
-      return serializeFrameworkException(error, serdeContextBase);
-    };
-    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
-  }
-  try {
-    let validationFailures = validationFn(input);
-    if (validationFailures && validationFailures.length > 0) {
-      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
-      if (validationException) {
-        return serializer.serializeError(validationException, serdeContextBase);
-      }
-    }
-    let output = await operation(input, context);
-    return serializer.serialize(output, serdeContextBase);
-  } catch(error: unknown) {
-    if (serializer.isOperationError(error)) {
-      return serializer.serializeError(error, serdeContextBase);
-    }
-    console.log('Received an unexpected error', error);
-    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
-  }
-}
 export class GetItemHandler<Context> implements __ServiceHandler<Context> {
-  private readonly operation: __Operation<GetItemServerInput, GetItemServerOutput, Context>;
   private readonly mux: __Mux<"InterceptorExample", "GetItem">;
+  private readonly operation: __Operation<GetItemServerInput, GetItemServerOutput, Context>;
   private readonly serializer: __OperationSerializer<InterceptorExampleService<Context>, "GetItem", GetItemErrors>;
   private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
   private readonly validationCustomizer: __ValidationCustomizer<"GetItem">;
+  private readonly interceptors: __ServerInterceptor<Context>[] = [];
+  private readonly authSchemes: __AuthScheme<Context>[] = [];
   /**
    * Construct a GetItem handler.
    * @param operation The {@link __Operation} implementation that supplies the business logic for GetItem
@@ -147,12 +115,151 @@ export class GetItemHandler<Context> implements __ServiceHandler<Context> {
     this.serializeFrameworkException = serializeFrameworkException;
     this.validationCustomizer = validationCustomizer;
   }
+  withAuth(...schemes: __AuthScheme<Context>[]): this {
+    this.authSchemes.push(...schemes);
+    return this;
+  }
+  addInterceptor(interceptor: __ServerInterceptor<Context>): this {
+    this.interceptors.unshift(interceptor);
+    return this;
+  }
+  addInterceptors(...interceptors: __ServerInterceptor<Context>[]): this {
+    this.interceptors.unshift(...[...interceptors].reverse());
+    return this;
+  }
   async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
-    const target = this.mux.match(request);
-    if (target === undefined) {
-      console.log('Received a request that did not match example.interceptors#InterceptorExample.GetItem. This indicates a misconfiguration.');
-      return this.serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+    const steps: __FrameworkSteps<Context> = {
+      route: (request) => this.mux.match(request) !== undefined ? "GetItem" : undefined,
+      deserialize: async (_op, request) => {
+        try {
+          return await this.serializer.deserialize(request, { endpoint: () => Promise.resolve(request), ...serdeContextBase });
+        } catch (error: unknown) {
+          if (__isFrameworkException(error)) {
+            throw error;
+          }
+          throw new __SerializationException();
+        }
+      },
+      validate: (_op, input) => {
+        const validationFailures = (GetItemServerInput.validate as (input: any) => __ValidationFailure[])(input);
+        if (validationFailures && validationFailures.length > 0) {
+          const validationException = this.validationCustomizer({ operation: "GetItem" }, validationFailures);
+          if (validationException) {
+            throw validationException;
+          }
+        }
+      },
+      invoke: (_op, input, context) => this.operation(input as GetItemServerInput, context),
+      serialize: (_op, output) => this.serializer.serialize(output as GetItemServerOutput, serdeContextBase),
+      serializeError: (_op, error) => this.serializer.isOperationError(error) ? this.serializer.serializeError(error, serdeContextBase) : undefined,
+      serializeFrameworkException: (e) => this.serializeFrameworkException(e, serdeContextBase),
+    };
+
+    const convertError = (op: string | undefined, caught: unknown): Promise<__HttpResponse> => {
+      const modeled = steps.serializeError(op, caught);
+      if (modeled) {
+        return modeled;
+      }
+      if (__isFrameworkException(caught)) {
+        return steps.serializeFrameworkException(caught);
+      }
+      return steps.serializeFrameworkException(new __InternalFailureException());
+    };
+
+    const base = { request, context };
+    let operation: string | undefined;
+    let input: unknown;
+    let output: unknown;
+    let response: __HttpResponse | undefined;
+    let caller: __Caller | undefined;
+    let error: unknown;
+
+    const entered = new Set<__ServerInterceptor<Context>>();
+
+    try {
+      for (const interceptor of this.interceptors) {
+        if (interceptor.readBeforeExecution) {
+          interceptor.readBeforeExecution(base);
+        }
+        entered.add(interceptor);
+      }
+
+      let authScheme: string | undefined;
+      if (this.authSchemes.length > 0) {
+        for (const scheme of this.authSchemes) {
+          const result = await scheme.authenticate(request, context);
+          if (result) {
+            caller = result;
+            authScheme = scheme.name;
+            break;
+          }
+        }
+        if (!caller) {
+          throw new __UnauthenticatedException();
+        }
+        this.fireRead("readAfterAuthentication", () => ({ ...base, authScheme: authScheme!, caller: caller! }));
+      }
+
+      const req = this.fireModify<__HttpRequest, typeof base>("modifyBeforeDeserialization", request, (r) => ({ ...base, request: r }));
+
+      operation = steps.route(req);
+      if (!operation) {
+        throw new __UnknownOperationException();
+      }
+
+      input = await steps.deserialize(operation, req);
+      const inputHook = () => ({ ...base, operation: operation!, input });
+      this.fireRead("readAfterDeserialization", inputHook);
+      input = this.fireModify("modifyBeforeValidation", input, (v) => ({ ...base, operation: operation!, input: v }));
+      steps.validate(operation, input);
+      this.fireRead("readAfterValidation", inputHook);
+      this.fireRead("readBeforeInvocation", inputHook);
+      output = await steps.invoke(operation, input, context);
+      this.fireRead("readAfterInvocation", () => ({ ...base, operation: operation!, input, output }));
+      output = this.fireModify("modifyBeforeSerialization", output, (v) => ({ ...base, operation: operation!, input, output: v }));
+      response = await steps.serialize(operation, output);
+      this.fireRead("readAfterSerialization", () => ({ ...base, operation: operation!, input, output, response: response! }));
+    } catch (caught: unknown) {
+      error = caught;
+      response = await convertError(operation, caught);
     }
-    return handle(request, context, "GetItem", this.serializer, this.operation, this.serializeFrameworkException, GetItemServerInput.validate, this.validationCustomizer);
+
+    try {
+      response = this.fireModify("modifyBeforeCompletion", response!, (v) => ({ ...base, operation: operation!, input, output, response: v }));
+    } catch (caught: unknown) {
+      error = caught;
+      response = await convertError(operation, caught);
+    }
+
+    const execHook: __ExecutionHook<Context> = { request, context, operation, input, output, response, error };
+    for (const interceptor of this.interceptors) {
+      if (entered.has(interceptor) && interceptor.readAfterExecution) {
+        try {
+          interceptor.readAfterExecution(execHook);
+        } catch (e) {
+          // readAfterExecution is best-effort and must not mask the response; ignore hook failures.
+        }
+      }
+    }
+
+    return response!;
+  }
+  private fireRead<H>(method: keyof __ServerInterceptor<Context>, buildHook: () => H): void {
+    for (const interceptor of this.interceptors) {
+      const fn = interceptor[method] as ((hook: H) => void) | undefined;
+      if (fn) {
+        fn.call(interceptor, buildHook());
+      }
+    }
+  }
+  private fireModify<V, H>(method: keyof __ServerInterceptor<Context>, initial: V, buildHook: (current: V) => H): V {
+    let current = initial;
+    for (const interceptor of this.interceptors) {
+      const fn = interceptor[method] as ((hook: H) => V) | undefined;
+      if (fn) {
+        current = fn.call(interceptor, buildHook(current));
+      }
+    }
+    return current;
   }
 }

--- a/private/interceptor-example-ssdk/src/server/operations/GetItem.ts
+++ b/private/interceptor-example-ssdk/src/server/operations/GetItem.ts
@@ -1,0 +1,158 @@
+// smithy-typescript generated code
+import {
+  httpbinding,
+  InternalFailureException as __InternalFailureException,
+  isFrameworkException as __isFrameworkException,
+  Mux as __Mux,
+  Operation as __Operation,
+  OperationInput as __OperationInput,
+  OperationOutput as __OperationOutput,
+  OperationSerializer as __OperationSerializer,
+  SerializationException as __SerializationException,
+  ServerSerdeContext,
+  ServerSerdeContext as __ServerSerdeContext,
+  ServiceException as __ServiceException,
+  ServiceHandler as __ServiceHandler,
+  SmithyFrameworkException as __SmithyFrameworkException,
+  ValidationCustomizer as __ValidationCustomizer,
+  ValidationFailure as __ValidationFailure,
+} from "@aws-smithy/server-common";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
+import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
+import { NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";
+
+import { GetItemInput, GetItemOutput } from "../../models/models_0";
+import {
+  deserializeGetItemRequest,
+  serializeFrameworkException,
+  serializeGetItemResponse,
+} from "../../protocols/Fakeprotocol";
+import { InterceptorExampleService } from "../InterceptorExampleService";
+
+export type GetItem<Context> = __Operation<GetItemServerInput, GetItemServerOutput, Context>
+
+export interface GetItemServerInput extends GetItemInput {}
+export namespace GetItemServerInput {
+  /**
+   * @internal
+   */
+  export const validate: (obj: Parameters<typeof GetItemInput.validate>[0]) => __ValidationFailure[] = GetItemInput.validate;
+}
+export interface GetItemServerOutput extends GetItemOutput {}
+
+export type GetItemErrors = never;
+
+export class GetItemSerializer implements __OperationSerializer<InterceptorExampleService<any>, "GetItem", GetItemErrors> {
+  serialize = serializeGetItemResponse;
+  deserialize = deserializeGetItemRequest;
+
+  isOperationError(error: any): error is GetItemErrors {
+    return false;
+  };
+
+  serializeError(error: GetItemErrors, ctx: ServerSerdeContext): Promise<__HttpResponse> {
+    throw error;
+  }
+
+}
+
+export const getGetItemHandler = <Context>(operation: __Operation<GetItemServerInput, GetItemServerOutput, Context>, customizer: __ValidationCustomizer<"GetItem">): __ServiceHandler<Context, __HttpRequest, __HttpResponse> => {
+  const mux = new httpbinding.HttpBindingMux<"InterceptorExample", "GetItem">([
+    new httpbinding.UriSpec<"InterceptorExample", "GetItem">(
+      'GET',
+      [
+        { type: 'path_literal', value: "item" },
+        { type: 'path' },
+      ],
+      [
+      ],
+      { service: "InterceptorExample", operation: "GetItem" }),
+  ]);
+  return new GetItemHandler(operation, mux, new GetItemSerializer(), serializeFrameworkException, customizer);
+}
+
+const serdeContextBase = {
+  base64Encoder: toBase64,
+  base64Decoder: fromBase64,
+  utf8Encoder: toUtf8,
+  utf8Decoder: fromUtf8,
+  streamCollector: streamCollector,
+  requestHandler: new NodeHttpHandler(),
+  disableHostPrefix: true
+};
+async function handle<S, O extends keyof S & string, Context>(
+  request: __HttpRequest,
+  context: Context,
+  operationName: O,
+  serializer: __OperationSerializer<S, O, __ServiceException>,
+  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
+  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
+  validationCustomizer: __ValidationCustomizer<O>
+): Promise<__HttpResponse> {
+  let input;
+  try {
+    input = await serializer.deserialize(request, {
+      endpoint: () => Promise.resolve(request), ...serdeContextBase
+    });
+  } catch (error: unknown) {
+    if (__isFrameworkException(error)) {
+      return serializeFrameworkException(error, serdeContextBase);
+    };
+    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
+  }
+  try {
+    let validationFailures = validationFn(input);
+    if (validationFailures && validationFailures.length > 0) {
+      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
+      if (validationException) {
+        return serializer.serializeError(validationException, serdeContextBase);
+      }
+    }
+    let output = await operation(input, context);
+    return serializer.serialize(output, serdeContextBase);
+  } catch(error: unknown) {
+    if (serializer.isOperationError(error)) {
+      return serializer.serializeError(error, serdeContextBase);
+    }
+    console.log('Received an unexpected error', error);
+    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+  }
+}
+export class GetItemHandler<Context> implements __ServiceHandler<Context> {
+  private readonly operation: __Operation<GetItemServerInput, GetItemServerOutput, Context>;
+  private readonly mux: __Mux<"InterceptorExample", "GetItem">;
+  private readonly serializer: __OperationSerializer<InterceptorExampleService<Context>, "GetItem", GetItemErrors>;
+  private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
+  private readonly validationCustomizer: __ValidationCustomizer<"GetItem">;
+  /**
+   * Construct a GetItem handler.
+   * @param operation The {@link __Operation} implementation that supplies the business logic for GetItem
+   * @param mux The {@link __Mux} that verifies which service and operation are being invoked by a given {@link __HttpRequest}
+   * @param serializer An {@link __OperationSerializer} for GetItem that
+   *                   handles deserialization of requests and serialization of responses
+   * @param serializeFrameworkException A function that can serialize {@link __SmithyFrameworkException}s
+   * @param validationCustomizer A {@link __ValidationCustomizer} for turning validation failures into {@link __SmithyFrameworkException}s
+   */
+  constructor(
+    operation: __Operation<GetItemServerInput, GetItemServerOutput, Context>,
+    mux: __Mux<"InterceptorExample", "GetItem">,
+    serializer: __OperationSerializer<InterceptorExampleService<Context>, "GetItem", GetItemErrors>,
+    serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+    validationCustomizer: __ValidationCustomizer<"GetItem">
+  ) {
+    this.operation = operation;
+    this.mux = mux;
+    this.serializer = serializer;
+    this.serializeFrameworkException = serializeFrameworkException;
+    this.validationCustomizer = validationCustomizer;
+  }
+  async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
+    const target = this.mux.match(request);
+    if (target === undefined) {
+      console.log('Received a request that did not match example.interceptors#InterceptorExample.GetItem. This indicates a misconfiguration.');
+      return this.serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+    }
+    return handle(request, context, "GetItem", this.serializer, this.operation, this.serializeFrameworkException, GetItemServerInput.validate, this.validationCustomizer);
+  }
+}

--- a/private/interceptor-example-ssdk/src/server/operations/Ping.ts
+++ b/private/interceptor-example-ssdk/src/server/operations/Ping.ts
@@ -1,0 +1,157 @@
+// smithy-typescript generated code
+import {
+  httpbinding,
+  InternalFailureException as __InternalFailureException,
+  isFrameworkException as __isFrameworkException,
+  Mux as __Mux,
+  Operation as __Operation,
+  OperationInput as __OperationInput,
+  OperationOutput as __OperationOutput,
+  OperationSerializer as __OperationSerializer,
+  SerializationException as __SerializationException,
+  ServerSerdeContext,
+  ServerSerdeContext as __ServerSerdeContext,
+  ServiceException as __ServiceException,
+  ServiceHandler as __ServiceHandler,
+  SmithyFrameworkException as __SmithyFrameworkException,
+  ValidationCustomizer as __ValidationCustomizer,
+  ValidationFailure as __ValidationFailure,
+} from "@aws-smithy/server-common";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
+import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
+import { NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";
+
+import { PingInput, PingOutput } from "../../models/models_0";
+import {
+  deserializePingRequest,
+  serializeFrameworkException,
+  serializePingResponse,
+} from "../../protocols/Fakeprotocol";
+import { InterceptorExampleService } from "../InterceptorExampleService";
+
+export type Ping<Context> = __Operation<PingServerInput, PingServerOutput, Context>
+
+export interface PingServerInput extends PingInput {}
+export namespace PingServerInput {
+  /**
+   * @internal
+   */
+  export const validate: (obj: Parameters<typeof PingInput.validate>[0]) => __ValidationFailure[] = PingInput.validate;
+}
+export interface PingServerOutput extends PingOutput {}
+
+export type PingErrors = never;
+
+export class PingSerializer implements __OperationSerializer<InterceptorExampleService<any>, "Ping", PingErrors> {
+  serialize = serializePingResponse;
+  deserialize = deserializePingRequest;
+
+  isOperationError(error: any): error is PingErrors {
+    return false;
+  };
+
+  serializeError(error: PingErrors, ctx: ServerSerdeContext): Promise<__HttpResponse> {
+    throw error;
+  }
+
+}
+
+export const getPingHandler = <Context>(operation: __Operation<PingServerInput, PingServerOutput, Context>, customizer: __ValidationCustomizer<"Ping">): __ServiceHandler<Context, __HttpRequest, __HttpResponse> => {
+  const mux = new httpbinding.HttpBindingMux<"InterceptorExample", "Ping">([
+    new httpbinding.UriSpec<"InterceptorExample", "Ping">(
+      'POST',
+      [
+        { type: 'path_literal', value: "ping" },
+      ],
+      [
+      ],
+      { service: "InterceptorExample", operation: "Ping" }),
+  ]);
+  return new PingHandler(operation, mux, new PingSerializer(), serializeFrameworkException, customizer);
+}
+
+const serdeContextBase = {
+  base64Encoder: toBase64,
+  base64Decoder: fromBase64,
+  utf8Encoder: toUtf8,
+  utf8Decoder: fromUtf8,
+  streamCollector: streamCollector,
+  requestHandler: new NodeHttpHandler(),
+  disableHostPrefix: true
+};
+async function handle<S, O extends keyof S & string, Context>(
+  request: __HttpRequest,
+  context: Context,
+  operationName: O,
+  serializer: __OperationSerializer<S, O, __ServiceException>,
+  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
+  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
+  validationCustomizer: __ValidationCustomizer<O>
+): Promise<__HttpResponse> {
+  let input;
+  try {
+    input = await serializer.deserialize(request, {
+      endpoint: () => Promise.resolve(request), ...serdeContextBase
+    });
+  } catch (error: unknown) {
+    if (__isFrameworkException(error)) {
+      return serializeFrameworkException(error, serdeContextBase);
+    };
+    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
+  }
+  try {
+    let validationFailures = validationFn(input);
+    if (validationFailures && validationFailures.length > 0) {
+      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
+      if (validationException) {
+        return serializer.serializeError(validationException, serdeContextBase);
+      }
+    }
+    let output = await operation(input, context);
+    return serializer.serialize(output, serdeContextBase);
+  } catch(error: unknown) {
+    if (serializer.isOperationError(error)) {
+      return serializer.serializeError(error, serdeContextBase);
+    }
+    console.log('Received an unexpected error', error);
+    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+  }
+}
+export class PingHandler<Context> implements __ServiceHandler<Context> {
+  private readonly operation: __Operation<PingServerInput, PingServerOutput, Context>;
+  private readonly mux: __Mux<"InterceptorExample", "Ping">;
+  private readonly serializer: __OperationSerializer<InterceptorExampleService<Context>, "Ping", PingErrors>;
+  private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
+  private readonly validationCustomizer: __ValidationCustomizer<"Ping">;
+  /**
+   * Construct a Ping handler.
+   * @param operation The {@link __Operation} implementation that supplies the business logic for Ping
+   * @param mux The {@link __Mux} that verifies which service and operation are being invoked by a given {@link __HttpRequest}
+   * @param serializer An {@link __OperationSerializer} for Ping that
+   *                   handles deserialization of requests and serialization of responses
+   * @param serializeFrameworkException A function that can serialize {@link __SmithyFrameworkException}s
+   * @param validationCustomizer A {@link __ValidationCustomizer} for turning validation failures into {@link __SmithyFrameworkException}s
+   */
+  constructor(
+    operation: __Operation<PingServerInput, PingServerOutput, Context>,
+    mux: __Mux<"InterceptorExample", "Ping">,
+    serializer: __OperationSerializer<InterceptorExampleService<Context>, "Ping", PingErrors>,
+    serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+    validationCustomizer: __ValidationCustomizer<"Ping">
+  ) {
+    this.operation = operation;
+    this.mux = mux;
+    this.serializer = serializer;
+    this.serializeFrameworkException = serializeFrameworkException;
+    this.validationCustomizer = validationCustomizer;
+  }
+  async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
+    const target = this.mux.match(request);
+    if (target === undefined) {
+      console.log('Received a request that did not match example.interceptors#InterceptorExample.Ping. This indicates a misconfiguration.');
+      return this.serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+    }
+    return handle(request, context, "Ping", this.serializer, this.operation, this.serializeFrameworkException, PingServerInput.validate, this.validationCustomizer);
+  }
+}

--- a/private/interceptor-example-ssdk/src/server/operations/Ping.ts
+++ b/private/interceptor-example-ssdk/src/server/operations/Ping.ts
@@ -1,19 +1,24 @@
 // smithy-typescript generated code
 import {
+  AuthScheme as __AuthScheme,
+  Caller as __Caller,
+  ExecutionHook as __ExecutionHook,
+  FrameworkSteps as __FrameworkSteps,
   httpbinding,
   InternalFailureException as __InternalFailureException,
   isFrameworkException as __isFrameworkException,
   Mux as __Mux,
   Operation as __Operation,
-  OperationInput as __OperationInput,
-  OperationOutput as __OperationOutput,
   OperationSerializer as __OperationSerializer,
   SerializationException as __SerializationException,
+  ServerInterceptor as __ServerInterceptor,
   ServerSerdeContext,
   ServerSerdeContext as __ServerSerdeContext,
   ServiceException as __ServiceException,
   ServiceHandler as __ServiceHandler,
   SmithyFrameworkException as __SmithyFrameworkException,
+  UnauthenticatedException as __UnauthenticatedException,
+  UnknownOperationException as __UnknownOperationException,
   ValidationCustomizer as __ValidationCustomizer,
   ValidationFailure as __ValidationFailure,
 } from "@aws-smithy/server-common";
@@ -79,51 +84,14 @@ const serdeContextBase = {
   requestHandler: new NodeHttpHandler(),
   disableHostPrefix: true
 };
-async function handle<S, O extends keyof S & string, Context>(
-  request: __HttpRequest,
-  context: Context,
-  operationName: O,
-  serializer: __OperationSerializer<S, O, __ServiceException>,
-  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
-  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
-  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
-  validationCustomizer: __ValidationCustomizer<O>
-): Promise<__HttpResponse> {
-  let input;
-  try {
-    input = await serializer.deserialize(request, {
-      endpoint: () => Promise.resolve(request), ...serdeContextBase
-    });
-  } catch (error: unknown) {
-    if (__isFrameworkException(error)) {
-      return serializeFrameworkException(error, serdeContextBase);
-    };
-    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
-  }
-  try {
-    let validationFailures = validationFn(input);
-    if (validationFailures && validationFailures.length > 0) {
-      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
-      if (validationException) {
-        return serializer.serializeError(validationException, serdeContextBase);
-      }
-    }
-    let output = await operation(input, context);
-    return serializer.serialize(output, serdeContextBase);
-  } catch(error: unknown) {
-    if (serializer.isOperationError(error)) {
-      return serializer.serializeError(error, serdeContextBase);
-    }
-    console.log('Received an unexpected error', error);
-    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
-  }
-}
 export class PingHandler<Context> implements __ServiceHandler<Context> {
-  private readonly operation: __Operation<PingServerInput, PingServerOutput, Context>;
   private readonly mux: __Mux<"InterceptorExample", "Ping">;
+  private readonly operation: __Operation<PingServerInput, PingServerOutput, Context>;
   private readonly serializer: __OperationSerializer<InterceptorExampleService<Context>, "Ping", PingErrors>;
   private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
   private readonly validationCustomizer: __ValidationCustomizer<"Ping">;
+  private readonly interceptors: __ServerInterceptor<Context>[] = [];
+  private readonly authSchemes: __AuthScheme<Context>[] = [];
   /**
    * Construct a Ping handler.
    * @param operation The {@link __Operation} implementation that supplies the business logic for Ping
@@ -146,12 +114,151 @@ export class PingHandler<Context> implements __ServiceHandler<Context> {
     this.serializeFrameworkException = serializeFrameworkException;
     this.validationCustomizer = validationCustomizer;
   }
+  withAuth(...schemes: __AuthScheme<Context>[]): this {
+    this.authSchemes.push(...schemes);
+    return this;
+  }
+  addInterceptor(interceptor: __ServerInterceptor<Context>): this {
+    this.interceptors.unshift(interceptor);
+    return this;
+  }
+  addInterceptors(...interceptors: __ServerInterceptor<Context>[]): this {
+    this.interceptors.unshift(...[...interceptors].reverse());
+    return this;
+  }
   async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
-    const target = this.mux.match(request);
-    if (target === undefined) {
-      console.log('Received a request that did not match example.interceptors#InterceptorExample.Ping. This indicates a misconfiguration.');
-      return this.serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+    const steps: __FrameworkSteps<Context> = {
+      route: (request) => this.mux.match(request) !== undefined ? "Ping" : undefined,
+      deserialize: async (_op, request) => {
+        try {
+          return await this.serializer.deserialize(request, { endpoint: () => Promise.resolve(request), ...serdeContextBase });
+        } catch (error: unknown) {
+          if (__isFrameworkException(error)) {
+            throw error;
+          }
+          throw new __SerializationException();
+        }
+      },
+      validate: (_op, input) => {
+        const validationFailures = (PingServerInput.validate as (input: any) => __ValidationFailure[])(input);
+        if (validationFailures && validationFailures.length > 0) {
+          const validationException = this.validationCustomizer({ operation: "Ping" }, validationFailures);
+          if (validationException) {
+            throw validationException;
+          }
+        }
+      },
+      invoke: (_op, input, context) => this.operation(input as PingServerInput, context),
+      serialize: (_op, output) => this.serializer.serialize(output as PingServerOutput, serdeContextBase),
+      serializeError: (_op, error) => this.serializer.isOperationError(error) ? this.serializer.serializeError(error, serdeContextBase) : undefined,
+      serializeFrameworkException: (e) => this.serializeFrameworkException(e, serdeContextBase),
+    };
+
+    const convertError = (op: string | undefined, caught: unknown): Promise<__HttpResponse> => {
+      const modeled = steps.serializeError(op, caught);
+      if (modeled) {
+        return modeled;
+      }
+      if (__isFrameworkException(caught)) {
+        return steps.serializeFrameworkException(caught);
+      }
+      return steps.serializeFrameworkException(new __InternalFailureException());
+    };
+
+    const base = { request, context };
+    let operation: string | undefined;
+    let input: unknown;
+    let output: unknown;
+    let response: __HttpResponse | undefined;
+    let caller: __Caller | undefined;
+    let error: unknown;
+
+    const entered = new Set<__ServerInterceptor<Context>>();
+
+    try {
+      for (const interceptor of this.interceptors) {
+        if (interceptor.readBeforeExecution) {
+          interceptor.readBeforeExecution(base);
+        }
+        entered.add(interceptor);
+      }
+
+      let authScheme: string | undefined;
+      if (this.authSchemes.length > 0) {
+        for (const scheme of this.authSchemes) {
+          const result = await scheme.authenticate(request, context);
+          if (result) {
+            caller = result;
+            authScheme = scheme.name;
+            break;
+          }
+        }
+        if (!caller) {
+          throw new __UnauthenticatedException();
+        }
+        this.fireRead("readAfterAuthentication", () => ({ ...base, authScheme: authScheme!, caller: caller! }));
+      }
+
+      const req = this.fireModify<__HttpRequest, typeof base>("modifyBeforeDeserialization", request, (r) => ({ ...base, request: r }));
+
+      operation = steps.route(req);
+      if (!operation) {
+        throw new __UnknownOperationException();
+      }
+
+      input = await steps.deserialize(operation, req);
+      const inputHook = () => ({ ...base, operation: operation!, input });
+      this.fireRead("readAfterDeserialization", inputHook);
+      input = this.fireModify("modifyBeforeValidation", input, (v) => ({ ...base, operation: operation!, input: v }));
+      steps.validate(operation, input);
+      this.fireRead("readAfterValidation", inputHook);
+      this.fireRead("readBeforeInvocation", inputHook);
+      output = await steps.invoke(operation, input, context);
+      this.fireRead("readAfterInvocation", () => ({ ...base, operation: operation!, input, output }));
+      output = this.fireModify("modifyBeforeSerialization", output, (v) => ({ ...base, operation: operation!, input, output: v }));
+      response = await steps.serialize(operation, output);
+      this.fireRead("readAfterSerialization", () => ({ ...base, operation: operation!, input, output, response: response! }));
+    } catch (caught: unknown) {
+      error = caught;
+      response = await convertError(operation, caught);
     }
-    return handle(request, context, "Ping", this.serializer, this.operation, this.serializeFrameworkException, PingServerInput.validate, this.validationCustomizer);
+
+    try {
+      response = this.fireModify("modifyBeforeCompletion", response!, (v) => ({ ...base, operation: operation!, input, output, response: v }));
+    } catch (caught: unknown) {
+      error = caught;
+      response = await convertError(operation, caught);
+    }
+
+    const execHook: __ExecutionHook<Context> = { request, context, operation, input, output, response, error };
+    for (const interceptor of this.interceptors) {
+      if (entered.has(interceptor) && interceptor.readAfterExecution) {
+        try {
+          interceptor.readAfterExecution(execHook);
+        } catch (e) {
+          // readAfterExecution is best-effort and must not mask the response; ignore hook failures.
+        }
+      }
+    }
+
+    return response!;
+  }
+  private fireRead<H>(method: keyof __ServerInterceptor<Context>, buildHook: () => H): void {
+    for (const interceptor of this.interceptors) {
+      const fn = interceptor[method] as ((hook: H) => void) | undefined;
+      if (fn) {
+        fn.call(interceptor, buildHook());
+      }
+    }
+  }
+  private fireModify<V, H>(method: keyof __ServerInterceptor<Context>, initial: V, buildHook: (current: V) => H): V {
+    let current = initial;
+    for (const interceptor of this.interceptors) {
+      const fn = interceptor[method] as ((hook: H) => V) | undefined;
+      if (fn) {
+        current = fn.call(interceptor, buildHook(current));
+      }
+    }
+    return current;
   }
 }

--- a/private/interceptor-example-ssdk/src/server/operations/index.ts
+++ b/private/interceptor-example-ssdk/src/server/operations/index.ts
@@ -1,0 +1,3 @@
+// smithy-typescript generated code
+export * from "./GetItem";
+export * from "./Ping";

--- a/private/interceptor-example-ssdk/tsconfig.cjs.json
+++ b/private/interceptor-example-ssdk/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist-cjs",
+    "noCheck": true
+  }
+}

--- a/private/interceptor-example-ssdk/tsconfig.es.json
+++ b/private/interceptor-example-ssdk/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "lib": ["dom"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist-es",
+    "noCheck": true
+  }
+}

--- a/private/interceptor-example-ssdk/tsconfig.json
+++ b/private/interceptor-example-ssdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src"]
+}

--- a/private/interceptor-example-ssdk/tsconfig.types.json
+++ b/private/interceptor-example-ssdk/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true,
+    "noCheck": false
+  }
+}

--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -65,6 +65,17 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
       );
     }
 
+    const serverCommonDir = path.join(__dirname, "..", "smithy-typescript-ssdk-libs", "server-common");
+    const serverCommonTarget = path.join(node_modules, "@aws-smithy", "server-common");
+    if (fs.existsSync(path.join(serverCommonDir, "dist")) && fs.existsSync(serverCommonTarget)) {
+      await spawnProcess("rm", ["-rf", path.join(serverCommonTarget, "dist")]);
+      await Promise.all(
+        ["dist", "package.json"].map((entry) =>
+          spawnProcess("cp", ["-r", path.join(serverCommonDir, entry), serverCommonTarget])
+        )
+      );
+    }
+
     await spawnProcess("yarn", ["build"], { cwd: codegenDir });
 
     // Optionally, after building the package, it's packed and copied to node_modules so that

--- a/scripts/post-protocol-test-codegen.js
+++ b/scripts/post-protocol-test-codegen.js
@@ -14,17 +14,19 @@ const private = path.join(root, "private");
 
 const privatePackages = fs.readdirSync(private);
 
+const isWorkspaceDep = (dep) => dep.startsWith("@smithy/") || dep.startsWith("@aws-smithy/");
+
 for (const dir of privatePackages) {
   const pkgJsonPath = path.join(private, dir, "package.json");
   if (fs.existsSync(pkgJsonPath)) {
     const pkgJson = require(pkgJsonPath);
     for (const dep in pkgJson.dependencies ?? {}) {
-      if (dep.startsWith("@smithy/")) {
+      if (isWorkspaceDep(dep)) {
         pkgJson.dependencies[dep] = "workspace:^";
       }
     }
     for (const dep in pkgJson.devDependencies ?? {}) {
-      if (dep.startsWith("@smithy/")) {
+      if (isWorkspaceDep(dep)) {
         pkgJson.devDependencies[dep] = "workspace:^";
       }
     }

--- a/scripts/post-protocol-test-codegen.js
+++ b/scripts/post-protocol-test-codegen.js
@@ -1,12 +1,15 @@
 /**
  *
  * Script to be run after protocol test codegen to set the smithy dependencies
- * to workspace:^
+ * to workspace:^ and to drop declared dependencies that the generated source
+ * never imports.
  *
  */
 
 const path = require("node:path");
 const fs = require("node:fs");
+
+const { getPackageName } = require("./validation/validation-shared");
 
 const root = path.join(__dirname, "..");
 
@@ -16,11 +19,51 @@ const privatePackages = fs.readdirSync(private);
 
 const isWorkspaceDep = (dep) => dep.startsWith("@smithy/") || dep.startsWith("@aws-smithy/");
 
+// Dependencies the deps-used validation always treats as used.
+const IMPLICIT_DEPS = new Set(["tslib"]);
+const IMPORT_RE = /from\s+["']([^"']+)["']/g;
+
+const collectImportedPackages = (dir) => {
+  const imported = new Set();
+  const visit = (current) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== "node_modules") {
+          visit(full);
+        }
+      } else if (entry.name.endsWith(".ts")) {
+        const code = fs.readFileSync(full, "utf-8");
+        let match;
+        IMPORT_RE.lastIndex = 0;
+        while ((match = IMPORT_RE.exec(code)) !== null) {
+          const specifier = match[1];
+          if (specifier.startsWith(".") || specifier.startsWith("node:")) {
+            continue;
+          }
+          imported.add(getPackageName(specifier));
+        }
+      }
+    }
+  };
+  const srcDir = path.join(dir, "src");
+  if (fs.existsSync(srcDir)) {
+    visit(srcDir);
+  }
+  return imported;
+};
+
 for (const dir of privatePackages) {
-  const pkgJsonPath = path.join(private, dir, "package.json");
+  const packageDir = path.join(private, dir);
+  const pkgJsonPath = path.join(packageDir, "package.json");
   if (fs.existsSync(pkgJsonPath)) {
     const pkgJson = require(pkgJsonPath);
+    const imported = collectImportedPackages(packageDir);
     for (const dep in pkgJson.dependencies ?? {}) {
+      if (!IMPLICIT_DEPS.has(dep) && !imported.has(dep)) {
+        delete pkgJson.dependencies[dep];
+        continue;
+      }
       if (isWorkspaceDep(dep)) {
         pkgJson.dependencies[dep] = "workspace:^";
       }

--- a/smithy-typescript-codegen-test/model/interceptors/main.smithy
+++ b/smithy-typescript-codegen-test/model/interceptors/main.smithy
@@ -1,0 +1,48 @@
+$version: "2.0"
+
+namespace example.interceptors
+
+use common#fakeProtocol
+
+/// Minimal service used to generate a checked-in server SDK example for
+/// reviewing the interceptor pipeline emitted by the codegen.
+@fakeProtocol
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
+@auth([])
+service InterceptorExample {
+    version: "2024-01-01"
+    operations: [
+        Ping
+        GetItem
+    ]
+}
+
+/// A plain operation with no auth. Exercises the full pipeline:
+/// deserialize, validate, invoke, serialize.
+@http(method: "POST", uri: "/ping")
+operation Ping {
+    input := {
+        message: String
+    }
+    output := {
+        message: String
+    }
+}
+
+/// An operation that requires API key auth. Exercises the authenticate
+/// step and the UnauthenticatedException path.
+@readonly
+@http(method: "GET", uri: "/item/{id}")
+@auth([httpApiKeyAuth])
+operation GetItem {
+    input := {
+        @required
+        @httpLabel
+        id: String
+    }
+
+    output := {
+        id: String
+        name: String
+    }
+}

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -1,6 +1,37 @@
 {
     "version": "1.0",
     "projections": {
+        "interceptor-example": {
+            "transforms": [
+                {
+                    "name": "includeServices",
+                    "args": {
+                        "services": ["example.interceptors#InterceptorExample"]
+                    }
+                }
+            ],
+            "plugins": {
+                "typescript-server-codegen": {
+                    "service": "example.interceptors#InterceptorExample",
+                    "package": "interceptor-example-ssdk",
+                    "packageVersion": "0.0.1",
+                    "packageJson": {
+                        "license": "Apache-2.0",
+                        "private": true
+                    },
+                    "disableDefaultValidation": true
+                },
+                "typescript-client-codegen": {
+                    "service": "example.interceptors#InterceptorExample",
+                    "package": "interceptor-example",
+                    "packageVersion": "0.0.1",
+                    "packageJson": {
+                        "license": "Apache-2.0",
+                        "private": true
+                    }
+                }
+            }
+        },
         "ssdk-test": {
             "transforms": [
                 {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -42,34 +42,47 @@ final class ServerGenerator {
         TypeScriptWriter writer
     ) {
         addCommonHandlerImports(writer);
-        writer.addImport(
-            "UnknownOperationException",
-            "__UnknownOperationException",
-            TypeScriptDependency.SERVER_COMMON
-        );
 
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
         Symbol operationsType = serviceSymbol.expectProperty("operations", Symbol.class);
 
         writeSerdeContextBase(writer);
-        writeHandleFunction(writer);
+
+        writer.openBlock(
+            "const $LValidators: { [K in $T]: (input: any) => __ValidationFailure[] } = {",
+            "};",
+            handlerSymbol.getName(),
+            operationsType,
+            () -> {
+                for (OperationShape operation : operations) {
+                    Symbol operationSymbol = symbolProvider.toSymbol(operation);
+                    Symbol inputSymbol = operationSymbol.expectProperty("inputType", Symbol.class);
+                    writer.write("$S: $T.validate,", operationSymbol.getName(), inputSymbol);
+                }
+            }
+        );
 
         String classDeclaration = "export class $L<Context> implements __ServiceHandler<Context> {";
         writer.openBlock(classDeclaration, "}", handlerSymbol.getName(), () -> {
-            writer.write("private readonly service: $T<Context>;", serviceSymbol);
             writer.write("private readonly mux: __Mux<$S, $T>;", serviceShape.getId().getName(), operationsType);
             writer.write(
-                "private readonly serializerFactory: <T extends $T>(operation: T) => " +
-                    "__OperationSerializer<$T<Context>, T, __ServiceException>;",
+                "private readonly service: $T<Context>;",
+                serviceSymbol
+            );
+            writer.write(
+                "private readonly serializerFactory: <T extends $T>(op: T) => "
+                    + "__OperationSerializer<$T<Context>, T, __ServiceException>;",
                 operationsType,
                 serviceSymbol
             );
             writer.write(
-                "private readonly serializeFrameworkException: (e: __SmithyFrameworkException, " +
-                    "ctx: __ServerSerdeContext) => Promise<__HttpResponse>;"
+                "private readonly serializeFrameworkException: (e: __SmithyFrameworkException, "
+                    + "ctx: __ServerSerdeContext) => Promise<__HttpResponse>;"
             );
             writer.write("private readonly validationCustomizer: __ValidationCustomizer<$T>;", operationsType);
+            writeInterceptorState(writer);
+
             writer.writeDocs(() -> {
                 writer.write("Construct a $T handler.", serviceSymbol);
                 writer.write(
@@ -114,31 +127,74 @@ final class ServerGenerator {
             writer.write("this.serializeFrameworkException = serializeFrameworkException;");
             writer.write("this.validationCustomizer = validationCustomizer;");
             writer.closeBlock("}");
-            String handleDecl = "async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {";
-            writer.openBlock(handleDecl, "}", () -> {
-                writer.write("const target = this.mux.match(request);");
-                writer.openBlock("if (target === undefined) {", "}", () -> {
-                    writer.write(
-                        "return this.serializeFrameworkException(new __UnknownOperationException(), " +
-                            "serdeContextBase);"
-                    );
-                });
-                writer.openBlock("switch (target.operation) {", "}", () -> {
-                    for (OperationShape operation : operations) {
-                        Symbol operationSymbol = symbolProvider.toSymbol(operation);
-                        Symbol inputSymbol = operationSymbol.expectProperty("inputType", Symbol.class);
-                        writer.openBlock("case $S : {", "}", operationSymbol.getName(), () -> {
+
+            writeInterceptorRegistration(writer);
+
+            writeHandleMethod(
+                writer,
+                () -> {
+                    writer.write("route: (request) => this.mux.match(request)?.operation,");
+                    writer.openBlock("deserialize: async (operation, request) => {", "},", () -> {
+                        writer.openBlock("try {", "} catch (error: unknown) {", () -> {
                             writer.write(
-                                "return handle(request, context, $1S, this.serializerFactory($1S), " +
-                                    "this.service.$1L, this.serializeFrameworkException, $2T.validate, " +
-                                    "this.validationCustomizer);",
-                                operationSymbol.getName(),
-                                inputSymbol
+                                "return await this.serializerFactory(operation as $L).deserialize(request, "
+                                    + "{ endpoint: () => Promise.resolve(request), ...serdeContextBase });",
+                                operationsType.getName()
                             );
                         });
-                    }
-                });
-            });
+                        writer.indent();
+                        writer.openBlock("if (__isFrameworkException(error)) {", "}", () -> {
+                            writer.write("throw error;");
+                        });
+                        writer.write("throw new __SerializationException();");
+                        writer.closeBlock("}");
+                    });
+                    writer.openBlock("validate: (operation, input) => {", "},", () -> {
+                        writer.write(
+                            "const validationFailures = $LValidators[operation as $L](input);",
+                            handlerSymbol.getName(),
+                            operationsType.getName()
+                        );
+                        writer.openBlock("if (validationFailures && validationFailures.length > 0) {", "}", () -> {
+                            writer.write(
+                                "const validationException = this.validationCustomizer("
+                                    + "{ operation: operation as $L }, validationFailures);",
+                                operationsType.getName()
+                            );
+                            writer.openBlock("if (validationException) {", "}", () -> {
+                                writer.write("throw validationException;");
+                            });
+                        });
+                    });
+                    writer.write(
+                        "invoke: (operation, input, context) => "
+                            + "(this.service[operation as $L] as any)(input, context),",
+                        operationsType.getName()
+                    );
+                    writer.write(
+                        "serialize: (operation, output) => "
+                            + "this.serializerFactory(operation as $L).serialize(output as any, serdeContextBase),",
+                        operationsType.getName()
+                    );
+                    writer.openBlock("serializeError: (operation, error) => {", "},", () -> {
+                        writer.openBlock("if (operation === undefined) {", "}", () -> {
+                            writer.write("return undefined;");
+                        });
+                        writer.write(
+                            "const serializer = this.serializerFactory(operation as $L);",
+                            operationsType.getName()
+                        );
+                        writer.write(
+                            "return serializer.isOperationError(error) ? "
+                                + "serializer.serializeError(error, serdeContextBase) : undefined;"
+                        );
+                    });
+                    writer.write(
+                        "serializeFrameworkException: (e) => "
+                            + "this.serializeFrameworkException(e, serdeContextBase),"
+                    );
+                }
+            );
         });
     }
 
@@ -149,9 +205,9 @@ final class ServerGenerator {
         TypeScriptWriter writer
     ) {
         addCommonHandlerImports(writer);
+        writer.addImport("Operation", "__Operation", TypeScriptDependency.SERVER_COMMON);
 
         writeSerdeContextBase(writer);
-        writeHandleFunction(writer);
 
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         Symbol operationSymbol = symbolProvider.toSymbol(operation);
@@ -164,8 +220,8 @@ final class ServerGenerator {
 
         String declaration = "export class $L<Context> implements __ServiceHandler<Context> {";
         writer.openBlock(declaration, "}", handlerSymbol.getName(), () -> {
-            writer.write("private readonly operation: __Operation<$T, $T, Context>;", inputSymbol, outputSymbol);
             writer.write("private readonly mux: __Mux<$S, $S>;", serviceShape.getId().getName(), operationName);
+            writer.write("private readonly operation: __Operation<$T, $T, Context>;", inputSymbol, outputSymbol);
             writer.write(
                 "private readonly serializer: __OperationSerializer<$T<Context>, $S, $T>;",
                 serviceSymbol,
@@ -173,10 +229,12 @@ final class ServerGenerator {
                 errorsSymbol
             );
             writer.write(
-                "private readonly serializeFrameworkException: (e: __SmithyFrameworkException, " +
-                    "ctx: __ServerSerdeContext) => Promise<__HttpResponse>;"
+                "private readonly serializeFrameworkException: (e: __SmithyFrameworkException, "
+                    + "ctx: __ServerSerdeContext) => Promise<__HttpResponse>;"
             );
             writer.write("private readonly validationCustomizer: __ValidationCustomizer<$S>;", operationName);
+            writeInterceptorState(writer);
+
             writer.writeDocs(() -> {
                 writer.write("Construct a $T handler.", operationSymbol);
                 writer.write(
@@ -221,42 +279,291 @@ final class ServerGenerator {
             writer.write("this.serializeFrameworkException = serializeFrameworkException;");
             writer.write("this.validationCustomizer = validationCustomizer;");
             writer.closeBlock("}");
-            writer.openBlock(
-                "async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {",
-                "}",
+
+            writeInterceptorRegistration(writer);
+
+            writeHandleMethod(
+                writer,
                 () -> {
-                    writer.write("const target = this.mux.match(request);");
-                    writer.openBlock("if (target === undefined) {", "}", () -> {
-                        writer.write(
-                            "console.log('Received a request that did not match $L.$L. This indicates a " +
-                                "misconfiguration.');",
-                            serviceShape.getId(),
-                            operation.getId().getName()
-                        );
-                        writer.write(
-                            "return this.serializeFrameworkException(new __InternalFailureException(), " +
-                                "serdeContextBase);"
-                        );
-                    });
                     writer.write(
-                        "return handle(request, context, $S, this.serializer, this.operation, " +
-                            "this.serializeFrameworkException, $T.validate, this.validationCustomizer);",
-                        operationName,
-                        inputSymbol
+                        "route: (request) => this.mux.match(request) !== undefined ? $S : undefined,",
+                        operationName
+                    );
+                    writer.openBlock("deserialize: async (_op, request) => {", "},", () -> {
+                        writer.openBlock("try {", "} catch (error: unknown) {", () -> {
+                            writer.write(
+                                "return await this.serializer.deserialize(request, "
+                                    + "{ endpoint: () => Promise.resolve(request), ...serdeContextBase });"
+                            );
+                        });
+                        writer.indent();
+                        writer.openBlock("if (__isFrameworkException(error)) {", "}", () -> {
+                            writer.write("throw error;");
+                        });
+                        writer.write("throw new __SerializationException();");
+                        writer.closeBlock("}");
+                    });
+                    writer.openBlock("validate: (_op, input) => {", "},", () -> {
+                        writer.write(
+                            "const validationFailures = ($T.validate as (input: any) => "
+                                + "__ValidationFailure[])(input);",
+                            inputSymbol
+                        );
+                        writer.openBlock("if (validationFailures && validationFailures.length > 0) {", "}", () -> {
+                            writer.write(
+                                "const validationException = this.validationCustomizer({ operation: $S }, "
+                                    + "validationFailures);",
+                                operationName
+                            );
+                            writer.openBlock("if (validationException) {", "}", () -> {
+                                writer.write("throw validationException;");
+                            });
+                        });
+                    });
+                    writer.write("invoke: (_op, input, context) => this.operation(input as $T, context),", inputSymbol);
+                    writer.write(
+                        "serialize: (_op, output) => "
+                            + "this.serializer.serialize(output as $T, serdeContextBase),",
+                        outputSymbol
+                    );
+                    writer.write(
+                        "serializeError: (_op, error) => "
+                            + "this.serializer.isOperationError(error) ? "
+                            + "this.serializer.serializeError(error, serdeContextBase) : undefined,"
+                    );
+                    writer.write(
+                        "serializeFrameworkException: (e) => "
+                            + "this.serializeFrameworkException(e, serdeContextBase),"
                     );
                 }
             );
         });
     }
 
+    /** Per-handler interceptor and auth-scheme state. */
+    private static void writeInterceptorState(TypeScriptWriter writer) {
+        writer.write("private readonly interceptors: __ServerInterceptor<Context>[] = [];");
+        writer.write("private readonly authSchemes: __AuthScheme<Context>[] = [];");
+    }
+
+    /**
+     * Emit the chainable registration methods (withAuth / addInterceptor / addInterceptors). These
+     * mirror the opt-in registration surface so interceptors and auth are additive.
+     */
+    private static void writeInterceptorRegistration(TypeScriptWriter writer) {
+        writer.openBlock("withAuth(...schemes: __AuthScheme<Context>[]): this {", "}", () -> {
+            writer.write("this.authSchemes.push(...schemes);");
+            writer.write("return this;");
+        });
+        writer.openBlock("addInterceptor(interceptor: __ServerInterceptor<Context>): this {", "}", () -> {
+            writer.write("this.interceptors.unshift(interceptor);");
+            writer.write("return this;");
+        });
+        writer.openBlock("addInterceptors(...interceptors: __ServerInterceptor<Context>[]): this {", "}", () -> {
+            writer.write("this.interceptors.unshift(...[...interceptors].reverse());");
+            writer.write("return this;");
+        });
+    }
+
+    /**
+     * Emit the full interceptor pipeline (the handle() method plus its private helpers) inline into
+     * the handler. The framework steps (route / deserialize / validate / invoke / serialize /
+     * serializeError / serializeFrameworkException) are supplied by the caller as a TypeScript
+     * object literal body via {@code stepsBody}; everything else (hook firing, the authenticate
+     * loop, error conversion, and balanced teardown) is identical across handlers.
+     *
+     * @param stepsBody emits the per-handler {@code FrameworkSteps} object-literal members
+     */
+    private static void writeHandleMethod(
+        TypeScriptWriter writer,
+        Runnable stepsBody
+    ) {
+        writer.openBlock(
+            "async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {",
+            "}",
+            () -> {
+                writer.openBlock("const steps: __FrameworkSteps<Context> = {", "};", stepsBody);
+                writer.write("");
+                writer.openBlock(
+                    "const convertError = (op: string | undefined, caught: unknown): Promise<__HttpResponse> => {",
+                    "};",
+                    () -> {
+                        writer.write("const modeled = steps.serializeError(op, caught);");
+                        writer.openBlock("if (modeled) {", "}", () -> writer.write("return modeled;"));
+                        writer.openBlock("if (__isFrameworkException(caught)) {", "}", () -> {
+                            writer.write("return steps.serializeFrameworkException(caught);");
+                        });
+                        writer.write("return steps.serializeFrameworkException(new __InternalFailureException());");
+                    }
+                );
+                writer.write("");
+                writer.write("const base = { request, context };");
+                writer.write("let operation: string | undefined;");
+                writer.write("let input: unknown;");
+                writer.write("let output: unknown;");
+                writer.write("let response: __HttpResponse | undefined;");
+                writer.write("let caller: __Caller | undefined;");
+                writer.write("let error: unknown;");
+                writer.write("");
+                writer.write("const entered = new Set<__ServerInterceptor<Context>>();");
+                writer.write("");
+
+                writer.openBlock("try {", "} catch (caught: unknown) {", () -> {
+                    writer.openBlock("for (const interceptor of this.interceptors) {", "}", () -> {
+                        writer.openBlock("if (interceptor.readBeforeExecution) {", "}", () -> {
+                            writer.write("interceptor.readBeforeExecution(base);");
+                        });
+                        writer.write("entered.add(interceptor);");
+                    });
+                    writer.write("");
+                    writer.write("let authScheme: string | undefined;");
+                    writer.openBlock("if (this.authSchemes.length > 0) {", "}", () -> {
+                        writer.openBlock("for (const scheme of this.authSchemes) {", "}", () -> {
+                            writer.write("const result = await scheme.authenticate(request, context);");
+                            writer.openBlock("if (result) {", "}", () -> {
+                                writer.write("caller = result;");
+                                writer.write("authScheme = scheme.name;");
+                                writer.write("break;");
+                            });
+                        });
+                        writer.openBlock("if (!caller) {", "}", () -> {
+                            writer.write("throw new __UnauthenticatedException();");
+                        });
+                        writer.write(
+                            "this.fireRead(\"readAfterAuthentication\", () => "
+                                + "({ ...base, authScheme: authScheme!, caller: caller! }));"
+                        );
+                    });
+                    writer.write("");
+                    writer.write(
+                        "const req = this.fireModify<__HttpRequest, typeof base>("
+                            + "\"modifyBeforeDeserialization\", request, (r) => ({ ...base, request: r }));"
+                    );
+                    writer.write("");
+                    writer.write("operation = steps.route(req);");
+                    writer.openBlock("if (!operation) {", "}", () -> {
+                        writer.write("throw new __UnknownOperationException();");
+                    });
+                    writer.write("");
+                    writer.write("input = await steps.deserialize(operation, req);");
+                    writer.write("const inputHook = () => ({ ...base, operation: operation!, input });");
+                    writer.write("this.fireRead(\"readAfterDeserialization\", inputHook);");
+                    writer.write(
+                        "input = this.fireModify(\"modifyBeforeValidation\", input, (v) => "
+                            + "({ ...base, operation: operation!, input: v }));"
+                    );
+                    writer.write("steps.validate(operation, input);");
+                    writer.write("this.fireRead(\"readAfterValidation\", inputHook);");
+                    writer.write("this.fireRead(\"readBeforeInvocation\", inputHook);");
+                    writer.write("output = await steps.invoke(operation, input, context);");
+                    writer.write(
+                        "this.fireRead(\"readAfterInvocation\", () => "
+                            + "({ ...base, operation: operation!, input, output }));"
+                    );
+                    writer.write(
+                        "output = this.fireModify(\"modifyBeforeSerialization\", output, (v) => "
+                            + "({ ...base, operation: operation!, input, output: v }));"
+                    );
+                    writer.write("response = await steps.serialize(operation, output);");
+                    writer.write(
+                        "this.fireRead(\"readAfterSerialization\", () => "
+                            + "({ ...base, operation: operation!, input, output, response: response! }));"
+                    );
+                });
+                writer.indent();
+                writer.write("error = caught;");
+                writer.write("response = await convertError(operation, caught);");
+                writer.closeBlock("}");
+
+                writer.write("");
+                writer.openBlock("try {", "} catch (caught: unknown) {", () -> {
+                    writer.write(
+                        "response = this.fireModify(\"modifyBeforeCompletion\", response!, (v) => "
+                            + "({ ...base, operation: operation!, input, output, response: v }));"
+                    );
+                });
+                writer.indent();
+                writer.write("error = caught;");
+                writer.write("response = await convertError(operation, caught);");
+                writer.closeBlock("}");
+
+                writer.write("");
+                writer.write(
+                    "const execHook: __ExecutionHook<Context> = "
+                        + "{ request, context, operation, input, output, response, error };"
+                );
+                writer.openBlock("for (const interceptor of this.interceptors) {", "}", () -> {
+                    writer.openBlock(
+                        "if (entered.has(interceptor) && interceptor.readAfterExecution) {",
+                        "}",
+                        () -> {
+                            writer.openBlock("try {", "} catch (e) {", () -> {
+                                writer.write("interceptor.readAfterExecution(execHook);");
+                            });
+                            writer.indent();
+                            writer.write(
+                                "// readAfterExecution is best-effort and must not mask the response; "
+                                    + "ignore hook failures."
+                            );
+                            writer.closeBlock("}");
+                        }
+                    );
+                });
+                writer.write("");
+                writer.write("return response!;");
+            }
+        );
+
+        writer.openBlock(
+            "private fireRead<H>(method: keyof __ServerInterceptor<Context>, buildHook: () => H): void {",
+            "}",
+            () -> {
+                writer.openBlock("for (const interceptor of this.interceptors) {", "}", () -> {
+                    writer.write("const fn = interceptor[method] as ((hook: H) => void) | undefined;");
+                    writer.openBlock("if (fn) {", "}", () -> writer.write("fn.call(interceptor, buildHook());"));
+                });
+            }
+        );
+
+        writer.openBlock(
+            "private fireModify<V, H>(method: keyof __ServerInterceptor<Context>, initial: V, "
+                + "buildHook: (current: V) => H): V {",
+            "}",
+            () -> {
+                writer.write("let current = initial;");
+                writer.openBlock("for (const interceptor of this.interceptors) {", "}", () -> {
+                    writer.write("const fn = interceptor[method] as ((hook: H) => V) | undefined;");
+                    writer.openBlock(
+                        "if (fn) {",
+                        "}",
+                        () -> writer.write("current = fn.call(interceptor, buildHook(current));")
+                    );
+                });
+                writer.write("return current;");
+            }
+        );
+    }
+
     private static void addCommonHandlerImports(TypeScriptWriter writer) {
-        writer.addImport("Operation", "__Operation", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("ServiceHandler", "__ServiceHandler", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("FrameworkSteps", "__FrameworkSteps", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("ServerInterceptor", "__ServerInterceptor", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("AuthScheme", "__AuthScheme", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("Caller", "__Caller", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("ExecutionHook", "__ExecutionHook", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("Mux", "__Mux", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("OperationSerializer", "__OperationSerializer", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("InternalFailureException", "__InternalFailureException", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("SerializationException", "__SerializationException", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("UnauthenticatedException", "__UnauthenticatedException", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport(
+            "UnknownOperationException",
+            "__UnknownOperationException",
+            TypeScriptDependency.SERVER_COMMON
+        );
         writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("ValidationFailure", "__ValidationFailure", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("isFrameworkException", "__isFrameworkException", TypeScriptDependency.SERVER_COMMON);
         writer.addImportSubmodule(
             "HttpRequest",
             "__HttpRequest",
@@ -271,68 +578,6 @@ final class ServerGenerator {
         );
         writer.addImport("ServiceException", "__ServiceException", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", TypeScriptDependency.SERVER_COMMON);
-    }
-
-    private static void writeHandleFunction(TypeScriptWriter writer) {
-        writer.addImport("Operation", "__Operation", TypeScriptDependency.SERVER_COMMON);
-        writer.addImport("OperationInput", "__OperationInput", TypeScriptDependency.SERVER_COMMON);
-        writer.addImport("OperationOutput", "__OperationOutput", TypeScriptDependency.SERVER_COMMON);
-        writer.addImport("ValidationFailure", "__ValidationFailure", TypeScriptDependency.SERVER_COMMON);
-        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", TypeScriptDependency.SERVER_COMMON);
-        writer.addImport("isFrameworkException", "__isFrameworkException", TypeScriptDependency.SERVER_COMMON);
-
-        writer.openBlock(
-            "async function handle<S, O extends keyof S & string, Context>(",
-            "): Promise<__HttpResponse> {",
-            () -> {
-                writer.write("request: __HttpRequest,");
-                writer.write("context: Context,");
-                writer.write("operationName: O,");
-                writer.write("serializer: __OperationSerializer<S, O, __ServiceException>,");
-                writer.write("operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,");
-                writer.write(
-                    "serializeFrameworkException: (e: __SmithyFrameworkException, " +
-                        "ctx: __ServerSerdeContext) => Promise<__HttpResponse>,"
-                );
-                writer.write("validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],");
-                writer.write("validationCustomizer: __ValidationCustomizer<O>");
-            }
-        );
-        writer.indent();
-        writer.write("let input;");
-        writer.openBlock("try {", "} catch (error: unknown) {", () -> {
-            writer.openBlock("input = await serializer.deserialize(request, {", "});", () -> {
-                writer.write("endpoint: () => Promise.resolve(request), ...serdeContextBase");
-            });
-        });
-        writer.indent();
-        writer.openBlock("if (__isFrameworkException(error)) {", "};", () -> {
-            writer.write("return serializeFrameworkException(error, serdeContextBase);");
-        });
-        writer.write("return serializeFrameworkException(new __SerializationException(), " + "serdeContextBase);");
-        writer.closeBlock("}");
-        writer.openBlock("try {", "} catch(error: unknown) {", () -> {
-            writer.write("let validationFailures = validationFn(input);");
-            writer.openBlock("if (validationFailures && validationFailures.length > 0) {", "}", () -> {
-                writer.write(
-                    "let validationException = validationCustomizer({ operation: operationName }, " +
-                        "validationFailures);"
-                );
-                writer.openBlock("if (validationException) {", "}", () -> {
-                    writer.write("return serializer.serializeError(validationException, serdeContextBase);");
-                });
-            });
-            writer.write("let output = await operation(input, context);");
-            writer.write("return serializer.serialize(output, serdeContextBase);");
-        });
-        writer.indent();
-        writer.openBlock("if (serializer.isOperationError(error)) {", "}", () -> {
-            writer.write("return serializer.serializeError(error, serdeContextBase);");
-        });
-        writer.write("console.log('Received an unexpected error', error);");
-        writer.write("return serializeFrameworkException(new __InternalFailureException(), " + "serdeContextBase);");
-        writer.closeBlock("}");
-        writer.closeBlock("}");
     }
 
     private static void writeSerdeContextBase(TypeScriptWriter writer) {

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/framework-errors.smithy
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/framework-errors.smithy
@@ -19,3 +19,7 @@ structure UnsupportedMediaTypeException {}
 @error("client")
 @httpError(406)
 structure NotAcceptableException {}
+
+@error("client")
+@httpError(401)
+structure UnauthenticatedException {}

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -27,6 +27,7 @@
   "author": "AWS Smithy Team",
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/core": "workspace:^",
     "@smithy/protocol-http": "workspace:^",
     "@smithy/types": "workspace:^",
     "re2-wasm": "^1.0.2",

--- a/smithy-typescript-ssdk-libs/server-common/src/errors.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/errors.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalFailureException, SerializationException, isFrameworkException } from "./errors";
+
+describe("isFrameworkException", () => {
+  it("returns true for a framework exception", () => {
+    expect(isFrameworkException(new InternalFailureException())).toBe(true);
+    expect(isFrameworkException(new SerializationException())).toBe(true);
+  });
+
+  it("returns false for a non-framework object", () => {
+    expect(isFrameworkException(new Error("boom"))).toBe(false);
+    expect(isFrameworkException({})).toBe(false);
+    expect(isFrameworkException({ $frameworkError: false })).toBe(false);
+  });
+
+  it("returns false (does not throw) for thrown primitives and nullish values", () => {
+    expect(() => isFrameworkException(null)).not.toThrow();
+    expect(() => isFrameworkException(undefined)).not.toThrow();
+    expect(isFrameworkException(null)).toBe(false);
+    expect(isFrameworkException(undefined)).toBe(false);
+    expect(isFrameworkException("a string")).toBe(false);
+    expect(isFrameworkException(42)).toBe(false);
+    expect(isFrameworkException(true)).toBe(false);
+    expect(isFrameworkException(Symbol("s"))).toBe(false);
+  });
+});

--- a/smithy-typescript-ssdk-libs/server-common/src/errors.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/errors.ts
@@ -32,9 +32,13 @@ export type SmithyFrameworkException =
   | UnknownOperationException
   | SerializationException
   | UnsupportedMediaTypeException
-  | NotAcceptableException;
+  | NotAcceptableException
+  | UnauthenticatedException;
 
 export const isFrameworkException = (error: any): error is SmithyFrameworkException => {
+  if (error == null || (typeof error !== "object" && typeof error !== "function")) {
+    return false;
+  }
   if (!error.hasOwnProperty("$frameworkError")) {
     return false;
   }
@@ -73,5 +77,12 @@ export class NotAcceptableException {
   readonly name = "NotAcceptableException";
   readonly $fault = "client";
   readonly statusCode = 406;
+  readonly $frameworkError = true;
+}
+
+export class UnauthenticatedException {
+  readonly name = "UnauthenticatedException";
+  readonly $fault = "client";
+  readonly statusCode = 401;
   readonly $frameworkError = true;
 }

--- a/smithy-typescript-ssdk-libs/server-common/src/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/index.ts
@@ -21,6 +21,18 @@ import type { ServiceException } from "./errors";
 export * as httpbinding from "./httpbinding";
 export * from "./accept";
 export * from "./errors";
+export type {
+  AuthHook,
+  AuthScheme,
+  Caller,
+  ExecutionHook,
+  FrameworkSteps,
+  InputHook,
+  OutputHook,
+  RequestHook,
+  ResponseHook,
+  ServerInterceptor,
+} from "./interceptors";
 export * from "./validation";
 export * from "./unique";
 

--- a/smithy-typescript-ssdk-libs/server-common/src/interceptors/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/interceptors/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type {
+  AuthHook,
+  AuthScheme,
+  Caller,
+  ExecutionHook,
+  FrameworkSteps,
+  InputHook,
+  OutputHook,
+  RequestHook,
+  ResponseHook,
+  ServerInterceptor,
+} from "./types";

--- a/smithy-typescript-ssdk-libs/server-common/src/interceptors/types.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/interceptors/types.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { HttpRequest, HttpResponse } from "@smithy/core/protocols";
+
+import type { SmithyFrameworkException } from "../errors";
+
+/**
+ * Identity established by the authenticate step. The shape is service-defined;
+ * a successful auth scheme returns a value with at least a principal.
+ */
+export interface Caller {
+  readonly principal: string;
+}
+
+/**
+ * Read-only views passed to hooks. Each carries the fields populated at its
+ * position. Fields are readonly; to change a value, return it from a modify hook.
+ */
+export interface RequestHook<UserContext> {
+  readonly request: HttpRequest;
+  readonly context: UserContext;
+}
+
+export interface AuthHook<UserContext> extends RequestHook<UserContext> {
+  readonly authScheme: string;
+  readonly caller: Caller;
+}
+
+export interface InputHook<UserContext> extends RequestHook<UserContext> {
+  readonly operation: string;
+  readonly input: unknown;
+}
+
+export interface OutputHook<UserContext> extends InputHook<UserContext> {
+  readonly output: unknown;
+}
+
+export interface ResponseHook<UserContext> extends OutputHook<UserContext> {
+  readonly response: HttpResponse;
+}
+
+export interface ExecutionHook<UserContext> {
+  readonly request: HttpRequest;
+  readonly context: UserContext;
+  readonly operation?: string;
+  readonly input?: unknown;
+  readonly output?: unknown;
+  readonly response?: HttpResponse;
+  readonly error?: unknown;
+}
+
+/**
+ * A service interceptor. Implement only the hooks you need.
+ *
+ * Read hooks observe and cannot replace a framework step. Modify hooks return
+ * the value the next framework step runs on. Hooks are synchronous.
+ */
+export interface ServerInterceptor<UserContext = {}> {
+  readBeforeExecution?(hook: RequestHook<UserContext>): void;
+  readAfterAuthentication?(hook: AuthHook<UserContext>): void;
+  readAfterDeserialization?(hook: InputHook<UserContext>): void;
+  readAfterValidation?(hook: InputHook<UserContext>): void;
+  readBeforeInvocation?(hook: InputHook<UserContext>): void;
+  readAfterInvocation?(hook: OutputHook<UserContext>): void;
+  readAfterSerialization?(hook: ResponseHook<UserContext>): void;
+  readAfterExecution?(hook: ExecutionHook<UserContext>): void;
+
+  modifyBeforeDeserialization?(hook: RequestHook<UserContext>): HttpRequest;
+  modifyBeforeValidation?(hook: InputHook<UserContext>): unknown;
+  modifyBeforeSerialization?(hook: OutputHook<UserContext>): unknown;
+  modifyBeforeCompletion?(hook: ResponseHook<UserContext>): HttpResponse;
+}
+
+/**
+ * An auth scheme run at the authenticate step. Returns a Caller on success, or
+ * null/undefined to decline so the next registered scheme is tried.
+ */
+export interface AuthScheme<UserContext = {}> {
+  readonly name: string;
+  authenticate(request: HttpRequest, context: UserContext): Promise<Caller | null | undefined>;
+}
+
+/**
+ * The framework steps, generated per handler. They run in a fixed pipeline order
+ * and are not intended to be implemented by service teams; the generated handler
+ * supplies them to its pipeline.
+ */
+export interface FrameworkSteps<Context> {
+  route(request: HttpRequest): string | undefined;
+  deserialize(operation: string, request: HttpRequest): Promise<unknown>;
+  validate(operation: string, input: unknown): void;
+  invoke(operation: string, input: unknown, context: Context): Promise<unknown>;
+  serialize(operation: string, output: unknown): Promise<HttpResponse>;
+  serializeError(operation: string | undefined, error: unknown): Promise<HttpResponse> | undefined;
+  serializeFrameworkException(e: SmithyFrameworkException): Promise<HttpResponse>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common":
+"@aws-smithy/server-common@workspace:^, @aws-smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common":
   version: 0.0.0-use.local
   resolution: "@aws-smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common"
   dependencies:
@@ -6502,6 +6502,27 @@ __metadata:
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
+
+"interceptor-example-ssdk@workspace:private/interceptor-example-ssdk":
+  version: 0.0.0-use.local
+  resolution: "interceptor-example-ssdk@workspace:private/interceptor-example-ssdk"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-smithy/server-common": "workspace:^"
+    "@smithy/core": "workspace:^"
+    "@smithy/fetch-http-handler": "workspace:^"
+    "@smithy/node-http-handler": "workspace:^"
+    "@smithy/types": "workspace:^"
+    "@tsconfig/node20": "npm:20.1.8"
+    "@types/node": "npm:^20.14.8"
+    concurrently: "npm:7.0.0"
+    downlevel-dts: "npm:0.10.1"
+    premove: "npm:4.0.0"
+    tslib: "npm:^2.6.2"
+    typescript: "npm:~5.8.3"
+  languageName: unknown
+  linkType: soft
 
 "internal-slot@npm:^1.0.7":
   version: 1.0.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common"
   dependencies:
+    "@smithy/core": "workspace:^"
     "@smithy/protocol-http": "workspace:^"
     "@smithy/types": "workspace:^"
     "@types/node": "npm:^18.11.9"
@@ -6507,11 +6508,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "interceptor-example-ssdk@workspace:private/interceptor-example-ssdk"
   dependencies:
-    "@aws-crypto/sha256-browser": "npm:5.2.0"
-    "@aws-crypto/sha256-js": "npm:5.2.0"
     "@aws-smithy/server-common": "workspace:^"
     "@smithy/core": "workspace:^"
-    "@smithy/fetch-http-handler": "workspace:^"
     "@smithy/node-http-handler": "workspace:^"
     "@smithy/types": "workspace:^"
     "@tsconfig/node20": "npm:20.1.8"


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

 Adds a server-side interceptor API for the Smithy TypeScript SSDK.

  Generated service and operation handlers now expose `withAuth()` and
  `addInterceptor()` so service teams can plug in auth schemes and interceptors.
  The interceptor pipeline is emitted inline into each generated handler by the
  codegen (`ServerGenerator`), and `@aws-smithy/server-common` provides the shared
  interceptor types.

  Interceptors expose read and modify hooks around each step (auth, deserialize,
  validate, invoke, serialize) and fire in reverse registration order. Auth schemes
  are tried in order and the first one to authenticate wins; if none do, the request
  fails with `UnauthenticatedException` (401).

  Interceptors and auth are opt-in. The handler constructor and `handle()` signature
  are unchanged, so existing services keep working without any changes — with no
  interceptors and no auth registered, the generated handler behaves as before.

  Also in `@aws-smithy/server-common`:
  - New `UnauthenticatedException` (401), wired into the framework error union and
    the generated `serializeFrameworkException`.
  - `isFrameworkException` now safely returns `false` for non-object values instead
    of throwing.

  Notes for reviewers:
  - This touches `smithy-typescript-codegen`, so it is codegen-affecting. The change
    is additive/opt-in, so handlers generated without interceptors or auth produce
    equivalent responses to before. Happy to open the companion aws-sdk-js-v3 sync PR
    if you'd like.
  - No changeset: the modified package is `@aws-smithy/server-common` (under
    `smithy-typescript-ssdk-libs/`, not `/packages`), and `@aws-smithy/*` is in the
    changeset `ignore` list.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
