### PR TITLE
feat(ci): auto-version @aws-smithy/* SSDK libs on release

### DIFF
--- a/.github/workflows/release-npm-ssdk-libs.yml
+++ b/.github/workflows/release-npm-ssdk-libs.yml
@@ -18,6 +18,11 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn install
+      - name: Version
+        id: version
+        run: |
+          node scripts/bump-ssdk-alpha.js
+          echo "porcelain=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Configure AWS Credentials
         id: credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -26,6 +31,29 @@ jobs:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
           role-session-name: SmithyTypeScriptGitHubRelease
           audience: sts.amazonaws.com
+      - name: Configure deploy key for push
+        if: steps.version.outputs.porcelain != '0'
+        run: |
+          deploy_key=$(aws secretsmanager get-secret-value \
+            --region us-west-2 \
+            --secret-id ${{ secrets.DEPLOY_KEY_SECRET_ARN }} \
+            --query SecretString --output text)
+          echo "::add-mask::$deploy_key"
+          mkdir -p ~/.ssh
+          echo "$deploy_key" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git remote set-url origin git@github.com:smithy-lang/smithy-typescript.git
+          git config core.sshCommand "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes"
+      - name: Commit
+        id: commit
+        if: steps.version.outputs.porcelain != '0'
+        run: |
+          git config --global user.email "github-aws-smithy-automation@amazon.com"
+          git config --global user.name "Smithy Automation"
+          git add .
+          git commit -m 'Version SSDK lib packages'
+          git push
       - name: Fetch NPM token
         id: token
         run: |

--- a/.github/workflows/release-npm-ssdk-libs.yml
+++ b/.github/workflows/release-npm-ssdk-libs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
           cache: "yarn"
       - name: Install dependencies
         run: yarn install
@@ -28,7 +28,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-2
-          role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.JS_TEAM_ROLE_TO_ASSUME }}
           role-session-name: SmithyTypeScriptGitHubRelease
           audience: sts.amazonaws.com
       - name: Configure deploy key for push
@@ -54,17 +54,9 @@ jobs:
           git add .
           git commit -m 'Version SSDK lib packages'
           git push
-      - name: Fetch NPM token
-        id: token
-        run: |
-          aws configure --profile token set role_arn ${{ secrets.TOKEN_ROLE }}
-          aws configure --profile token set credential_source Environment
-          npm_token=$(aws secretsmanager get-secret-value --region us-west-2 --secret-id=SMITHY_PUBLISH_npmToken --query SecretString --output text --profile token)
-          echo "::add-mask::$npm_token"
-          echo "NPM_TOKEN=$npm_token" >> $GITHUB_ENV
       - name: Stage Release
         id: stage
-        if: steps.token.outcome == 'success'
+        if: steps.commit.outcome == 'success'
         run: |
           yarn stage-release --concurrency=1
       - name: Release
@@ -74,7 +66,6 @@ jobs:
         with:
           publish: yarn release
         env:
-          NPM_TOKEN: ${{ env.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Failure Nofitication
         if: ${{ failure() }}

--- a/scripts/bump-ssdk-alpha.js
+++ b/scripts/bump-ssdk-alpha.js
@@ -1,0 +1,37 @@
+// Bumps the prerelease number of the @aws-smithy/* SSDK packages (e.g.
+// 1.0.0-alpha.10 -> 1.0.0-alpha.11). These packages are intentionally kept out
+// of the changesets flow (they are listed under "ignore" in
+// .changeset/config.json) so that the GA @smithy/* release process is never
+// affected. This script is the dedicated version step for the SSDK release.
+const fs = require("fs");
+const path = require("path");
+
+const SSDK_DIR = path.join(__dirname, "..", "smithy-typescript-ssdk-libs");
+
+const ALPHA_RE = /^(\d+\.\d+\.\d+)-alpha\.(\d+)$/;
+
+function bumpFile(pkgJsonPath) {
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+  const match = ALPHA_RE.exec(pkg.version);
+  if (!match) {
+    throw new Error(
+      `${pkg.name} version "${pkg.version}" is not in the expected x.y.z-alpha.N form`
+    );
+  }
+  const [, base, n] = match;
+  const next = `${base}-alpha.${Number(n) + 1}`;
+  pkg.version = next;
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+  return { name: pkg.name, version: next };
+}
+
+const dirs = fs
+  .readdirSync(SSDK_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => path.join(SSDK_DIR, d.name, "package.json"))
+  .filter((p) => fs.existsSync(p));
+
+const bumped = dirs.map(bumpFile);
+for (const { name, version } of bumped) {
+  console.log(`bumped ${name} -> ${version}`);
+}

--- a/scripts/bump-ssdk-alpha.js
+++ b/scripts/bump-ssdk-alpha.js
@@ -3,8 +3,8 @@
 // of the changesets flow (they are listed under "ignore" in
 // .changeset/config.json) so that the GA @smithy/* release process is never
 // affected. This script is the dedicated version step for the SSDK release.
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const SSDK_DIR = path.join(__dirname, "..", "smithy-typescript-ssdk-libs");
 


### PR DESCRIPTION
*Issue #, if available:* Follow-up to #2096 (SSDK interceptor support)

*Description of changes:*

Adds automatic versioning for the @aws-smithy/* SSDK libraries to the release-npm-ssdk-libs workflow, mirroring the Version → commit → push pattern in the core release-npm-packages workflow.

 - New scripts/bump-ssdk-alpha.js: bumps each @aws-smithy/* package's prerelease number (alpha.N → alpha.N+1).
 - release-npm-ssdk-libs.yml: runs the bump, then commits & pushes the version change before staging/publishing.
 
 The SSDK libs remain in the changesets ignore list, so the GA @smithy/* release flow is unaffected — their versioning is handled independently by this script. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
