### PR TITLE
fix(core): convert string to buffer in checksumStream

### DIFF
--- a/.changeset/tricky-pigs-marry.md
+++ b/.changeset/tricky-pigs-marry.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+convert string to buffer in checksumStream

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.spec.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.spec.ts
@@ -274,6 +274,28 @@ describe(ChecksumStream.name, () => {
     });
   });
 
+  describe("string chunks", () => {
+    it("should handle string chunks from the source by converting them to Buffer", async () => {
+      const source = new Readable({
+        read() {
+          this.push("abcdefghijklm");
+          this.push("nopqrstuvwxyz");
+          this.push(null);
+        },
+      });
+
+      const checksumStream = new ChecksumStream({
+        expectedChecksum: canonicalBase64,
+        checksum: new Appender(),
+        checksumSourceLocation: "my-header",
+        source,
+      });
+
+      const collected = toUtf8(await collect(checksumStream));
+      expect(collected).toEqual(canonicalUtf8);
+    });
+  });
+
   describe("backpressure", () => {
     it("should only read from the source at the rate it is consumed", async () => {
       // for Node.js 22+ increased default highwater mark.

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
@@ -89,14 +89,13 @@ export class ChecksumStream extends Readable {
     if (this.destroyed) {
       return;
     }
-    const data = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
     try {
-      this.checksum.update(data);
+      this.checksum.update(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
     } catch (e: unknown) {
       this.destroy(e as Error);
       return;
     }
-    if (!this.push(data)) {
+    if (!this.push(chunk)) {
       this.source.pause();
     }
   };

--- a/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
+++ b/packages/core/src/submodules/serde/util-stream/checksum/ChecksumStream.ts
@@ -85,17 +85,18 @@ export class ChecksumStream extends Readable {
    * Update the checksum and forward each source chunk to the readable side,
    * pausing the source when the readable side signals backpressure.
    */
-  private onSourceData = (chunk: Buffer): void => {
+  private onSourceData = (chunk: Buffer | string): void => {
     if (this.destroyed) {
       return;
     }
+    const data = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
     try {
-      this.checksum.update(chunk);
+      this.checksum.update(data);
     } catch (e: unknown) {
       this.destroy(e as Error);
       return;
     }
-    if (!this.push(chunk)) {
+    if (!this.push(data)) {
       this.source.pause();
     }
   };


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-7042

*Description of changes:*

Convert string chunks to Buffer in `onSourceData` before passing to `checksum.update()`. Checksum [implementation](https://github.com/aws/aws-sdk-js-v3/blob/main/packages-internal/checksums/src/submodules/crc/crc32c/Crc32cJs.ts#L22) expects buffer and would miscompute when a string is given. Added unit test for string chunk handling.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
