### PR TITLE
chore(codegen): set checksums in shared config

### DIFF
--- a/private/my-local-model-schema/src/runtimeConfig.ts
+++ b/private/my-local-model-schema/src/runtimeConfig.ts
@@ -7,7 +7,7 @@ import {
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@smithy/core/retry";
-import { calculateBodyLength, Hash } from "@smithy/core/serde";
+import { calculateBodyLength } from "@smithy/core/serde";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
 
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
@@ -39,7 +39,6 @@ export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
         },
         config
       ),
-    sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };
 };

--- a/private/my-local-model/package.json
+++ b/private/my-local-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xyz",
   "description": "xyz client",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "scripts": {
     "build": "concurrently 'npm:build:cjs' 'npm:build:es' 'npm:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/private/my-local-model/src/runtimeConfig.ts
+++ b/private/my-local-model/src/runtimeConfig.ts
@@ -7,7 +7,7 @@ import {
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@smithy/core/retry";
-import { calculateBodyLength, Hash } from "@smithy/core/serde";
+import { calculateBodyLength } from "@smithy/core/serde";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
 
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
@@ -39,7 +39,6 @@ export const getRuntimeConfig = (config: XYZServiceClientConfig) => {
         },
         config
       ),
-    sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };
 };

--- a/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/runtimeConfig.ts
@@ -6,7 +6,7 @@ import {
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@smithy/core/retry";
-import { calculateBodyLength, Hash } from "@smithy/core/serde";
+import { calculateBodyLength } from "@smithy/core/serde";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
 
 import type { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
@@ -37,7 +37,6 @@ export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
         },
         config
       ),
-    sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };
 };

--- a/private/smithy-rpcv2-cbor/src/runtimeConfig.ts
+++ b/private/smithy-rpcv2-cbor/src/runtimeConfig.ts
@@ -6,7 +6,7 @@ import {
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@smithy/core/retry";
-import { calculateBodyLength, Hash } from "@smithy/core/serde";
+import { calculateBodyLength } from "@smithy/core/serde";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
 
 import type { RpcV2ProtocolClientConfig } from "./RpcV2ProtocolClient";
@@ -37,7 +37,6 @@ export const getRuntimeConfig = (config: RpcV2ProtocolClientConfig) => {
         },
         config
       ),
-    sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
   };
 };

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -49,11 +49,6 @@ final class RuntimeConfigGenerator {
             writer.addImport("NodeHttpHandler", "RequestHandler", TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
             writer.write("RequestHandler.create(config?.requestHandler ?? defaultConfigProvider)");
         },
-        "sha256",
-        writer -> {
-            writer.addImportSubmodule("Hash", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
-            writer.write("Hash.bind(null, \"sha256\")");
-        },
         "bodyLengthChecker",
         writer -> {
             writer.addImportSubmodule(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
@@ -76,6 +76,20 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
         }
 
         switch (target) {
+            case SHARED:
+                return MapUtils.of(
+                    "md5",
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
+                        writer.addImportSubmodule(
+                            "Md5",
+                            null,
+                            TypeScriptDependency.SMITHY_CORE,
+                            SmithyCoreSubmodules.CHECKSUM
+                        );
+                        writer.write("Md5");
+                    }
+                );
             case NODE:
                 return MapUtils.of(
                     "streamHasher",
@@ -88,17 +102,6 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
                             SmithyCoreSubmodules.CHECKSUM
                         );
                         writer.write("streamHasher");
-                    },
-                    "md5",
-                    writer -> {
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
-                        writer.addImportSubmodule(
-                            "Hash",
-                            null,
-                            TypeScriptDependency.SMITHY_CORE,
-                            SmithyCoreSubmodules.SERDE
-                        );
-                        writer.write("Hash.bind(null, \"md5\")");
                     }
                 );
             case BROWSER:
@@ -113,17 +116,6 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
                             SmithyCoreSubmodules.CHECKSUM
                         );
                         writer.write("streamHasher");
-                    },
-                    "md5",
-                    writer -> {
-                        writer.addDependency(TypeScriptDependency.SMITHY_CORE);
-                        writer.addImportSubmodule(
-                            "Md5",
-                            null,
-                            TypeScriptDependency.SMITHY_CORE,
-                            SmithyCoreSubmodules.CHECKSUM
-                        );
-                        writer.write("Md5");
                     }
                 );
             default:


### PR DESCRIPTION
Because runtimeConfig.shared.ts now uses the universal Sha256 impl which uses the native adapter if available, the node runtimeConfig no longer needs to set a value.