### PR TITLE
ci: skip changeset status check on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,4 +180,7 @@ jobs:
       - name: Install
         run: yarn
       - name: Ensure changesets exist for each changed package
+        # Skip on the release PR opened by the changesets action, where
+        # changesets have already been consumed by `changeset version`.
+        if: github.head_ref != 'changeset-release/main'
         run: yarn changeset status --since=origin/main


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6949

*Description of changes:*

The `ensure-typescript-packages-have-changesets` job ran
`yarn changeset status` on every PR, including the release PR opened
by the changesets action. On that PR the changeset files have already
been consumed by `changeset version` and versions bumped, so the check
reported changed packages with no changesets and failed CI.

Guard the step with `github.head_ref != 'changeset-release/main'` so it
is skipped only on the changesets release PR. Skipping the step (rather
than the whole job) keeps the job result as success, so the dependent
test-typescript job still runs.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
