### PR TITLE
ci: disable creating release PRs/publish using workflow_dispatch

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: # on button click
 
 jobs:
   version:

--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: # on button click
 
 jobs:
   release:


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6949

*Description of changes:*

In this repo, we've tested two publish attempts using pull requests:
* 7/2: https://github.com/smithy-lang/smithy-typescript/pull/2121
* 7/6: https://github.com/smithy-lang/smithy-typescript/pull/2123

We've also used changesets for 170+ releases in https://github.com/aws/aws-sdk-js-codemod

We agreed to just keep push to main for publishing, and disable workflow_dispatch which has a possibility of accidents.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
