### PR TITLE
fix(ci): grant pull-requests write permission to release-npm-ssdk-lib  workflow

### DIFF
--- a/.github/workflows/release-npm-ssdk-libs.yml
+++ b/.github/workflows/release-npm-ssdk-libs.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5


### PR DESCRIPTION


*Issue #, if available:*

[SSDK release failed ](https://github.com/smithy-lang/smithy-typescript/actions/runs/28400609329/job/84150565345#step:10:160) due to missing write permission

*Description of changes:*

The changesets action opens a Version Packages PR when a changeset is present, which requires the pull-requests permission. The workflow only granted id-token and contents, so it failed with 'Resource not accessible by integration' on the create-a-pull-request API.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
