### PR TITLE
refactor(core/serde): make ChecksumStream a Readable

### DIFF
--- a/.changeset/selfish-donuts-build.md
+++ b/.changeset/selfish-donuts-build.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Make ChecksumStream a Readable that consumes its source directly

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.spec.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.spec.ts
@@ -186,6 +186,51 @@ describe(ChecksumStream.name, () => {
 
       await expect(collect(checksumStream)).rejects.toThrow("digest failed");
     });
+
+    it("should surface an error emitted by the source", async () => {
+      const source = makeSource();
+      const checksumStream = new ChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source,
+      });
+
+      const sourceError = new Error("source failure");
+      const streamError = new Promise<Error>((resolve) => checksumStream.once("error", resolve));
+
+      source.emit("error", sourceError);
+
+      expect(await streamError).toBe(sourceError);
+      expect(checksumStream.destroyed).toBe(true);
+      expect(source.destroyed).toBe(true);
+    });
+  });
+
+  describe("lazy start", () => {
+    it("should not read from the source until the stream is consumed", async () => {
+      const checksum = new Appender();
+      const updateSpy = vi.spyOn(checksum, "update");
+      const source = makeSource();
+      const checksumStream = new ChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum,
+        checksumSourceLocation: "my-header",
+        source,
+      });
+
+      // The source is paused on construction and no chunk is processed until read.
+      expect(source.isPaused()).toBe(true);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(updateSpy).not.toHaveBeenCalled();
+
+      // Reading the stream is what drives consumption of the source.
+      const ait = checksumStream[Symbol.asyncIterator]();
+      await ait.next();
+      expect(updateSpy).toHaveBeenCalled();
+
+      checksumStream.destroy();
+    });
   });
 
   describe("_destroy", () => {

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
@@ -1,4 +1,4 @@
-import { Duplex, type Readable } from "node:stream";
+import { Readable } from "node:stream";
 import type { Checksum, Encoder } from "@smithy/types";
 
 import { toBase64 } from "../../util-base64/toBase64";
@@ -36,13 +36,12 @@ export interface ChecksumStreamInit<T extends Readable | ReadableStream> {
  *
  * @internal
  */
-export class ChecksumStream extends Duplex {
+export class ChecksumStream extends Readable {
   private expectedChecksum: string;
   private checksumSourceLocation: string;
   private checksum: Checksum;
-  private source?: Readable;
+  private source: Readable;
   private base64Encoder: Encoder;
-  private pendingCallback: ((err?: Error) => void) | null = null;
 
   public constructor({
     expectedChecksum,
@@ -52,24 +51,82 @@ export class ChecksumStream extends Duplex {
     base64Encoder,
   }: ChecksumStreamInit<Readable>) {
     super();
-    if (typeof (source as Readable).pipe === "function") {
-      this.source = source as Readable;
-    } else {
+    if (typeof (source as Readable).pipe !== "function") {
       throw new Error(
         `@smithy/util-stream: unsupported source type ${source?.constructor?.name ?? source} in ChecksumStream.`
       );
     }
+    this.source = source as Readable;
 
     this.base64Encoder = base64Encoder ?? toBase64;
     this.expectedChecksum = expectedChecksum;
     this.checksum = checksum;
     this.checksumSourceLocation = checksumSourceLocation;
 
-    // connect this stream to the end of the source stream.
-    this.source.pipe(this);
+    // Observe the source, updating the running checksum and forwarding each
+    // chunk to this stream's readable side. The source is paused immediately
+    // and is only resumed while this stream is being read (see _read), so data
+    // is pulled at the rate it is consumed and is never buffered twice.
+    this.source.on("data", this.onSourceData);
+    this.source.on("end", this.onSourceEnd);
+    this.source.on("error", this.onSourceError);
+    this.source.pause();
   }
 
   /**
+   * Update the checksum and forward each source chunk to the readable side,
+   * pausing the source when the readable side signals backpressure.
+   */
+  private onSourceData = (chunk: Buffer): void => {
+    if (this.destroyed) {
+      return;
+    }
+    try {
+      this.checksum.update(chunk);
+    } catch (e: unknown) {
+      this.destroy(e as Error);
+      return;
+    }
+    if (!this.push(chunk)) {
+      this.source.pause();
+    }
+  };
+
+  /**
+   * When the source finishes, perform the checksum comparison and end this stream.
+   */
+  private onSourceEnd = async (): Promise<void> => {
+    if (this.destroyed) {
+      return;
+    }
+    try {
+      const digest: Uint8Array = await this.checksum.digest();
+      const received = this.base64Encoder(digest);
+      if (this.expectedChecksum !== received) {
+        this.destroy(
+          new Error(
+            `Checksum mismatch: expected "${this.expectedChecksum}" but received "${received}"` +
+              ` in response header "${this.checksumSourceLocation}".`
+          )
+        );
+        return;
+      }
+    } catch (e: unknown) {
+      this.destroy(e as Error);
+      return;
+    }
+    this.push(null);
+  };
+
+  /**
+   * Surface source errors on this stream.
+   */
+  private onSourceError = (error: Error): void => {
+    this.destroy(error);
+  };
+
+  /**
+   * Resume the source so it flows at the rate this stream is consumed.
    * Do not call this directly.
    * @internal
    */
@@ -77,55 +134,7 @@ export class ChecksumStream extends Duplex {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     size: number
   ): void {
-    if (this.pendingCallback) {
-      const callback = this.pendingCallback;
-      this.pendingCallback = null;
-      callback();
-    }
-  }
-
-  /**
-   * When the upstream source flows data to this stream,
-   * calculate a step update of the checksum.
-   * Do not call this directly.
-   * @internal
-   */
-  public _write(chunk: Buffer, encoding: string, callback: (err?: Error) => void): void {
-    try {
-      this.checksum.update(chunk);
-      const canPushMore = this.push(chunk);
-      if (!canPushMore) {
-        this.pendingCallback = callback;
-        return;
-      }
-    } catch (e: unknown) {
-      return callback(e as Error);
-    }
-    return callback();
-  }
-
-  /**
-   * When the upstream source finishes, perform the checksum comparison.
-   * Do not call this directly.
-   * @internal
-   */
-  public async _final(callback: (err?: Error) => void): Promise<void> {
-    try {
-      const digest: Uint8Array = await this.checksum.digest();
-      const received = this.base64Encoder(digest);
-      if (this.expectedChecksum !== received) {
-        return callback(
-          new Error(
-            `Checksum mismatch: expected "${this.expectedChecksum}" but received "${received}"` +
-              ` in response header "${this.checksumSourceLocation}".`
-          )
-        );
-      }
-    } catch (e: unknown) {
-      return callback(e as Error);
-    }
-    this.push(null);
-    return callback();
+    this.source.resume();
   }
 
   /**

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
@@ -34,6 +34,14 @@ export interface ChecksumStreamInit<T extends Readable | ReadableStream> {
  * Wrapper for throwing checksum errors for streams without
  * buffering the stream.
  *
+ * Note: this effectively behaves as a duplex, reading from the source on one
+ * side and forwarding chunks to its own readable side on the other. It should
+ * not be rewritten back into a Duplex (or Transform). The source is observed
+ * and driven manually (pause/resume in onSourceData/_read) so data is pulled
+ * at the rate it is consumed and never buffered twice; this manual control is
+ * used deliberately for performance and would be lost with the built-in duplex
+ * machinery.
+ *
  * @internal
  */
 export class ChecksumStream extends Readable {


### PR DESCRIPTION
*Issue #, if available:*

Noticed while working on JS-6752

*Description of changes:*

Change ChecksumStream's base class from Duplex to Readable and consume
the source directly instead of piping it in. The source is attached via
its data/end/error events, the checksum is updated per chunk before
forwarding it with push(), and _read drives backpressure by pausing and
resuming the source.

This removes the writable side that only existed to serve as the pipe
target, so the source is no longer buffered on both a writable and a
readable side. Behavior is unchanged: checksum mismatches and
update/digest errors surface as stream errors during read, the source
is torn down on destroy, and instanceof Readable still holds.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
