### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: ${{ matrix.java }}
           distribution: "corretto"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
@@ -47,20 +47,20 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "yarn"
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: ${{ matrix.java }}
           distribution: "corretto"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
@@ -79,8 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     name: TypeScript Lint
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "yarn"
@@ -99,18 +99,18 @@ jobs:
         node: [18, 20, 22, 24, 26]
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: "17"
           distribution: "corretto"
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Install dependencies
@@ -130,8 +130,8 @@ jobs:
     runs-on: smithy-typescript_ubuntu-latest_8-core
     name: Extract Docs
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "yarn"
@@ -148,8 +148,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Ensure TypeScript is formatted
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "yarn"
@@ -168,12 +168,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Ensure TypeScript packages have changesets
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         # Include full git history needed for `yarn changeset status`
         with:
           ref: ${{github.event.pull_request.head.sha}}
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "yarn"

--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -18,7 +18,7 @@ jobs:
           git_sync_source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
           git_sync_destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }}
         if: env.git_sync_source_repo && env.git_sync_destination_repo
-        uses: wei/git-sync@v3
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83 # v3.0.0
         with:
           source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
           source_branch: "main"

--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -11,8 +11,8 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "yarn"
@@ -25,7 +25,7 @@ jobs:
           echo "porcelain=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Configure AWS Credentials
         id: credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.JS_TEAM_ROLE_TO_ASSUME }}
@@ -61,7 +61,7 @@ jobs:
           yarn stage-release --concurrency=1
       - name: Release
         id: release
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         if: steps.stage.outcome == 'success'
         with:
           publish: yarn release

--- a/.github/workflows/release-npm-ssdk-libs.yml
+++ b/.github/workflows/release-npm-ssdk-libs.yml
@@ -11,8 +11,8 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "yarn"
@@ -25,7 +25,7 @@ jobs:
           echo "porcelain=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Configure AWS Credentials
         id: credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.JS_TEAM_ROLE_TO_ASSUME }}
@@ -61,7 +61,7 @@ jobs:
           yarn stage-release --concurrency=1
       - name: Release
         id: release
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         if: steps.stage.outcome == 'success'
         with:
           publish: yarn release

--- a/.github/workflows/update-smithy-gradle-plugin.yml
+++ b/.github/workflows/update-smithy-gradle-plugin.yml
@@ -14,7 +14,7 @@ jobs:
   get-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Fetch latest smithy-gradle-plugin version
         id: fetch-latest


### PR DESCRIPTION
*Issue #, if available:*

Similar to https://github.com/aws/aws-sdk-js-v3/pull/8032

*Description of changes:*

Pin every action across all workflows to an immutable commit SHA
instead of a mutable major version tag, per GitHub's guidance for
using third-party actions. The human-readable release is kept in a
trailing comment for each entry.

Each SHA resolves to the same commit the major tag pointed to, so
there is no behavioral change. Pinned actions:

- actions/checkout v7.0.0
- actions/setup-java v5.4.0
- actions/setup-node v6.4.0
- gradle/actions/setup-gradle v6.2.0
- aws-actions/configure-aws-credentials v6.2.1
- wei/git-sync v3.0.0
- changesets/action v1.9.0

Keeps SHA-pinned actions maintained by letting Dependabot open
weekly grouped PRs that advance both the pinned commit and its
version comment.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
