### PR TITLE
ci: split release into version PR and publish workflows

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,31 @@
+name: create-release-pr
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # on button click
+
+jobs:
+  version:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install
+      - name: Create Release Pull Request
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          version: yarn changeset version
+          commit: "Version NPM packages"
+          title: "Version NPM packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -1,11 +1,19 @@
 name: release-npm-packages
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch: # on button click
 
 jobs:
   release:
     name: Release TypeScript packages to NPM
+    # Only publish when the "Version NPM packages" PR is merged into main
+    # (or when triggered manually via the Run workflow button).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'Version NPM packages')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -18,11 +26,6 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn install
-      - name: Version
-        id: version
-        run: |
-          yarn changeset version
-          echo "porcelain=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Configure AWS Credentials
         id: credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
@@ -31,32 +34,8 @@ jobs:
           role-to-assume: ${{ secrets.JS_TEAM_ROLE_TO_ASSUME }}
           role-session-name: SmithyTypeScriptGitHubRelease
           audience: sts.amazonaws.com
-      - name: Configure deploy key for push
-        if: steps.version.outputs.porcelain != '0'
-        run: |
-          deploy_key=$(aws secretsmanager get-secret-value \
-            --region us-west-2 \
-            --secret-id ${{ secrets.DEPLOY_KEY_SECRET_ARN }} \
-            --query SecretString --output text)
-          echo "::add-mask::$deploy_key"
-          mkdir -p ~/.ssh
-          echo "$deploy_key" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          git remote set-url origin git@github.com:smithy-lang/smithy-typescript.git
-          git config core.sshCommand "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes"
-      - name: Commit
-        id: commit
-        if: steps.version.outputs.porcelain != '0'
-        run: |
-          git config --global user.email "github-aws-smithy-automation@amazon.com"
-          git config --global user.name "Smithy Automation"
-          git add .
-          git commit -m 'Version NPM packages'
-          git push
       - name: Stage Release
         id: stage
-        if: steps.commit.outcome == 'success'
         run: |
           yarn stage-release --concurrency=1
       - name: Release


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6949

*Description of changes:*

Add `create-release-pr.yml` which uses the changesets action to open a
"Version NPM packages" PR on push to main instead of committing version
bumps directly to the branch.

Update `release-npm-packages.yml` to publish only after that PR is merged:
it now runs on push to main (guarded by the version commit message) and
drops the version/commit/push and deploy-key steps, keeping just the
stage and publish steps.

After this PR is merged, in order to publish new versions of `@smithy/*` packages,
maintainers just need to approve PR titled "Version NPM packages" and merge it.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
