### PR TITLE
feat(core/config): IMDSv2 region fallback in default Node region chain

### DIFF
--- a/.changeset/imds-region-fallback.md
+++ b/.changeset/imds-region-fallback.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+Add IMDSv2 region fallback to NODE_REGION_CONFIG_OPTIONS default, consolidated with defaults-mode region inference.

--- a/packages/core/src/submodules/config/config-resolver/regionConfig/config.spec.ts
+++ b/packages/core/src/submodules/config/config-resolver/regionConfig/config.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test as it } from "vitest";
+import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import {
   NODE_REGION_CONFIG_FILE_OPTIONS,
@@ -6,6 +6,9 @@ import {
   REGION_ENV_NAME,
   REGION_INI_NAME,
 } from "./config";
+import { getInstanceMetadataRegion } from "./getInstanceMetadataRegion";
+
+vi.mock("./getInstanceMetadataRegion");
 
 describe("config", () => {
   describe("NODE_REGION_CONFIG_OPTIONS", () => {
@@ -23,11 +26,26 @@ describe("config", () => {
       });
     });
 
-    it("default throws error", () => {
-      const { default: defaultKey } = NODE_REGION_CONFIG_OPTIONS;
-      expect(() => {
-        (defaultKey as any)();
-      }).toThrowError(new Error("Region is missing"));
+    describe("default", () => {
+      beforeEach(() => {
+        vi.mocked(getInstanceMetadataRegion).mockReset();
+      });
+
+      afterEach(() => {
+        vi.resetAllMocks();
+      });
+
+      it("returns IMDS region when available", async () => {
+        vi.mocked(getInstanceMetadataRegion).mockResolvedValue("us-west-2");
+        const { default: defaultKey } = NODE_REGION_CONFIG_OPTIONS;
+        await expect((defaultKey as () => Promise<string>)()).resolves.toBe("us-west-2");
+      });
+
+      it("throws Region is missing when IMDS returns undefined", async () => {
+        vi.mocked(getInstanceMetadataRegion).mockResolvedValue(undefined);
+        const { default: defaultKey } = NODE_REGION_CONFIG_OPTIONS;
+        await expect((defaultKey as () => Promise<string>)()).rejects.toThrowError(new Error("Region is missing"));
+      });
     });
   });
 

--- a/packages/core/src/submodules/config/config-resolver/regionConfig/config.ts
+++ b/packages/core/src/submodules/config/config-resolver/regionConfig/config.ts
@@ -1,4 +1,5 @@
 import type { LoadedConfigSelectors, LocalConfigOptions } from "../../node-config-provider/configLoader";
+import { getInstanceMetadataRegion } from "./getInstanceMetadataRegion";
 
 /**
  * @internal
@@ -15,7 +16,11 @@ export const REGION_INI_NAME = "region";
 export const NODE_REGION_CONFIG_OPTIONS: LoadedConfigSelectors<string> = {
   environmentVariableSelector: (env) => env[REGION_ENV_NAME],
   configFileSelector: (profile) => profile[REGION_INI_NAME],
-  default: () => {
+  default: async () => {
+    const region = await getInstanceMetadataRegion();
+    if (region) {
+      return region;
+    }
     throw new Error("Region is missing");
   },
 };

--- a/packages/core/src/submodules/config/config-resolver/regionConfig/getInstanceMetadataRegion.spec.ts
+++ b/packages/core/src/submodules/config/config-resolver/regionConfig/getInstanceMetadataRegion.spec.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
+
+import type { getInstanceMetadataRegion as GetInstanceMetadataRegion } from "./getInstanceMetadataRegion";
+
+const requestMock = vi.fn();
+vi.mock("node:http", () => ({
+  request: requestMock,
+}));
+
+interface FakeReqInit {
+  body?: string;
+  statusCode?: number;
+  error?: Error;
+}
+
+class FakeReq extends EventEmitter {
+  end = vi.fn();
+  destroy = vi.fn();
+}
+
+class FakeRes extends EventEmitter {
+  statusCode: number;
+  constructor(statusCode: number) {
+    super();
+    this.statusCode = statusCode;
+  }
+}
+
+const fakeRequest = (init: FakeReqInit) =>
+  vi.fn(() => {
+    const req = new FakeReq();
+    queueMicrotask(() => {
+      if (init.error) {
+        req.emit("error", init.error);
+        return;
+      }
+      const res = new FakeRes(init.statusCode ?? 200);
+      req.emit("response", res);
+      queueMicrotask(() => {
+        if (init.body !== undefined) {
+          res.emit("data", Buffer.from(init.body));
+        }
+        res.emit("end");
+      });
+    });
+    return req;
+  });
+
+describe("getInstanceMetadataRegion", () => {
+  const originalEnv = process.env;
+
+  let getInstanceMetadataRegion: typeof GetInstanceMetadataRegion;
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv };
+    delete process.env.AWS_EC2_METADATA_DISABLED;
+    delete process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT;
+    delete process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE;
+    requestMock.mockReset();
+    ({ getInstanceMetadataRegion } = await import("./getInstanceMetadataRegion"));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns the region after a token PUT and region GET", async () => {
+    requestMock
+      .mockImplementationOnce(fakeRequest({ body: "imds-token", statusCode: 200 }))
+      .mockImplementationOnce(fakeRequest({ body: "us-west-2", statusCode: 200 }));
+
+    await expect(getInstanceMetadataRegion()).resolves.toBe("us-west-2");
+
+    const tokenCall = requestMock.mock.calls[0][0];
+    expect(tokenCall.method).toBe("PUT");
+    expect(tokenCall.path).toBe("/latest/api/token");
+    expect(tokenCall.headers).toMatchObject({ "x-aws-ec2-metadata-token-ttl-seconds": "21600" });
+
+    const regionCall = requestMock.mock.calls[1][0];
+    expect(regionCall.method).toBe("GET");
+    expect(regionCall.path).toBe("/latest/meta-data/placement/region");
+    expect(regionCall.headers).toMatchObject({ "x-aws-ec2-metadata-token": "imds-token" });
+  });
+
+  it("trims whitespace from the region response", async () => {
+    requestMock
+      .mockImplementationOnce(fakeRequest({ body: "tok", statusCode: 200 }))
+      .mockImplementationOnce(fakeRequest({ body: "  us-east-1\n", statusCode: 200 }));
+
+    await expect(getInstanceMetadataRegion()).resolves.toBe("us-east-1");
+  });
+
+  it("returns undefined when AWS_EC2_METADATA_DISABLED is set", async () => {
+    process.env.AWS_EC2_METADATA_DISABLED = "true";
+
+    await expect(getInstanceMetadataRegion()).resolves.toBeUndefined();
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined and caches negative result on token PUT error", async () => {
+    requestMock.mockImplementationOnce(fakeRequest({ error: new Error("ECONNREFUSED") }));
+
+    await expect(getInstanceMetadataRegion()).resolves.toBeUndefined();
+    await expect(getInstanceMetadataRegion()).resolves.toBeUndefined();
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined on non-2xx response", async () => {
+    requestMock.mockImplementationOnce(fakeRequest({ statusCode: 500, body: "" }));
+
+    await expect(getInstanceMetadataRegion()).resolves.toBeUndefined();
+  });
+
+  it("returns undefined on empty region body", async () => {
+    requestMock
+      .mockImplementationOnce(fakeRequest({ body: "tok", statusCode: 200 }))
+      .mockImplementationOnce(fakeRequest({ body: "", statusCode: 200 }));
+
+    await expect(getInstanceMetadataRegion()).resolves.toBeUndefined();
+  });
+
+  it("uses AWS_EC2_METADATA_SERVICE_ENDPOINT host when set", async () => {
+    process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT = "http://192.0.2.10/";
+    requestMock
+      .mockImplementationOnce(fakeRequest({ body: "tok", statusCode: 200 }))
+      .mockImplementationOnce(fakeRequest({ body: "us-west-2", statusCode: 200 }));
+
+    await getInstanceMetadataRegion();
+    expect(requestMock.mock.calls[0][0].hostname).toBe("192.0.2.10");
+  });
+
+  it("preserves a non-default port from AWS_EC2_METADATA_SERVICE_ENDPOINT", async () => {
+    process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT = "http://127.0.0.1:54321/";
+    requestMock
+      .mockImplementationOnce(fakeRequest({ body: "tok", statusCode: 200 }))
+      .mockImplementationOnce(fakeRequest({ body: "us-west-2", statusCode: 200 }));
+
+    await getInstanceMetadataRegion();
+    expect(requestMock.mock.calls[0][0].hostname).toBe("127.0.0.1");
+    expect(requestMock.mock.calls[0][0].port).toBe(54321);
+  });
+
+  it("uses IPv6 endpoint when AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6", async () => {
+    process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE = "IPv6";
+    requestMock
+      .mockImplementationOnce(fakeRequest({ body: "tok", statusCode: 200 }))
+      .mockImplementationOnce(fakeRequest({ body: "us-west-2", statusCode: 200 }));
+
+    await getInstanceMetadataRegion();
+    expect(requestMock.mock.calls[0][0].hostname).toBe("fd00:ec2::254");
+  });
+
+  it("defaults to 169.254.169.254 when no endpoint env vars are set", async () => {
+    requestMock
+      .mockImplementationOnce(fakeRequest({ body: "tok", statusCode: 200 }))
+      .mockImplementationOnce(fakeRequest({ body: "us-west-2", statusCode: 200 }));
+
+    await getInstanceMetadataRegion();
+    expect(requestMock.mock.calls[0][0].hostname).toBe("169.254.169.254");
+  });
+});

--- a/packages/core/src/submodules/config/config-resolver/regionConfig/getInstanceMetadataRegion.ts
+++ b/packages/core/src/submodules/config/config-resolver/regionConfig/getInstanceMetadataRegion.ts
@@ -1,0 +1,128 @@
+import type { IncomingMessage } from "node:http";
+
+import {
+  ENV_IMDS_DISABLED,
+  IMDS_REGION_PATH,
+  IMDS_TOKEN_PATH,
+  X_AWS_EC2_METADATA_TOKEN,
+  X_AWS_EC2_METADATA_TOKEN_TTL,
+} from "../../defaults-mode/constants";
+
+const TIMEOUT_MS = 1000;
+const NEG_CACHE_TTL_MS = 60_000;
+
+let negativeCacheUntil = 0;
+
+interface ImdsEndpoint {
+  hostname: string;
+  port?: number;
+}
+
+/**
+ * Returns the region of the host from the EC2 Instance Metadata Service (IMDSv2),
+ * or undefined if unavailable.
+ *
+ * @internal
+ */
+export const getInstanceMetadataRegion = async (): Promise<string | undefined> => {
+  if (process.env[ENV_IMDS_DISABLED]) {
+    return undefined;
+  }
+  if (Date.now() < negativeCacheUntil) {
+    return undefined;
+  }
+  try {
+    const endpoint = resolveImdsEndpoint();
+    const token = (
+      await imdsRequest({
+        ...endpoint,
+        path: IMDS_TOKEN_PATH,
+        method: "PUT",
+        headers: {
+          [X_AWS_EC2_METADATA_TOKEN_TTL]: "21600",
+        },
+      })
+    ).toString();
+    const region = (
+      await imdsRequest({
+        ...endpoint,
+        path: IMDS_REGION_PATH,
+        method: "GET",
+        headers: {
+          [X_AWS_EC2_METADATA_TOKEN]: token,
+        },
+      })
+    )
+      .toString()
+      .trim();
+    return region || cacheNegativeAndReturnUndefined();
+  } catch {
+    return cacheNegativeAndReturnUndefined();
+  }
+};
+
+const cacheNegativeAndReturnUndefined = (): undefined => {
+  negativeCacheUntil = Date.now() + NEG_CACHE_TTL_MS;
+  return undefined;
+};
+
+const resolveImdsEndpoint = (): ImdsEndpoint => {
+  const envEndpoint = process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT;
+  if (envEndpoint) {
+    const url = new URL(envEndpoint);
+    return {
+      hostname: url.hostname.replace(/^\[(.+)]$/, "$1"),
+      port: url.port ? Number(url.port) : undefined,
+    };
+  }
+  if (process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE === "IPv6") {
+    return { hostname: "fd00:ec2::254" };
+  }
+  return { hostname: "169.254.169.254" };
+};
+
+interface ImdsRequestOptions {
+  hostname: string;
+  port?: number;
+  path: string;
+  method: "GET" | "PUT";
+  headers?: Record<string, string>;
+}
+
+const imdsRequest = async (options: ImdsRequestOptions): Promise<Buffer> => {
+  const { request } = await import("node:http");
+  return new Promise<Buffer>((resolve, reject) => {
+    const req = request({
+      hostname: options.hostname,
+      port: options.port,
+      path: options.path,
+      method: options.method,
+      headers: options.headers,
+      timeout: TIMEOUT_MS,
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    req.on("error", (err: Error) => {
+      reject(err);
+      req.destroy();
+    });
+    req.on("timeout", () => {
+      reject(new Error("TimeoutError from instance metadata service"));
+      req.destroy();
+    });
+    req.on("response", (res: IncomingMessage) => {
+      const { statusCode = 400 } = res;
+      if (statusCode < 200 || statusCode >= 300) {
+        reject(Object.assign(new Error("Error response received from instance metadata service"), { statusCode }));
+        req.destroy();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () => {
+        resolve(Buffer.concat(chunks));
+        req.destroy();
+      });
+    });
+    req.end();
+  });
+};

--- a/packages/core/src/submodules/config/defaults-mode/constants.ts
+++ b/packages/core/src/submodules/config/defaults-mode/constants.ts
@@ -22,3 +22,15 @@ export const DEFAULTS_MODE_OPTIONS = ["in-region", "cross-region", "mobile", "st
  * @internal
  */
 export const IMDS_REGION_PATH = "/latest/meta-data/placement/region";
+/**
+ * @internal
+ */
+export const IMDS_TOKEN_PATH = "/latest/api/token";
+/**
+ * @internal
+ */
+export const X_AWS_EC2_METADATA_TOKEN = "x-aws-ec2-metadata-token";
+/**
+ * @internal
+ */
+export const X_AWS_EC2_METADATA_TOKEN_TTL = "x-aws-ec2-metadata-token-ttl-seconds";

--- a/packages/core/src/submodules/config/defaults-mode/resolveDefaultsModeConfig.ts
+++ b/packages/core/src/submodules/config/defaults-mode/resolveDefaultsModeConfig.ts
@@ -1,18 +1,11 @@
-import type { IncomingMessage } from "node:http";
 import type { DefaultsMode, ResolvedDefaultsMode } from "@smithy/core/client";
 import type { Provider } from "@smithy/types";
 
 import { NODE_REGION_CONFIG_OPTIONS } from "../config-resolver/regionConfig/config";
+import { getInstanceMetadataRegion } from "../config-resolver/regionConfig/getInstanceMetadataRegion";
 import { loadConfig } from "../node-config-provider/configLoader";
 import { memoize } from "../property-provider/memoize";
-import {
-  AWS_DEFAULT_REGION_ENV,
-  AWS_EXECUTION_ENV,
-  AWS_REGION_ENV,
-  DEFAULTS_MODE_OPTIONS,
-  ENV_IMDS_DISABLED,
-  IMDS_REGION_PATH,
-} from "./constants";
+import { AWS_DEFAULT_REGION_ENV, AWS_EXECUTION_ENV, AWS_REGION_ENV, DEFAULTS_MODE_OPTIONS } from "./constants";
 import { NODE_DEFAULTS_MODE_CONFIG_OPTIONS } from "./defaultsModeConfig";
 
 /**
@@ -79,65 +72,5 @@ const inferPhysicalRegion = async (): Promise<string | undefined> => {
     // region, if they're set
     return process.env[AWS_REGION_ENV] ?? process.env[AWS_DEFAULT_REGION_ENV];
   }
-  if (!process.env[ENV_IMDS_DISABLED]) {
-    // We couldn't figure out the region from environment variables. Check IMDSv2
-    try {
-      const endpoint = await getImdsEndpoint();
-      return (await imdsHttpGet({ hostname: endpoint.hostname, path: IMDS_REGION_PATH })).toString();
-    } catch (e) {
-      // Swallow the error.
-    }
-  }
-};
-
-/**
- * Inlined from @smithy/credential-provider-imds to avoid circular dependency.
- */
-const getImdsEndpoint = async (): Promise<{ hostname: string; path: string }> => {
-  const envEndpoint = process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT;
-  if (envEndpoint) {
-    const url = new URL(envEndpoint);
-    return { hostname: url.hostname, path: url.pathname };
-  }
-  const envMode = process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE;
-  if (envMode === "IPv6") {
-    return { hostname: "fd00:ec2::254", path: "/" };
-  }
-  return { hostname: "169.254.169.254", path: "/" };
-};
-
-const imdsHttpGet = async ({ hostname, path }: { hostname: string; path: string }): Promise<Buffer> => {
-  const { request } = await import("node:http");
-  return new Promise((resolve, reject) => {
-    const req = request({
-      method: "GET",
-      hostname: hostname.replace(/^\[(.+)]$/, "$1"),
-      path,
-      timeout: 1000,
-      signal: AbortSignal.timeout(1000),
-    });
-    req.on("error", (err: Error) => {
-      reject(err);
-      req.destroy();
-    });
-    req.on("timeout", () => {
-      reject(new Error("TimeoutError from instance metadata service"));
-      req.destroy();
-    });
-    req.on("response", (res: IncomingMessage) => {
-      const { statusCode = 400 } = res;
-      if (statusCode < 200 || 300 <= statusCode) {
-        reject(Object.assign(new Error("Error response received from instance metadata service"), { statusCode }));
-        req.destroy();
-        return;
-      }
-      const chunks: Buffer[] = [];
-      res.on("data", (chunk: Buffer) => chunks.push(chunk));
-      res.on("end", () => {
-        resolve(Buffer.concat(chunks));
-        req.destroy();
-      });
-    });
-    req.end();
-  });
+  return getInstanceMetadataRegion();
 };


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/6183
JS-6904

*Description of changes:*
- Wires `NODE_REGION_CONFIG_OPTIONS.default` to try IMDSv2 before throwing "Region is missing"
- Consolidates with `inferPhysicalRegion` in `defaults-mode`, which previously inlined its own IMDS helpers. Both now share getInstanceMetadataRegion.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
