### PR TITLE
feat(codegen): generate thinner command classes

### DIFF
--- a/.changeset/smart-oranges-scream.md
+++ b/.changeset/smart-oranges-scream.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+add internal higher order factory for Command classes

--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -135,6 +135,7 @@
     "isSerializableHeaderValue": "function",
     "LazyValueInstruction": "type(object)",
     "loadConfigsForDefaultMode": "function",
+    "makeBuilder": "function",
     "map": "function",
     "NoOpLogger": "function",
     "normalizeProvider": "function",

--- a/packages/core/src/submodules/client/index.ts
+++ b/packages/core/src/submodules/client/index.ts
@@ -85,3 +85,4 @@ export {
 export { schemaLogFilter } from "./smithy-client/schemaLogFilter";
 export { serializeFloat, serializeDateTime } from "./smithy-client/ser-utils";
 export { _json } from "./smithy-client/serde-json";
+export { makeBuilder } from "./smithy-client/client-command-builder";

--- a/packages/core/src/submodules/client/smithy-client/client-command-builder.spec.ts
+++ b/packages/core/src/submodules/client/smithy-client/client-command-builder.spec.ts
@@ -1,0 +1,285 @@
+import { SMITHY_CONTEXT_KEY, type MetadataBearer, type StaticOperationSchema } from "@smithy/types";
+import { describe, expect, test as it, vi } from "vitest";
+
+import { makeBuilder } from "./client-command-builder";
+import { Command } from "./command";
+
+describe(makeBuilder.name, () => {
+  const commonParams = {
+    Region: { type: "builtInParams", name: "region" },
+    Endpoint: { type: "builtInParams", name: "endpoint" },
+  };
+  const serviceShapeName = "MyService";
+  const sdkClientName = "MyServiceClient";
+  const mockEndpointPlugin = vi.fn().mockReturnValue({ applyToStack: vi.fn() });
+
+  const operationSchema: StaticOperationSchema = [9, "com.example#", "GetItem", {}, "unit", "unit"];
+
+  it("returns a command factory function", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+    expect(typeof command).toBe("function");
+  });
+
+  it("creates a Command class from the factory", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+
+    const CommandClass = command({}, () => [], "GetItem", operationSchema);
+
+    const instance = new CommandClass({ key: "value" });
+    expect(instance).toBeInstanceOf(Command);
+    expect(instance.input).toEqual({ key: "value" });
+  });
+
+  it("merges commonParams and operation-specific params in endpoint parameter instructions", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+    const operationParams = {
+      BucketName: { type: "contextParams", name: "Bucket" },
+    };
+
+    const CommandClass = command(operationParams, () => [], "GetItem", operationSchema);
+
+    expect(CommandClass.getEndpointParameterInstructions()).toEqual({
+      Region: { type: "builtInParams", name: "region" },
+      Endpoint: { type: "builtInParams", name: "endpoint" },
+      BucketName: { type: "contextParams", name: "Bucket" },
+    });
+  });
+
+  it("operation-specific params override common params", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+    const operationParams = {
+      Region: { type: "contextParams", name: "overrideRegion" },
+    };
+
+    const CommandClass = command(operationParams, () => [], "GetItem", operationSchema);
+
+    expect(CommandClass.getEndpointParameterInstructions()).toEqual({
+      Region: { type: "contextParams", name: "overrideRegion" },
+      Endpoint: { type: "builtInParams", name: "endpoint" },
+    });
+  });
+
+  it("sets the service and operation names in the smithy context", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+    const middlewareFn = vi.fn().mockReturnValue([]);
+
+    const CommandClass = command({}, middlewareFn, "GetItem", operationSchema, { authSchemes: [] });
+
+    const instance = new CommandClass({});
+
+    const mockStack = {
+      concat: () => ({
+        resolve: (handler: any, ctx: any) => {
+          expect(ctx.commandName).toBe("GetItemCommand");
+          expect(ctx[SMITHY_CONTEXT_KEY]).toMatchObject({
+            service: serviceShapeName,
+            operation: "GetItem",
+            authSchemes: [],
+          });
+          return vi.fn();
+        },
+      }),
+    };
+
+    instance.resolveMiddleware(mockStack as any, { logger: {} as any, requestHandler: { handle: vi.fn() } }, {});
+  });
+
+  it("sets the client name and command name identifiers", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+    const middlewareFn = vi.fn().mockReturnValue([]);
+
+    const CommandClass = command({}, middlewareFn, "PutItem", operationSchema);
+
+    const instance = new CommandClass({});
+
+    const mockStack = {
+      concat: () => ({
+        resolve: (handler: any, ctx: any) => {
+          expect(ctx.commandName).toBe("PutItemCommand");
+          return vi.fn();
+        },
+      }),
+    };
+
+    instance.resolveMiddleware(mockStack as any, { logger: {} as any, requestHandler: { handle: vi.fn() } }, {});
+  });
+
+  it("capitalizes the operation shape name in the command name", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+    const middlewareFn = vi.fn().mockReturnValue([]);
+
+    const CommandClass = command({}, middlewareFn, "camelCaseOperation", operationSchema);
+
+    const instance = new CommandClass({});
+
+    const mockStack = {
+      concat: () => ({
+        resolve: (handler: any, ctx: any) => {
+          expect(ctx.commandName).toBe("CamelCaseOperationCommand");
+          return vi.fn();
+        },
+      }),
+    };
+
+    instance.resolveMiddleware(mockStack as any, { logger: {} as any, requestHandler: { handle: vi.fn() } }, {});
+  });
+
+  it("passes the middleware function which receives CommandCtor, clientStack, config, and options", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+    const middlewareFn = vi.fn().mockReturnValue([]);
+
+    const CommandClass = command({}, middlewareFn, "GetItem", operationSchema);
+
+    const instance = new CommandClass({});
+    const config = { logger: {} as any, requestHandler: { handle: vi.fn() } };
+    const options = { requestTimeout: 3000 };
+
+    const mockStack = {
+      concat: () => ({
+        resolve: () => vi.fn(),
+      }),
+    };
+
+    instance.resolveMiddleware(mockStack as any, config, options);
+
+    expect(middlewareFn).toHaveBeenCalledWith(CommandClass, mockStack, config, options);
+  });
+
+  it("attaches the operation schema to the command instance", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+
+    const CommandClass = command({}, () => [], "GetItem", operationSchema);
+
+    const instance = new CommandClass({});
+    expect(instance.schema).toBe(operationSchema);
+  });
+
+  it("allows empty input", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+
+    const CommandClass = command({}, () => [], "GetItem", operationSchema);
+
+    const instance = new CommandClass();
+    expect(instance.input).toEqual({});
+  });
+
+  it("supports creating multiple different command classes from the same builder", () => {
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, mockEndpointPlugin);
+
+    const GetItemCommand = command({}, () => [], "GetItem", operationSchema);
+    const putSchema: StaticOperationSchema = [9, "com.example#", "PutItem", {}, "unit", "unit"];
+    const PutItemCommand = command(
+      { TableName: { type: "contextParams", name: "Table" } },
+      () => [],
+      "PutItem",
+      putSchema
+    );
+
+    const getInst = new GetItemCommand({ id: "1" });
+    const putInst = new PutItemCommand({ data: "hello" });
+
+    expect(getInst).toBeInstanceOf(Command);
+    expect(putInst).toBeInstanceOf(Command);
+    expect(getInst.input).toEqual({ id: "1" });
+    expect(putInst.input).toEqual({ data: "hello" });
+
+    expect(GetItemCommand.getEndpointParameterInstructions()).toEqual(commonParams);
+    expect(PutItemCommand.getEndpointParameterInstructions()).toEqual({
+      ...commonParams,
+      TableName: { type: "contextParams", name: "Table" },
+    });
+  });
+
+  it("automatically prepends the endpoint plugin before user plugins", () => {
+    const epPlugin = { applyToStack: vi.fn() };
+    const ep = vi.fn().mockReturnValue(epPlugin);
+    const userPlugin = { applyToStack: vi.fn() };
+    const middlewareFn = vi.fn().mockReturnValue([userPlugin]);
+
+    const command = makeBuilder(commonParams, serviceShapeName, sdkClientName, ep);
+    const CommandClass = command({}, middlewareFn, "GetItem", operationSchema);
+
+    const instance = new CommandClass({});
+    const usedPlugins: any[] = [];
+    vi.spyOn(instance.middlewareStack, "use").mockImplementation((p: any) => {
+      usedPlugins.push(p);
+    });
+
+    const mockStack = {
+      concat: () => ({
+        resolve: () => vi.fn(),
+      }),
+    };
+
+    instance.resolveMiddleware(mockStack as any, { requestHandler: { handle: vi.fn() } }, {});
+
+    expect(ep).toHaveBeenCalledWith(expect.objectContaining({ requestHandler: expect.anything() }), commonParams);
+    expect(usedPlugins[0]).toBe(epPlugin);
+    expect(usedPlugins[1]).toBe(userPlugin);
+  });
+
+  it("requires constructor argument when input has required fields", () => {
+    type RequiredInput = {
+      key: string | undefined;
+      optional?: string;
+    };
+    type TestOutput = MetadataBearer;
+    type TestConfig = { logger?: any; requestHandler: { handle: any } };
+
+    const command = makeBuilder<TestConfig, RequiredInput, TestOutput>(
+      commonParams,
+      serviceShapeName,
+      sdkClientName,
+      mockEndpointPlugin
+    );
+
+    const CommandClass = command<RequiredInput, TestOutput>({}, () => [], "GetItem", operationSchema);
+
+    // Constructing with required input works.
+    const instance = new CommandClass({ key: "value" });
+    expect(instance).toBeInstanceOf(Command);
+    expect(instance.input).toEqual({ key: "value" });
+
+    // Type-level assertion: RequiredInput commands do NOT accept zero arguments.
+    // The following would be a type error if uncommented:
+    // new CommandClass(); // <-- TS2554: Expected 1 arguments, but got 0.
+
+    // Verify at type level using conditional types.
+    type CtorParams = ConstructorParameters<typeof CommandClass>;
+    type IsOptional = [] extends CtorParams ? true : false;
+    const assertNotOptional: IsOptional = false as const;
+    void assertNotOptional;
+  });
+
+  it("allows omitting constructor argument when input has only optional fields", () => {
+    type OptionalInput = {
+      key?: string;
+      optional?: string;
+    };
+    type TestOutput = MetadataBearer;
+    type TestConfig = { logger?: any; requestHandler: { handle: any } };
+
+    const command = makeBuilder<TestConfig, OptionalInput, TestOutput>(
+      commonParams,
+      serviceShapeName,
+      sdkClientName,
+      mockEndpointPlugin
+    );
+
+    const CommandClass = command<OptionalInput, TestOutput>({}, () => [], "GetItem", operationSchema);
+
+    // Constructing with no arguments works.
+    const instance = new CommandClass();
+    expect(instance).toBeInstanceOf(Command);
+
+    // Constructing with an argument also works.
+    const instance2 = new CommandClass({ key: "hello" });
+    expect(instance2.input).toEqual({ key: "hello" });
+
+    // Verify at type level that zero args is accepted.
+    type CtorParams = ConstructorParameters<typeof CommandClass>;
+    type IsOptional = [] extends CtorParams ? true : false;
+    const assertOptional: IsOptional = true as const;
+    void assertOptional;
+  });
+});

--- a/packages/core/src/submodules/client/smithy-client/client-command-builder.ts
+++ b/packages/core/src/submodules/client/smithy-client/client-command-builder.ts
@@ -1,0 +1,66 @@
+import type {
+  Logger,
+  MetadataBearer,
+  OptionalParameter,
+  Pluggable,
+  RequestHandler,
+  StaticOperationSchema,
+} from "@smithy/types";
+
+import { Command, type CommandImpl } from "./command";
+
+/**
+ * Higher order factory for Command builders specific to a client.
+ * Produces a command factory that creates Command classes with
+ * pre-configured endpoint params, middleware, and schema.
+ *
+ * @param common - common endpoint params.
+ * @param service - service shape name.
+ * @param name - SDK Client Name.
+ * @param ep - endpoint plugin provider.
+ *
+ * @internal
+ */
+export function makeBuilder<
+  C extends { logger?: Logger; requestHandler: RequestHandler<any, any, any> },
+  SI extends object,
+  SO extends MetadataBearer,
+>(
+  common: Record<string, unknown>,
+  service: string,
+  name: string,
+  ep: (config: any, instructions: any) => Pluggable<any, any>
+) {
+  /**
+   * @param added - additional endpoint params.
+   * @param plugins - customization plugins.
+   * @param op - operation shape name.
+   * @param $ - operation schema.
+   * @param smithyContext
+   * @internal
+   */
+  return function makeCommand<I extends SI, O extends SO>(
+    added: typeof common,
+    plugins: (CommandCtor: any, clientStack: any, config: any, options: any) => Pluggable<any, any>[],
+    op: string,
+    $: StaticOperationSchema,
+    smithyContext: Record<string, unknown> = {}
+  ): {
+    new (input: I): CommandImpl<I, O, C, SI, SO>;
+    new (...[input]: OptionalParameter<I>): CommandImpl<I, O, C, SI, SO>;
+    getEndpointParameterInstructions(): Record<string, unknown>;
+  } {
+    const epMerged = Object.assign({}, common, added);
+    return Command.classBuilder<I, O, C, SI, SO>()
+      .ep(epMerged)
+      .m(function (this: any, CommandCtor: any, clientStack: any, config: any, options: any) {
+        const list = plugins.call(this, CommandCtor, clientStack, config, options);
+        list.unshift(ep(config, CommandCtor.getEndpointParameterInstructions()));
+        return list;
+      })
+      .s(service, op, smithyContext)
+      .n(name, op.charAt(0).toUpperCase() + op.slice(1) + "Command")
+      .sc($)
+      .build() as any;
+  };
+}

--- a/packages/core/src/submodules/client/smithy-client/command.ts
+++ b/packages/core/src/submodules/client/smithy-client/command.ts
@@ -47,7 +47,7 @@ export abstract class Command<
   public static classBuilder<
     I extends SI,
     O extends SO,
-    C extends { logger: Logger; requestHandler: RequestHandler<any, any, any> },
+    C extends { logger?: Logger; requestHandler: RequestHandler<any, any, any> },
     SI extends object = any,
     SO extends MetadataBearer = any,
   >() {
@@ -65,7 +65,7 @@ export abstract class Command<
    */
   public resolveMiddlewareWithContext(
     clientStack: IMiddlewareStack<any, any>,
-    configuration: { logger: Logger; requestHandler: RequestHandler<any, any, any> },
+    configuration: { logger?: Logger; requestHandler: RequestHandler<any, any, any> },
     options: any,
     {
       middlewareFn,
@@ -130,7 +130,7 @@ type ResolveMiddlewareContextArgs = {
 class ClassBuilder<
   I extends SI,
   O extends SO,
-  C extends { logger: Logger; requestHandler: RequestHandler<any, any, any> },
+  C extends { logger?: Logger; requestHandler: RequestHandler<any, any, any> },
   SI extends object = any,
   SO extends MetadataBearer = any,
 > {
@@ -315,7 +315,7 @@ class ClassBuilder<
 export interface CommandImpl<
   I extends SI,
   O extends SO,
-  C extends { logger: Logger; requestHandler: RequestHandler<any, any, any> },
+  C extends { logger?: Logger; requestHandler: RequestHandler<any, any, any> },
   SI extends object = any,
   SO extends MetadataBearer = any,
 > extends Command<I, O, C, SI, SO> {

--- a/private/my-local-model-schema/src/commandBuilder.ts
+++ b/private/my-local-model-schema/src/commandBuilder.ts
@@ -1,0 +1,30 @@
+// smithy-typescript generated code
+import { makeBuilder } from "@smithy/core/client";
+import { getEndpointPlugin } from "@smithy/core/endpoints";
+
+import { commonParams } from "./endpoint/EndpointParameters";
+import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "./XYZServiceClient";
+
+
+/**
+ * @internal
+ */
+export const command = makeBuilder<XYZServiceClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>(commonParams, "XYZService", "XYZServiceClient", getEndpointPlugin);
+
+/**
+ * @internal
+ */
+export const _ep0 = {};
+
+/**
+ * @internal
+ */
+export const _ep1 = {
+  CustomHeaderValue: { type: "contextParams", name: "customHeaderInput" },
+};
+
+/**
+ * @internal
+ */
+export const _mw0 = (Command: any, cs: any, config: any, o: any) => [
+];

--- a/private/my-local-model-schema/src/commands/CamelCaseOperationCommand.ts
+++ b/private/my-local-model-schema/src/commands/CamelCaseOperationCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { CamelCaseOperationInput, CamelCaseOperationOutput } from "../models/models_0";
 import { camelCaseOperation$ } from "../schemas/schemas_0";
-import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -64,22 +60,12 @@ export interface CamelCaseOperationCommandOutput extends CamelCaseOperationOutpu
  *
  *
  */
-export class CamelCaseOperationCommand extends $Command
-  .classBuilder<
-    CamelCaseOperationCommandInput,
-    CamelCaseOperationCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("XYZService", "camelCaseOperation", {})
-  .n("XYZServiceClient", "CamelCaseOperationCommand")
-  .sc(camelCaseOperation$)
-  .build() {
+export class CamelCaseOperationCommand extends command<CamelCaseOperationCommandInput, CamelCaseOperationCommandOutput>(
+  _ep0,
+  _mw0,
+  "camelCaseOperation",
+  camelCaseOperation$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/my-local-model-schema/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model-schema/src/commands/GetNumbersCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep1, _mw0, command } from "../commandBuilder";
 import type { GetNumbersRequest, GetNumbersResponse } from "../models/models_0";
 import { GetNumbers$ } from "../schemas/schemas_0";
-import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -103,25 +99,12 @@ export interface GetNumbersCommandOutput extends GetNumbersResponse, __MetadataB
  *
  *
  */
-export class GetNumbersCommand extends $Command
-  .classBuilder<
-    GetNumbersCommandInput,
-    GetNumbersCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep({
-    ...commonParams,
-    CustomHeaderValue: { type: "contextParams", name: "customHeaderInput" },
-  })
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("XYZService", "GetNumbers", {})
-  .n("XYZServiceClient", "GetNumbersCommand")
-  .sc(GetNumbers$)
-  .build() {
+export class GetNumbersCommand extends command<GetNumbersCommandInput, GetNumbersCommandOutput>(
+  _ep1,
+  _mw0,
+  "GetNumbers",
+  GetNumbers$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/my-local-model-schema/src/commands/HostPrefixOperationCommand.ts
+++ b/private/my-local-model-schema/src/commands/HostPrefixOperationCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { HostPrefixOperationInput } from "../models/models_0";
 import { HostPrefixOperation$ } from "../schemas/schemas_0";
-import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -59,22 +55,12 @@ export interface HostPrefixOperationCommandOutput extends __MetadataBearer {}
  *
  *
  */
-export class HostPrefixOperationCommand extends $Command
-  .classBuilder<
-    HostPrefixOperationCommandInput,
-    HostPrefixOperationCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("XYZService", "HostPrefixOperation", {})
-  .n("XYZServiceClient", "HostPrefixOperationCommand")
-  .sc(HostPrefixOperation$)
-  .build() {
+export class HostPrefixOperationCommand extends command<HostPrefixOperationCommandInput, HostPrefixOperationCommandOutput>(
+  _ep0,
+  _mw0,
+  "HostPrefixOperation",
+  HostPrefixOperation$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/my-local-model-schema/src/commands/HttpLabelCommandCommand.ts
+++ b/private/my-local-model-schema/src/commands/HttpLabelCommandCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { HttpLabelCommandInput, HttpLabelCommandOutput } from "../models/models_0";
 import { HttpLabelCommand$ } from "../schemas/schemas_0";
-import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -59,22 +55,12 @@ export interface HttpLabelCommandCommandOutput extends HttpLabelCommandOutput, _
  *
  *
  */
-export class HttpLabelCommandCommand extends $Command
-  .classBuilder<
-    HttpLabelCommandCommandInput,
-    HttpLabelCommandCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("XYZService", "HttpLabelCommand", {})
-  .n("XYZServiceClient", "HttpLabelCommandCommand")
-  .sc(HttpLabelCommand$)
-  .build() {
+export class HttpLabelCommandCommand extends command<HttpLabelCommandCommandInput, HttpLabelCommandCommandOutput>(
+  _ep0,
+  _mw0,
+  "HttpLabelCommand",
+  HttpLabelCommand$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { TradeEventStreamRequest, TradeEventStreamResponse } from "../models/models_0";
 import { TradeEventStream$ } from "../schemas/schemas_0";
-import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedConfig } from "../XYZServiceClient";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -83,30 +79,12 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  *
  *
  */
-export class TradeEventStreamCommand extends $Command
-  .classBuilder<
-    TradeEventStreamCommandInput,
-    TradeEventStreamCommandOutput,
-    XYZServiceClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("XYZService", "TradeEventStream", {
-    /**
-     * @internal
-     */
-    eventStream: {
-      input: true,
-      output: true,
-    },
-  })
-  .n("XYZServiceClient", "TradeEventStreamCommand")
-  .sc(TradeEventStream$)
-  .build() {
+export class TradeEventStreamCommand extends command<TradeEventStreamCommandInput, TradeEventStreamCommandOutput>(
+  _ep0,
+  _mw0,
+  "TradeEventStream",
+  TradeEventStream$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/my-local-model-schema/src/index.ts
+++ b/private/my-local-model-schema/src/index.ts
@@ -11,6 +11,7 @@ export type { ClientInputEndpointParameters } from "./endpoint/EndpointParameter
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
+export { Command as $Command } from "@smithy/core/client";
 export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";

--- a/private/my-local-model/src/commands/CamelCaseOperationCommand.ts
+++ b/private/my-local-model/src/commands/CamelCaseOperationCommand.ts
@@ -13,7 +13,6 @@ import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedCon
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/my-local-model/src/commands/GetNumbersCommand.ts
+++ b/private/my-local-model/src/commands/GetNumbersCommand.ts
@@ -13,7 +13,6 @@ import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedCon
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/my-local-model/src/commands/HostPrefixOperationCommand.ts
+++ b/private/my-local-model/src/commands/HostPrefixOperationCommand.ts
@@ -13,7 +13,6 @@ import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedCon
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/my-local-model/src/commands/HttpLabelCommandCommand.ts
+++ b/private/my-local-model/src/commands/HttpLabelCommandCommand.ts
@@ -13,7 +13,6 @@ import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedCon
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/my-local-model/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model/src/commands/TradeEventStreamCommand.ts
@@ -18,7 +18,6 @@ import type { ServiceInputTypes, ServiceOutputTypes, XYZServiceClientResolvedCon
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/my-local-model/src/index.ts
+++ b/private/my-local-model/src/index.ts
@@ -11,6 +11,7 @@ export type { ClientInputEndpointParameters } from "./endpoint/EndpointParameter
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { XYZServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
+export { Command as $Command } from "@smithy/core/client";
 export * from "./pagination";
 export * from "./waiters";
 

--- a/private/smithy-rpcv2-cbor-schema/src/commandBuilder.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commandBuilder.ts
@@ -1,0 +1,23 @@
+// smithy-typescript generated code
+import { makeBuilder } from "@smithy/core/client";
+import { getEndpointPlugin } from "@smithy/core/endpoints";
+
+import { commonParams } from "./endpoint/EndpointParameters";
+import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "./RpcV2ProtocolClient";
+
+
+/**
+ * @internal
+ */
+export const command = makeBuilder<RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>(commonParams, "RpcV2Protocol", "RpcV2ProtocolClient", getEndpointPlugin);
+
+/**
+ * @internal
+ */
+export const _ep0 = {};
+
+/**
+ * @internal
+ */
+export const _mw0 = (Command: any, cs: any, config: any, o: any) => [
+];

--- a/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { EmptyStructure } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { EmptyInputOutput$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -55,22 +51,12 @@ export interface EmptyInputOutputCommandOutput extends EmptyStructure, __Metadat
  *
  *
  */
-export class EmptyInputOutputCommand extends $Command
-  .classBuilder<
-    EmptyInputOutputCommandInput,
-    EmptyInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "EmptyInputOutput", {})
-  .n("RpcV2ProtocolClient", "EmptyInputOutputCommand")
-  .sc(EmptyInputOutput$)
-  .build() {
+export class EmptyInputOutputCommand extends command<EmptyInputOutputCommandInput, EmptyInputOutputCommandOutput>(
+  _ep0,
+  _mw0,
+  "EmptyInputOutput",
+  EmptyInputOutput$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { Float16Output } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { Float16$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -57,22 +53,12 @@ export interface Float16CommandOutput extends Float16Output, __MetadataBearer {}
  *
  *
  */
-export class Float16Command extends $Command
-  .classBuilder<
-    Float16CommandInput,
-    Float16CommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "Float16", {})
-  .n("RpcV2ProtocolClient", "Float16Command")
-  .sc(Float16$)
-  .build() {
+export class Float16Command extends command<Float16CommandInput, Float16CommandOutput>(
+  _ep0,
+  _mw0,
+  "Float16",
+  Float16$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { FractionalSecondsOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { FractionalSeconds$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -57,22 +53,12 @@ export interface FractionalSecondsCommandOutput extends FractionalSecondsOutput,
  *
  *
  */
-export class FractionalSecondsCommand extends $Command
-  .classBuilder<
-    FractionalSecondsCommandInput,
-    FractionalSecondsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "FractionalSeconds", {})
-  .n("RpcV2ProtocolClient", "FractionalSecondsCommand")
-  .sc(FractionalSeconds$)
-  .build() {
+export class FractionalSecondsCommand extends command<FractionalSecondsCommandInput, FractionalSecondsCommandOutput>(
+  _ep0,
+  _mw0,
+  "FractionalSeconds",
+  FractionalSeconds$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { GreetingWithErrorsOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { GreetingWithErrors$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -70,22 +66,12 @@ export interface GreetingWithErrorsCommandOutput extends GreetingWithErrorsOutpu
  *
  * @public
  */
-export class GreetingWithErrorsCommand extends $Command
-  .classBuilder<
-    GreetingWithErrorsCommandInput,
-    GreetingWithErrorsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "GreetingWithErrors", {})
-  .n("RpcV2ProtocolClient", "GreetingWithErrorsCommand")
-  .sc(GreetingWithErrors$)
-  .build() {
+export class GreetingWithErrorsCommand extends command<GreetingWithErrorsCommandInput, GreetingWithErrorsCommandOutput>(
+  _ep0,
+  _mw0,
+  "GreetingWithErrors",
+  GreetingWithErrors$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
@@ -1,17 +1,13 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import { NoInputOutput$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -54,22 +50,12 @@ export interface NoInputOutputCommandOutput extends __MetadataBearer {}
  *
  *
  */
-export class NoInputOutputCommand extends $Command
-  .classBuilder<
-    NoInputOutputCommandInput,
-    NoInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "NoInputOutput", {})
-  .n("RpcV2ProtocolClient", "NoInputOutputCommand")
-  .sc(NoInputOutput$)
-  .build() {
+export class NoInputOutputCommand extends command<NoInputOutputCommandInput, NoInputOutputCommandOutput>(
+  _ep0,
+  _mw0,
+  "NoInputOutput",
+  NoInputOutput$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { OperationWithDefaultsInput, OperationWithDefaultsOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { OperationWithDefaults$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -123,22 +119,12 @@ export interface OperationWithDefaultsCommandOutput extends OperationWithDefault
  *
  *
  */
-export class OperationWithDefaultsCommand extends $Command
-  .classBuilder<
-    OperationWithDefaultsCommandInput,
-    OperationWithDefaultsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "OperationWithDefaults", {})
-  .n("RpcV2ProtocolClient", "OperationWithDefaultsCommand")
-  .sc(OperationWithDefaults$)
-  .build() {
+export class OperationWithDefaultsCommand extends command<OperationWithDefaultsCommandInput, OperationWithDefaultsCommandOutput>(
+  _ep0,
+  _mw0,
+  "OperationWithDefaults",
+  OperationWithDefaults$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { SimpleStructure } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { OptionalInputOutput$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -59,22 +55,12 @@ export interface OptionalInputOutputCommandOutput extends SimpleStructure, __Met
  *
  *
  */
-export class OptionalInputOutputCommand extends $Command
-  .classBuilder<
-    OptionalInputOutputCommandInput,
-    OptionalInputOutputCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "OptionalInputOutput", {})
-  .n("RpcV2ProtocolClient", "OptionalInputOutputCommand")
-  .sc(OptionalInputOutput$)
-  .build() {
+export class OptionalInputOutputCommand extends command<OptionalInputOutputCommandInput, OptionalInputOutputCommandOutput>(
+  _ep0,
+  _mw0,
+  "OptionalInputOutput",
+  OptionalInputOutput$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { RecursiveShapesInputOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { RecursiveShapes$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -83,22 +79,12 @@ export interface RecursiveShapesCommandOutput extends RecursiveShapesInputOutput
  *
  *
  */
-export class RecursiveShapesCommand extends $Command
-  .classBuilder<
-    RecursiveShapesCommandInput,
-    RecursiveShapesCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "RecursiveShapes", {})
-  .n("RpcV2ProtocolClient", "RecursiveShapesCommand")
-  .sc(RecursiveShapes$)
-  .build() {
+export class RecursiveShapesCommand extends command<RecursiveShapesCommandInput, RecursiveShapesCommandOutput>(
+  _ep0,
+  _mw0,
+  "RecursiveShapes",
+  RecursiveShapes$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { RpcV2CborDenseMapsInputOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { RpcV2CborDenseMaps$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -100,22 +96,12 @@ export interface RpcV2CborDenseMapsCommandOutput extends RpcV2CborDenseMapsInput
  *
  * @public
  */
-export class RpcV2CborDenseMapsCommand extends $Command
-  .classBuilder<
-    RpcV2CborDenseMapsCommandInput,
-    RpcV2CborDenseMapsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "RpcV2CborDenseMaps", {})
-  .n("RpcV2ProtocolClient", "RpcV2CborDenseMapsCommand")
-  .sc(RpcV2CborDenseMaps$)
-  .build() {
+export class RpcV2CborDenseMapsCommand extends command<RpcV2CborDenseMapsCommandInput, RpcV2CborDenseMapsCommandOutput>(
+  _ep0,
+  _mw0,
+  "RpcV2CborDenseMaps",
+  RpcV2CborDenseMaps$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { RpcV2CborListInputOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { RpcV2CborLists$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -138,22 +134,12 @@ export interface RpcV2CborListsCommandOutput extends RpcV2CborListInputOutput, _
  *
  * @public
  */
-export class RpcV2CborListsCommand extends $Command
-  .classBuilder<
-    RpcV2CborListsCommandInput,
-    RpcV2CborListsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "RpcV2CborLists", {})
-  .n("RpcV2ProtocolClient", "RpcV2CborListsCommand")
-  .sc(RpcV2CborLists$)
-  .build() {
+export class RpcV2CborListsCommand extends command<RpcV2CborListsCommandInput, RpcV2CborListsCommandOutput>(
+  _ep0,
+  _mw0,
+  "RpcV2CborLists",
+  RpcV2CborLists$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { RpcV2CborSparseMapsInputOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { RpcV2CborSparseMaps$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -100,22 +96,12 @@ export interface RpcV2CborSparseMapsCommandOutput extends RpcV2CborSparseMapsInp
  *
  *
  */
-export class RpcV2CborSparseMapsCommand extends $Command
-  .classBuilder<
-    RpcV2CborSparseMapsCommandInput,
-    RpcV2CborSparseMapsCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "RpcV2CborSparseMaps", {})
-  .n("RpcV2ProtocolClient", "RpcV2CborSparseMapsCommand")
-  .sc(RpcV2CborSparseMaps$)
-  .build() {
+export class RpcV2CborSparseMapsCommand extends command<RpcV2CborSparseMapsCommandInput, RpcV2CborSparseMapsCommandOutput>(
+  _ep0,
+  _mw0,
+  "RpcV2CborSparseMaps",
+  RpcV2CborSparseMaps$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { SimpleScalarStructure } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { SimpleScalarProperties$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -77,22 +73,12 @@ export interface SimpleScalarPropertiesCommandOutput extends SimpleScalarStructu
  *
  *
  */
-export class SimpleScalarPropertiesCommand extends $Command
-  .classBuilder<
-    SimpleScalarPropertiesCommandInput,
-    SimpleScalarPropertiesCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "SimpleScalarProperties", {})
-  .n("RpcV2ProtocolClient", "SimpleScalarPropertiesCommand")
-  .sc(SimpleScalarProperties$)
-  .build() {
+export class SimpleScalarPropertiesCommand extends command<SimpleScalarPropertiesCommandInput, SimpleScalarPropertiesCommandOutput>(
+  _ep0,
+  _mw0,
+  "SimpleScalarProperties",
+  SimpleScalarProperties$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
@@ -1,18 +1,14 @@
 // smithy-typescript generated code
-import { Command as $Command } from "@smithy/core/client";
-import { getEndpointPlugin } from "@smithy/core/endpoints";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { commonParams } from "../endpoint/EndpointParameters";
+import { _ep0, _mw0, command } from "../commandBuilder";
 import type { SparseNullsOperationInputOutput } from "../models/models_0";
-import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RpcV2ProtocolClient";
 import { SparseNullsOperation$ } from "../schemas/schemas_0";
 
 /**
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *
@@ -69,22 +65,12 @@ export interface SparseNullsOperationCommandOutput extends SparseNullsOperationI
  *
  *
  */
-export class SparseNullsOperationCommand extends $Command
-  .classBuilder<
-    SparseNullsOperationCommandInput,
-    SparseNullsOperationCommandOutput,
-    RpcV2ProtocolClientResolvedConfig,
-    ServiceInputTypes,
-    ServiceOutputTypes
-  >()
-  .ep(commonParams)
-  .m(function (this: any, Command: any, cs: any, config: RpcV2ProtocolClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
-  })
-  .s("RpcV2Protocol", "SparseNullsOperation", {})
-  .n("RpcV2ProtocolClient", "SparseNullsOperationCommand")
-  .sc(SparseNullsOperation$)
-  .build() {
+export class SparseNullsOperationCommand extends command<SparseNullsOperationCommandInput, SparseNullsOperationCommandOutput>(
+  _ep0,
+  _mw0,
+  "SparseNullsOperation",
+  SparseNullsOperation$
+) {
   /** @internal type navigation helper, not in runtime. */
   protected declare static __types: {
     api: {

--- a/private/smithy-rpcv2-cbor-schema/src/index.ts
+++ b/private/smithy-rpcv2-cbor-schema/src/index.ts
@@ -6,6 +6,7 @@ export type { ClientInputEndpointParameters } from "./endpoint/EndpointParameter
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RpcV2ProtocolExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
+export { Command as $Command } from "@smithy/core/client";
 export * from "./schemas/schemas_0";
 
 export * from "./models/enums";

--- a/private/smithy-rpcv2-cbor/src/commands/EmptyInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/EmptyInputOutputCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/Float16Command.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/Float16Command.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/FractionalSecondsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/FractionalSecondsCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/GreetingWithErrorsCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/NoInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/NoInputOutputCommand.ts
@@ -12,7 +12,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/OperationWithDefaultsCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/OptionalInputOutputCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/OptionalInputOutputCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/RecursiveShapesCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RecursiveShapesCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborListsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborListsCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/SimpleScalarPropertiesCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/commands/SparseNullsOperationCommand.ts
+++ b/private/smithy-rpcv2-cbor/src/commands/SparseNullsOperationCommand.ts
@@ -13,7 +13,6 @@ import type { RpcV2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutpu
  * @public
  */
 export type { __MetadataBearer };
-export { $Command };
 /**
  * @public
  *

--- a/private/smithy-rpcv2-cbor/src/index.ts
+++ b/private/smithy-rpcv2-cbor/src/index.ts
@@ -6,6 +6,7 @@ export type { ClientInputEndpointParameters } from "./endpoint/EndpointParameter
 export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RpcV2ProtocolExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
+export { Command as $Command } from "@smithy/core/client";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandBuilderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandBuilderGenerator.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.typescript.codegen;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.endpointsV2.RuleSetParameterFinder;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Generates the commandBuilder.ts file.
+ *
+ * <p>The file contains the higher-order command factory (via makeBuilder),
+ * deduplicated endpoint parameter sets, and deduplicated middleware functions.
+ */
+@SmithyInternalApi
+public final class CommandBuilderGenerator {
+
+    static final String COMMAND_BUILDER_FILENAME = "commandBuilder.ts";
+
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final ServiceShape service;
+    private final SymbolProvider symbolProvider;
+    private final List<RuntimeClientPlugin> runtimePlugins;
+
+    // Deduplicated endpoint params (key = code string, value = variable name)
+    private final LinkedHashMap<String, String> uniqueEndpointParams = new LinkedHashMap<>();
+    // Deduplicated middleware functions (key = code string, value = variable name)
+    private final LinkedHashMap<String, String> uniqueMiddlewares = new LinkedHashMap<>();
+
+    // operation shape name -> deduplicated variable name (e.g. "GetNumbers" -> "_ep1")
+    private final Map<String, String> operationEndpointParamVar = new HashMap<>();
+    // operation shape name -> deduplicated variable name (e.g. "GetNumbers" -> "_mw0")
+    private final Map<String, String> operationMiddlewareVar = new HashMap<>();
+
+    private int epCounter = 0;
+    private int mwCounter = 0;
+
+    public CommandBuilderGenerator(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        List<RuntimeClientPlugin> runtimePlugins
+    ) {
+        this.settings = settings;
+        this.model = model;
+        this.service = settings.getService(model);
+        this.symbolProvider = symbolProvider;
+        this.runtimePlugins = runtimePlugins;
+    }
+
+    /**
+     * Collects all operations and deduplicates their endpoint params and middleware.
+     */
+    public void collectOperations() {
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<OperationShape> operations = new TreeSet<>(
+            Comparator.comparing(op -> symbolProvider.toSymbol(op).getName())
+        );
+        operations.addAll(topDownIndex.getContainedOperations(service));
+
+        RuleSetParameterFinder parameterFinder = new RuleSetParameterFinder(service);
+
+        for (OperationShape operation : operations) {
+            String operationName = operation.toShapeId().getName();
+
+            // Build endpoint params string (only the "more" params beyond commonParams)
+            String epCode = buildEndpointParamsCode(parameterFinder, operation);
+            String epVar = uniqueEndpointParams.computeIfAbsent(epCode, k -> "_ep" + epCounter++);
+            operationEndpointParamVar.put(operationName, epVar);
+
+            // Build middleware function string
+            String mwCode = buildMiddlewareCode(operation);
+            String mwVar = uniqueMiddlewares.computeIfAbsent(mwCode, k -> "_mw" + mwCounter++);
+            operationMiddlewareVar.put(operationName, mwVar);
+        }
+    }
+
+    /**
+     * Returns the endpoint param variable name for an operation.
+     */
+    public String getEndpointParamVar(OperationShape operation) {
+        return operationEndpointParamVar.get(operation.toShapeId().getName());
+    }
+
+    /**
+     * Returns the middleware variable name for an operation.
+     */
+    public String getMiddlewareVar(OperationShape operation) {
+        return operationMiddlewareVar.get(operation.toShapeId().getName());
+    }
+
+    /**
+     * Generates the commandBuilder.ts file content.
+     */
+    public void generate(TypeScriptDelegator delegator) {
+        delegator.useFileWriter(
+            Paths.get(CodegenUtils.SOURCE_FOLDER, COMMAND_BUILDER_FILENAME).toString(),
+            writer -> generateContent(writer)
+        );
+    }
+
+    private void generateContent(TypeScriptWriter writer) {
+
+        Symbol serviceSymbol = symbolProvider.toSymbol(service);
+        String clientName = serviceSymbol.getName();
+        String serviceShapeName = service.toShapeId().getName();
+        String configType = ServiceBareBonesClientGenerator.getResolvedConfigTypeName(serviceSymbol);
+
+        writer.addImportSubmodule("makeBuilder", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
+        writer.addImportSubmodule(
+            "getEndpointPlugin",
+            null,
+            TypeScriptDependency.SMITHY_CORE,
+            SmithyCoreSubmodules.ENDPOINTS
+        );
+
+        writer.addRelativeImport(
+            "commonParams",
+            null,
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, "endpoint/EndpointParameters")
+        );
+
+        // Import client-level types for makeBuilder generic params.
+        Path servicePath = Paths.get(".", CodegenUtils.SOURCE_FOLDER, clientName);
+        writer.addRelativeTypeImport(configType, null, servicePath);
+        writer.addRelativeTypeImport("ServiceInputTypes", null, servicePath);
+        writer.addRelativeTypeImport("ServiceOutputTypes", null, servicePath);
+
+        collectPluginImports(writer);
+
+        writer.write("");
+        writer.writeDocs("@internal");
+        writer.write(
+            "export const command = makeBuilder<$L, ServiceInputTypes, ServiceOutputTypes>"
+                + "(commonParams, $S, $S, getEndpointPlugin);",
+            configType,
+            serviceShapeName,
+            clientName
+        );
+
+        writer.write("");
+        for (Map.Entry<String, String> entry : uniqueEndpointParams.entrySet()) {
+            writer.writeDocs("@internal");
+            writer.write("export const $L = $L;", entry.getValue(), entry.getKey());
+            writer.write("");
+        }
+
+        for (Map.Entry<String, String> entry : uniqueMiddlewares.entrySet()) {
+            writer.writeDocs("@internal");
+            writer.write("export const $L = $L;", entry.getValue(), entry.getKey());
+            writer.write("");
+        }
+    }
+
+    private String buildEndpointParamsCode(RuleSetParameterFinder parameterFinder, OperationShape operation) {
+        Map<String, String> staticContextParamValues = parameterFinder.getStaticContextParamValues(operation);
+        Map<String, String> contextParams = parameterFinder.getContextParams(
+            model.getShape(operation.getInputShape()).get()
+        );
+        Map<String, String> operationContextParamValues = parameterFinder.getOperationContextParamValues(operation);
+
+        if (staticContextParamValues.isEmpty() && contextParams.isEmpty() && operationContextParamValues.isEmpty()) {
+            return "{}";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+
+        Set<String> paramNames = new java.util.HashSet<>();
+        staticContextParamValues.forEach((name, value) -> {
+            paramNames.add(name);
+            sb.append("  ")
+                .append(name)
+                .append(": { type: \"staticContextParams\", value: ")
+                .append(value)
+                .append(" },\n");
+        });
+
+        contextParams.forEach((name, memberName) -> {
+            if (!paramNames.contains(name)) {
+                sb.append("  ")
+                    .append(name)
+                    .append(": { type: \"contextParams\", name: \"")
+                    .append(memberName)
+                    .append("\" },\n");
+            }
+            paramNames.add(name);
+        });
+
+        operationContextParamValues.forEach((name, jmesPathForInputInJs) -> {
+            sb.append("  ")
+                .append(name)
+                .append(": { type: \"operationContextParams\", get: (input?: any) => ")
+                .append(jmesPathForInputInJs)
+                .append(" },\n");
+        });
+
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String buildMiddlewareCode(OperationShape operation) {
+        List<RuntimeClientPlugin> operationPlugins = runtimePlugins
+            .stream()
+            .filter(plugin -> plugin.matchesOperation(model, service, operation))
+            .filter(plugin -> plugin.getPluginFunction().isPresent())
+            .collect(Collectors.toList());
+
+        // Build the plugin list body first to check for 'this' usage.
+        StringBuilder body = new StringBuilder();
+        for (RuntimeClientPlugin plugin : operationPlugins) {
+            plugin.getPluginFunction().ifPresent(pluginSymbolRef -> {
+                String pluginName = pluginSymbolRef.getAlias();
+                String params = buildPluginParams(plugin, operation);
+                body.append("  ").append(pluginName).append("(config");
+                if (!params.isEmpty()) {
+                    body.append(", ").append(params);
+                }
+                body.append("),\n");
+            });
+        }
+
+        String bodyStr = body.toString();
+        boolean usesThis = bodyStr.contains("this");
+
+        StringBuilder sb = new StringBuilder();
+        if (usesThis) {
+            sb.append("function(Command: any, cs: any, config: any, o: any) {\n  return [\n");
+        } else {
+            sb.append("(Command: any, cs: any, config: any, o: any) => [\n");
+        }
+        sb.append(bodyStr);
+        if (usesThis) {
+            sb.append("  ];\n}");
+        } else {
+            sb.append("]");
+        }
+        return sb.toString();
+    }
+
+    private String buildPluginParams(RuntimeClientPlugin plugin, OperationShape operation) {
+        Map<String, Object> additionalParams = plugin.getAdditionalPluginFunctionParameters(model, service, operation);
+        if (additionalParams == null || additionalParams.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        for (Map.Entry<String, Object> entry : additionalParams.entrySet()) {
+            sb.append("    ").append(entry.getKey()).append(": ").append(formatValue(entry.getValue())).append(",\n");
+        }
+        sb.append("  }");
+        return sb.toString();
+    }
+
+    private String formatValue(Object value) {
+        if (value instanceof String) {
+            return "\"" + value + "\"";
+        } else if (value instanceof Boolean || value instanceof Number) {
+            return value.toString();
+        } else if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            return "[" + list.stream().map(this::formatValue).collect(Collectors.joining(", ")) + "]";
+        } else if (value instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) value;
+            StringBuilder sb = new StringBuilder("{ ");
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                sb.append("\"")
+                    .append(entry.getKey())
+                    .append("\": ")
+                    .append(formatValue(entry.getValue()))
+                    .append(", ");
+            }
+            sb.append("}");
+            return sb.toString();
+        } else if (value instanceof Symbol) {
+            return ((Symbol) value).getName();
+        }
+        return String.valueOf(value);
+    }
+
+    private void collectPluginImports(TypeScriptWriter writer) {
+        Set<String> pluginNames = new java.util.HashSet<>();
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+
+        List<software.amazon.smithy.codegen.core.SymbolReference> refs = new ArrayList<>();
+
+        for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
+            for (RuntimeClientPlugin plugin : runtimePlugins) {
+                if (!plugin.matchesOperation(model, service, operation)) {
+                    continue;
+                }
+                plugin.getPluginFunction().ifPresent(pluginSymbolRef -> {
+                    String alias = pluginSymbolRef.getAlias();
+                    if (pluginNames.add(alias)) {
+                        refs.add(pluginSymbolRef);
+                    }
+                });
+            }
+        }
+
+        for (var ref : refs) {
+            Symbol sym = ref.getSymbol();
+            String from = sym.getNamespace();
+            String name = ref.getAlias();
+            for (var dep : sym.getDependencies()) {
+                writer.addDependency(dep);
+            }
+            if (from.startsWith("./")) {
+                writer.addRelativeImport(name, null, Paths.get(from));
+            } else {
+                writer.addImport(name, null, from);
+            }
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -84,6 +84,7 @@ final class CommandGenerator implements Runnable {
     private final ApplicationProtocol applicationProtocol;
     private final SensitiveDataFinder sensitiveDataFinder;
     private final ServiceClosure closure;
+    private final CommandBuilderGenerator commandBuilderGenerator;
 
     CommandGenerator(
         TypeScriptSettings settings,
@@ -94,6 +95,30 @@ final class CommandGenerator implements Runnable {
         List<RuntimeClientPlugin> runtimePlugins,
         ProtocolGenerator protocolGenerator,
         ApplicationProtocol applicationProtocol
+    ) {
+        this(
+            settings,
+            model,
+            operation,
+            symbolProvider,
+            writer,
+            runtimePlugins,
+            protocolGenerator,
+            applicationProtocol,
+            null
+        );
+    }
+
+    CommandGenerator(
+        TypeScriptSettings settings,
+        Model model,
+        OperationShape operation,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer,
+        List<RuntimeClientPlugin> runtimePlugins,
+        ProtocolGenerator protocolGenerator,
+        ApplicationProtocol applicationProtocol,
+        CommandBuilderGenerator commandBuilderGenerator
     ) {
         this.settings = settings;
         this.model = model;
@@ -107,6 +132,7 @@ final class CommandGenerator implements Runnable {
             .collect(Collectors.toList());
         this.protocolGenerator = protocolGenerator;
         this.applicationProtocol = applicationProtocol;
+        this.commandBuilderGenerator = commandBuilderGenerator;
         this.closure = ServiceClosure.of(model, service);
         sensitiveDataFinder = new SensitiveDataFinder(model);
 
@@ -119,7 +145,11 @@ final class CommandGenerator implements Runnable {
     @Override
     public void run() {
         addInputAndOutputTypes();
-        generateClientCommand();
+        if (commandBuilderGenerator != null && SchemaGenerationAllowlist.allows(service.getId(), settings)) {
+            generateClientCommandWithBuilder();
+        } else {
+            generateClientCommand();
+        }
     }
 
     private void generateClientCommand() {
@@ -282,6 +312,152 @@ final class CommandGenerator implements Runnable {
         }
 
         writer.write("}"); // class close bracket.
+    }
+
+    private void generateClientCommandWithBuilder() {
+        Symbol serviceSymbol = symbolProvider.toSymbol(service);
+        String configType = ServiceBareBonesClientGenerator.getResolvedConfigTypeName(serviceSymbol);
+
+        // Import from commandBuilder.ts
+        String epVar = commandBuilderGenerator.getEndpointParamVar(operation);
+        String mwVar = commandBuilderGenerator.getMiddlewareVar(operation);
+
+        writer.addRelativeImport(
+            "command",
+            null,
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, "commandBuilder")
+        );
+        writer.addRelativeImport(
+            epVar,
+            null,
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, "commandBuilder")
+        );
+        writer.addRelativeImport(
+            mwVar,
+            null,
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, "commandBuilder")
+        );
+
+        // Import the operation schema
+        String operationSchema = closure.getShapeSchemaVariableName(operation, null);
+        writer.addRelativeImport(
+            operationSchema,
+            null,
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, SCHEMAS_FOLDER, "schemas_0")
+        );
+
+        String name = symbol.getName();
+        String operationShapeName = operation.toShapeId().getName();
+
+        // Documentation
+        StringBuilder additionalDocs = new StringBuilder()
+            .append("\n")
+            .append(
+                getCommandExample(
+                    serviceSymbol.getName(),
+                    configType,
+                    name,
+                    inputType.getName(),
+                    outputType.getName()
+                )
+            )
+            .append("\n")
+            .append(getThrownExceptions())
+            .append("\n")
+            .append(getCuratedExamples(name));
+
+        boolean operationHasDocumentation = operation.hasTrait(DocumentationTrait.class);
+
+        if (operationHasDocumentation) {
+            writer.writeShapeDocs(operation, shapeDoc -> shapeDoc + additionalDocs);
+        } else {
+            boolean isPublic = !operation.hasTrait(InternalTrait.class);
+            boolean isDeprecated = operation.hasTrait(DeprecatedTrait.class);
+
+            String deprecatedTag = "";
+            if (isDeprecated) {
+                DeprecatedTrait deprecatedTrait = operation.expectTrait(DeprecatedTrait.class);
+                deprecatedTag = TypeScriptWriter.buildDeprecationAnnotation(deprecatedTrait) + "\n";
+            }
+
+            writer.writeDocs(
+                (isPublic ? "@public\n" : "@internal\n") + deprecatedTag + additionalDocs
+            );
+        }
+
+        // Section of items like TypeScript @ts-ignore
+        writer.injectSection(
+            PreCommandClassCodeSection.builder()
+                .settings(settings)
+                .model(model)
+                .service(service)
+                .operation(operation)
+                .symbolProvider(symbolProvider)
+                .runtimeClientPlugins(runtimePlugins)
+                .protocolGenerator(protocolGenerator)
+                .applicationProtocol(applicationProtocol)
+                .build()
+        );
+
+        // Generate: class XXXCommand extends command<I, O>(_epN, _mwN, "OpName", $schema) {}
+        writer.pushState()
+            .putContext("inputType", inputType)
+            .putContext("outputType", outputType);
+        writer.openBlock(
+            """
+            export class $L extends command<$inputType:T, $outputType:T>(
+              $L,
+              $L,
+              $S,
+              $L
+            ) {""",
+            "}",
+            name,
+            epVar,
+            mwVar,
+            operationShapeName,
+            operationSchema,
+            () -> {
+                // Type navigation helper
+                Shape operationInputShape = model.expectShape(operation.getInputShape());
+                Symbol baseInput = symbolProvider.toSymbol(operationInputShape);
+                Shape operationOutputShape = model.expectShape(operation.getOutputShape());
+                Symbol baseOutput = symbolProvider.toSymbol(operationOutputShape);
+
+                if (!operationInputShape.getAllMembers().isEmpty()) {
+                    writer.addRelativeTypeImport(baseInput.getName(), null, Path.of(baseInput.getNamespace()));
+                }
+                if (!operationOutputShape.getAllMembers().isEmpty()) {
+                    writer.addRelativeTypeImport(baseOutput.getName(), null, Path.of(baseOutput.getNamespace()));
+                }
+
+                String baseInputStr = operationInputShape.getAllMembers().isEmpty() ? "{}" : baseInput.getName();
+                String baseOutputStr = operationOutputShape.getAllMembers().isEmpty() ? "{}" : baseOutput.getName();
+
+                writer.write("/** @internal type navigation helper, not in runtime. */");
+                writer.openBlock("protected declare static __types: {", "};", () -> {
+                    writer.write(
+                        """
+                        api: {
+                          input: $L;
+                          output: $L;
+                        };""",
+                        baseInputStr,
+                        baseOutputStr
+                    );
+                    writer.write(
+                        """
+                        sdk: {
+                          input: $T;
+                          output: $T;
+                        };""",
+                        inputType,
+                        outputType
+                    );
+                });
+            }
+        );
+        writer.popState();
     }
 
     private String getCommandExample(
@@ -622,7 +798,6 @@ final class CommandGenerator implements Runnable {
     private void addInputAndOutputTypes() {
         writer.writeDocs("@public");
         writer.write("export type { __MetadataBearer };");
-        writer.write("export { $$Command };");
 
         writeInputType(inputType.getName(), operationIndex.getInput(operation), symbol.getName());
         writeOutputType(outputType.getName(), operationIndex.getOutput(operation), symbol.getName());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -656,10 +656,27 @@ final class DirectedTypeScriptCodegen
             ServerCommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
         }
 
+        // Generate commandBuilder.ts with deduplicated params and middleware (schema mode only).
+        CommandBuilderGenerator commandBuilderGenerator = null;
+        if (
+            settings.generateClient()
+                && SchemaGenerationAllowlist.allows(service.getId(), settings)
+        ) {
+            commandBuilderGenerator = new CommandBuilderGenerator(
+                settings,
+                model,
+                symbolProvider,
+                runtimePlugins
+            );
+            commandBuilderGenerator.collectOperations();
+            commandBuilderGenerator.generate(delegator);
+        }
+
         // Generate each operation for the service.
         for (OperationShape operation : directive.operations()) {
             // Right now this only generates stubs
             if (settings.generateClient()) {
+                final CommandBuilderGenerator builderGen = commandBuilderGenerator;
                 delegator.useShapeWriter(
                     operation,
                     commandWriter -> new CommandGenerator(
@@ -670,7 +687,8 @@ final class DirectedTypeScriptCodegen
                         commandWriter,
                         runtimePlugins,
                         protocolGenerator,
-                        applicationProtocol
+                        applicationProtocol,
+                        builderGen
                     ).run()
                 );
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -117,6 +117,7 @@ final class IndexGenerator {
             """
             export * from "./commands";"""
         );
+        writer.write("export { Command as $$Command } from \"@smithy/core/client\";");
         if (SchemaGenerationAllowlist.allows(service.getId(), settings)) {
             writer.write(
                 """

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
@@ -30,12 +30,14 @@ public class IndexGeneratorTest {
         );
         SymbolProvider symbolProvider = new SymbolVisitor(model, settings);
         TypeScriptWriter writer = new TypeScriptWriter("");
+        TypeScriptWriter modelIndexer = new TypeScriptWriter("");
 
-        IndexGenerator.writeIndex(settings, model, symbolProvider, null, writer, writer);
+        IndexGenerator.writeIndex(settings, model, symbolProvider, null, writer, modelIndexer);
 
         String contents = writer.toString();
         assertThat(contents, containsString("export * from \"./Example\";"));
         assertThat(contents, containsString("export * from \"./ExampleClient\";"));
         assertThat(contents, containsString("export * from \"./commands\";"));
+        assertThat(contents, containsString("export { Command as $Command } from \"@smithy/core/client\";"));
     }
 }


### PR DESCRIPTION
Generate smaller Commands like:

```ts
const _ep0 = {
    Bucket: { type: "contextParams", name: "Bucket" },
    Key: { type: "contextParams", name: "Key" },
};
const _mw0 = (Command, cs, config, o) => [
    getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
    getThrow200ExceptionsPlugin(config),
];

class AbortMultipartUploadCommand extends command(_ep0, _mw0, "AbortMultipartUpload", AbortMultipartUpload$) {
}
class GetObjectAclCommand extends command(_ep0, _mw0, "GetObjectAcl", GetObjectAcl$) {
}
class DeleteObjectCommand extends command(_ep0, _mw0, "DeleteObject", DeleteObject$) {
}
```

Where _ep0 and _mw7 are deduplicated endpoint and middleware configurations.
This is using a factoryfactory that further reduces repeated client-scoped code.

Old code (per command):

```ts
class AbortMultipartUploadCommand extends Command
    .classBuilder()
    .ep({
    ...commonParams,
    Bucket: { type: "contextParams", name: "Bucket" },
    Key: { type: "contextParams", name: "Key" },
})
    .m(function (Command, cs, config, o) {
    return [
        getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
        getThrow200ExceptionsPlugin(config),
    ];
})
    .s("AmazonS3", "AbortMultipartUpload", {})
    .n("S3Client", "AbortMultipartUploadCommand")
    .sc(AbortMultipartUpload$)
    .build() {
}
```