### PR TITLE
feat(credential-provider-imds): add fromInstanceMetadataRegion provider

### DIFF
--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -548,9 +548,11 @@
     "ENV_CMDS_RELATIVE_URI": "string",
     "fromContainerMetadata": "function",
     "fromInstanceMetadata": "function",
+    "fromInstanceMetadataRegion": "function",
     "getInstanceMetadataEndpoint": "function",
     "httpRequest": "function",
     "InstanceMetadataCredentials": "type(interface)",
+    "InstanceMetadataRegionInit": "type(interface)",
     "providerConfigFromInit": "function",
     "RemoteProviderConfig": "type(interface)",
     "RemoteProviderInit": "type(interface)"

--- a/packages/credential-provider-imds/src/fromInstanceMetadataRegion.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadataRegion.spec.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
+
+import { httpRequest } from "./remoteProvider/httpRequest";
+import { getInstanceMetadataEndpoint } from "./utils/getInstanceMetadataEndpoint";
+
+vi.mock("./remoteProvider/httpRequest");
+vi.mock("./utils/getInstanceMetadataEndpoint");
+
+describe("fromInstanceMetadataRegion", () => {
+  const mockEndpoint = { hostname: "169.254.169.254", protocol: "http:", port: 80 } as any;
+  const mockToken = "imds-token";
+  const mockRegion = "us-west-2";
+
+  let fromInstanceMetadataRegion: typeof import("./fromInstanceMetadataRegion").fromInstanceMetadataRegion;
+  let ProviderError: typeof import("@smithy/core/config").ProviderError;
+
+  beforeEach(async () => {
+    delete process.env.AWS_EC2_METADATA_DISABLED;
+    vi.mocked(getInstanceMetadataEndpoint).mockResolvedValue(mockEndpoint);
+    ({ fromInstanceMetadataRegion } = await import("./fromInstanceMetadataRegion"));
+    ({ ProviderError } = await import("@smithy/core/config"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns the region from IMDSv2", async () => {
+    vi.mocked(httpRequest)
+      .mockResolvedValueOnce(Buffer.from(mockToken))
+      .mockResolvedValueOnce(Buffer.from(mockRegion));
+
+    await expect(fromInstanceMetadataRegion()()).resolves.toBe(mockRegion);
+  });
+
+  it("issues a PUT to /latest/api/token before the region GET", async () => {
+    vi.mocked(httpRequest)
+      .mockResolvedValueOnce(Buffer.from(mockToken))
+      .mockResolvedValueOnce(Buffer.from(mockRegion));
+
+    await fromInstanceMetadataRegion()();
+
+    const [tokenCall, regionCall] = vi.mocked(httpRequest).mock.calls;
+    expect(tokenCall[0]).toMatchObject({
+      path: "/latest/api/token",
+      method: "PUT",
+      headers: { "x-aws-ec2-metadata-token-ttl-seconds": "21600" },
+    });
+    expect(regionCall[0]).toMatchObject({
+      path: "/latest/meta-data/placement/region",
+      method: "GET",
+      headers: { "x-aws-ec2-metadata-token": mockToken },
+    });
+  });
+
+  it("passes the configured timeout to both IMDS requests", async () => {
+    vi.mocked(httpRequest)
+      .mockResolvedValueOnce(Buffer.from(mockToken))
+      .mockResolvedValueOnce(Buffer.from(mockRegion));
+
+    await fromInstanceMetadataRegion({ timeout: 250 })();
+
+    const calls = vi.mocked(httpRequest).mock.calls;
+    expect(calls[0][0].timeout).toBe(250);
+    expect(calls[1][0].timeout).toBe(250);
+  });
+
+  it("defaults timeout to 1000 ms", async () => {
+    vi.mocked(httpRequest)
+      .mockResolvedValueOnce(Buffer.from(mockToken))
+      .mockResolvedValueOnce(Buffer.from(mockRegion));
+
+    await fromInstanceMetadataRegion()();
+
+    expect(vi.mocked(httpRequest).mock.calls[0][0].timeout).toBe(1000);
+  });
+
+  it("trims whitespace from the region response", async () => {
+    vi.mocked(httpRequest)
+      .mockResolvedValueOnce(Buffer.from(mockToken))
+      .mockResolvedValueOnce(Buffer.from(`  ${mockRegion}\n`));
+
+    await expect(fromInstanceMetadataRegion()()).resolves.toBe(mockRegion);
+  });
+
+  it("throws ProviderError with tryNextLink when AWS_EC2_METADATA_DISABLED is set", async () => {
+    process.env.AWS_EC2_METADATA_DISABLED = "true";
+
+    await expect(fromInstanceMetadataRegion()()).rejects.toMatchObject({
+      tryNextLink: true,
+    });
+    expect(httpRequest).not.toHaveBeenCalled();
+  });
+
+  it("throws ProviderError with tryNextLink on empty region body", async () => {
+    vi.mocked(httpRequest)
+      .mockResolvedValueOnce(Buffer.from(mockToken))
+      .mockResolvedValueOnce(Buffer.from(""));
+
+    await expect(fromInstanceMetadataRegion()()).rejects.toMatchObject({
+      tryNextLink: true,
+    });
+  });
+
+  it("wraps non-ProviderError failures with tryNextLink", async () => {
+    vi.mocked(httpRequest).mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    // Single invocation so we test the wrap path, not the negative-cache short-circuit.
+    const promise = fromInstanceMetadataRegion()();
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({ tryNextLink: true });
+  });
+
+  it("memoizes negative results within the cache TTL", async () => {
+    vi.mocked(httpRequest).mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(fromInstanceMetadataRegion()()).rejects.toBeInstanceOf(ProviderError);
+    await expect(fromInstanceMetadataRegion()()).rejects.toBeInstanceOf(ProviderError);
+
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the token PUT up to maxRetries times before failing", async () => {
+    vi.mocked(httpRequest)
+      .mockRejectedValueOnce(new Error("attempt 1"))
+      .mockRejectedValueOnce(new Error("attempt 2"))
+      .mockResolvedValueOnce(Buffer.from(mockToken))
+      .mockResolvedValueOnce(Buffer.from(mockRegion));
+
+    await expect(fromInstanceMetadataRegion({ maxRetries: 2 })()).resolves.toBe(mockRegion);
+    // 2 failed token attempts + 1 successful token attempt + 1 region attempt = 4
+    expect(httpRequest).toHaveBeenCalledTimes(4);
+  });
+
+  it("defaults maxRetries to 0", async () => {
+    vi.mocked(httpRequest).mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(fromInstanceMetadataRegion()()).rejects.toBeInstanceOf(ProviderError);
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/credential-provider-imds/src/fromInstanceMetadataRegion.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadataRegion.ts
@@ -1,0 +1,105 @@
+import { ProviderError } from "@smithy/core/config";
+import type { Provider } from "@smithy/types";
+
+import { httpRequest } from "./remoteProvider/httpRequest";
+import { retry } from "./remoteProvider/retry";
+import { getInstanceMetadataEndpoint } from "./utils/getInstanceMetadataEndpoint";
+
+const IMDS_REGION_PATH = "/latest/meta-data/placement/region";
+const IMDS_TOKEN_PATH = "/latest/api/token";
+const X_AWS_EC2_METADATA_TOKEN = "x-aws-ec2-metadata-token";
+const X_AWS_EC2_METADATA_TOKEN_TTL = "x-aws-ec2-metadata-token-ttl-seconds";
+const ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
+const DEFAULT_TIMEOUT_MS = 1000;
+const DEFAULT_TOKEN_TTL_SECONDS = "21600";
+const NEG_CACHE_TTL_MS = 60_000;
+
+// Module-level so the negative result is shared across all provider invocations in a process.
+let negativeCacheUntil = 0;
+
+/**
+ * @public
+ */
+export interface InstanceMetadataRegionInit {
+  /**
+   * The connection timeout (in milliseconds).
+   */
+  timeout?: number;
+  /**
+   * The maximum number of times the HTTP connection should be retried.
+   */
+  maxRetries?: number;
+}
+
+/**
+ * Creates a region provider that sources the region from the EC2 Instance Metadata Service.
+ *
+ * @public
+ */
+export const fromInstanceMetadataRegion =
+  (init: InstanceMetadataRegionInit = {}): Provider<string> =>
+  async (): Promise<string> => {
+    if (process.env[ENV_IMDS_DISABLED]) {
+      throw new ProviderError("IMDS region provider disabled via AWS_EC2_METADATA_DISABLED", {
+        tryNextLink: true,
+      });
+    }
+    if (Date.now() < negativeCacheUntil) {
+      throw new ProviderError("IMDS region recently failed; skipping until cache expires", {
+        tryNextLink: true,
+      });
+    }
+
+    const timeout = init.timeout ?? DEFAULT_TIMEOUT_MS;
+    const maxRetries = init.maxRetries ?? 0;
+
+    try {
+      const endpoint = await getInstanceMetadataEndpoint();
+      const token = (
+        await retry(
+          () =>
+            httpRequest({
+              ...endpoint,
+              path: IMDS_TOKEN_PATH,
+              method: "PUT",
+              headers: {
+                [X_AWS_EC2_METADATA_TOKEN_TTL]: DEFAULT_TOKEN_TTL_SECONDS,
+              },
+              timeout,
+            }),
+          maxRetries
+        )
+      ).toString();
+
+      const region = (
+        await retry(
+          () =>
+            httpRequest({
+              ...endpoint,
+              path: IMDS_REGION_PATH,
+              method: "GET",
+              headers: {
+                [X_AWS_EC2_METADATA_TOKEN]: token,
+              },
+              timeout,
+            }),
+          maxRetries
+        )
+      )
+        .toString()
+        .trim();
+
+      if (!region) {
+        throw new ProviderError("Empty region response from IMDS", { tryNextLink: true });
+      }
+      return region;
+    } catch (e) {
+      negativeCacheUntil = Date.now() + NEG_CACHE_TTL_MS;
+      if (e instanceof ProviderError) {
+        throw e;
+      }
+      throw new ProviderError((e as Error)?.message ?? "Unknown IMDS region error", {
+        tryNextLink: true,
+      });
+    }
+  };

--- a/packages/credential-provider-imds/src/index.ts
+++ b/packages/credential-provider-imds/src/index.ts
@@ -7,6 +7,10 @@ export * from "./fromContainerMetadata";
  */
 export * from "./fromInstanceMetadata";
 /**
+ * @public
+ */
+export { fromInstanceMetadataRegion, type InstanceMetadataRegionInit } from "./fromInstanceMetadataRegion";
+/**
  * @internal
  */
 export * from "./remoteProvider/RemoteProviderInit";


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws/aws-sdk-js-v3/issues/6183
JS-6904

_Description of changes:_
Adds a named, exported region provider that resolves the host's region from EC2 IMDSv2. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.