### PR TITLE
ci: harden npm release trigger to changesets PR merge

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -1,24 +1,34 @@
 name: release-npm-packages
 
 on:
-  push:
+  # Fire when a pull request targeting main is closed. The `if` below
+  # ensures we only publish when it was actually merged AND it is the
+  # changesets release PR (see create-release-pr.yml).
+  pull_request:
     branches:
       - main
+    types:
+      - closed
 
 jobs:
   release:
     name: Release TypeScript packages to NPM
-    # Only publish when the "Version NPM packages" PR is merged into main
-    # (or when triggered manually via the Run workflow button).
+    # Only publish when the changesets "Version NPM packages" PR is merged
+    # into main.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.head_commit.message, 'Version NPM packages')
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'changeset-release/main' &&
+      github.event.pull_request.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
     steps:
+      # On a merged pull_request event the default checkout is a stale merge
+      # ref, so explicitly check out the updated main branch to publish it.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-6949

*Description of changes:*

Replace the head-commit-message check with a pull_request (closed)
trigger gated on the merge coming from the changesets release branch
and bot author. Any push could previously match the commit message
and trigger a publish.

- Trigger on pull_request closed instead of push to main
- Require merged == true, head.ref == 'changeset-release/main', and
  author github-actions[bot]
- Check out main explicitly so the merged state is published

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
