### PR TITLE
fix(core/serde): clean up ChecksumStream's source on destroy

### DIFF
--- a/.changeset/tricky-llamas-stare.md
+++ b/.changeset/tricky-llamas-stare.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Clean up ChecksumStream's source stream when destroyed.

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
@@ -136,8 +136,8 @@ export class ChecksumStream extends Duplex {
    * Do not call this directly.
    * @internal
    */
-  _destroy(error: Error | null, callback: (error?: Error | null | undefined) => void) : void {
+  public _destroy(error: Error | null, callback: (error?: Error | null | undefined) => void): void {
     this.source?.destroy();
-    callback?.(error);
+    callback(error);
   }
 }

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
@@ -127,4 +127,17 @@ export class ChecksumStream extends Duplex {
     this.push(null);
     return callback();
   }
+
+  /**
+   * Destroy the upstream source for cleanup so it is not left dangling, then
+   * complete this stream's destruction. The error is intentionally not forwarded
+   * to the source as the source is typically internal and without an error listener
+   * The error still surfaces on this stream via the callback.
+   * Do not call this directly.
+   * @internal
+   */
+  _destroy(error: Error | null, callback: (error?: Error | null | undefined) => void) : void {
+    this.source?.destroy();
+    callback?.(error);
+  }
 }

--- a/packages/core/src/submodules/serde/util-stream/checksum/createChecksumStream.spec.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/createChecksumStream.spec.ts
@@ -75,6 +75,46 @@ describe("Checksum streams", () => {
       }
     });
 
+    it("should destroy the upstream source when destroyed", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      checksumStream.destroy();
+
+      expect(checksumStream.destroyed).toBe(true);
+      expect(stream.destroyed).toBe(true);
+    });
+
+    it("should surface the error on itself, not the source, when destroyed with an error", async () => {
+      const stream = makeStream();
+      const checksumStream = createChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source: stream,
+      });
+
+      const error = new Error("boom");
+
+      const streamError = new Promise<Error>((resolve) => checksumStream.once("error", resolve));
+      let sourceErrored = false;
+      stream.once("error", () => {
+        sourceErrored = true;
+      });
+
+      checksumStream.destroy(error);
+
+      expect(await streamError).toBe(error);
+      expect(sourceErrored).toBe(false);
+      expect(checksumStream.destroyed).toBe(true);
+      expect(stream.destroyed).toBe(true);
+    });
+
     it("should handle backpressure", async () => {
       // for Node.js 22+ increased default highwater mark.
       Readable.setDefaultHighWaterMark(false, 16_384);


### PR DESCRIPTION
*Description of changes:*

Since #1869, the ChecksumStream has respected backpressure properly, which is of course a good thing. However, if the consumer does not have a reference to the source stream, they have no way to cleanly abandon it. They are forced to either consume the entire stream of leave the source stream dangling.

This is specifically an issue when interacting with the Body stream in AWS's S3 Client's GetObjectCommandOutput. The [guidance](https://github.com/aws/aws-sdk-js-v3/issues/6691#issuecomment-2498862552) has previously been to consume the Body entirely or destroy it to return the socket to the pool. Not doing so would eventually result socket exhaustion.

The previous lack of backpressure was masking this issue as the the ChecksumStream would unboundedly consume from the source stream, always, until completion. 