### PR TITLE
chore: revert "Version SSDK lib packages" (#2111) due to failed publish

### DIFF
--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-smithy/server-apigateway",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.10",
   "description": "Base components for Smithy services behind APIGateway",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-smithy/server-common",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.10",
   "description": "Base components for Smithy services",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/smithy-typescript-ssdk-libs/server-node/package.json
+++ b/smithy-typescript-ssdk-libs/server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-smithy/server-node",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.10",
   "description": "Base components for Smithy services running on NodeJS",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",


### PR DESCRIPTION
This reverts commit b72eec22bd6a5b084941c76c38e9cf878852f065.

due to failed publish
