### PR TITLE
feat: use npm trusted publishing instead of token

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -54,18 +54,9 @@ jobs:
           git add .
           git commit -m 'Version NPM packages'
           git push
-      - name: Fetch NPM token
-        id: token
-        if: steps.commit.outcome == 'success'
-        run: |
-          aws configure --profile token set role_arn ${{ secrets.JS_TEAM_TOKEN_ROLE }}
-          aws configure --profile token set credential_source Environment
-          npm_token=$(aws secretsmanager get-secret-value --region us-west-2 --secret-id=smithy-typescript-npm-token --query SecretString --output text --profile token)
-          echo "::add-mask::$npm_token"
-          echo "NPM_TOKEN=$npm_token" >> $GITHUB_ENV
       - name: Stage Release
         id: stage
-        if: steps.token.outcome == 'success'
+        if: steps.commit.outcome == 'success'
         run: |
           yarn stage-release --concurrency=1
       - name: Release
@@ -75,7 +66,6 @@ jobs:
         with:
           publish: yarn release
         env:
-          NPM_TOKEN: ${{ env.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Failure Nofitication
         if: ${{ failure() }}


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6577

*Description of changes:*

Switch the npm release workflow to use [npm trusted publishing][]
(OIDC) instead of a long-lived npm token.

Changes to `.github/workflows/release-npm-packages.yml`:
- Remove the "Fetch NPM token" step that assumed a role and pulled the npm
  token from AWS Secrets Manager.
- Remove the `NPM_TOKEN` env var from the "Release" step. Authentication now
  happens automatically via OIDC using the existing `id-token: write`
  permission.
- Re-chain the "Stage Release" condition to depend on the "Commit" step
  (`steps.commit.outcome == 'success'`) since the token step it previously
  depended on is gone.

The trusted publisher has already been configured on npmjs.com for this
repository and workflow.

Notes:
- Trusted publishing requires npm CLI >= 11.5.1. Node 24 (used by `setup-node`)
  bundles npm >= 11.5.1 since v24.5.0, so no npm upgrade step is needed.
- npm provenance is generated automatically with trusted publishing.

*Testing:*
- Workflow is `workflow_dispatch` only; will be validated on the next manual release run.

[npm trusted publishing]: https://docs.npmjs.com/trusted-publishers

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
