### PR TITLE
fix: set downlevel types to be used in typescript@'<4.5'

### DIFF
--- a/.changeset/shaggy-ducks-play.md
+++ b/.changeset/shaggy-ducks-play.md
@@ -1,0 +1,7 @@
+---
+"@smithy/snapshot-testing": patch
+"@smithy/typecheck": patch
+"@smithy/types": patch
+---
+
+Set downlevel types to be used in typescript@'<4.5'

--- a/packages/snapshot-testing/package.json
+++ b/packages/snapshot-testing/package.json
@@ -41,7 +41,7 @@
     "node": ">=18.0.0"
   },
   "typesVersions": {
-    "<=4.0": {
+    "<=4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
       ]

--- a/packages/typecheck/package.json
+++ b/packages/typecheck/package.json
@@ -40,7 +40,7 @@
     "node": ">=18.0.0"
   },
   "typesVersions": {
-    "<=4.0": {
+    "<=4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
       ]

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,7 @@
     "node": ">=18.0.0"
   },
   "typesVersions": {
-    "<=4.0": {
+    "<=4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
       ]


### PR DESCRIPTION
*Issue #, if available:*

* Noticed while working on TypeScript compatibility suite in https://github.com/aws/aws-sdk-js-v3/pull/8180
* The `types` package was skipped in https://github.com/smithy-lang/smithy-typescript/pull/1906

*Description of changes:*

Sets downlevel types to be used in '<4.5'

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
