### PR TITLE
fix: run build:types:downlevel before stage-release

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -29,6 +29,10 @@
       "outputs": ["dist-types/**"],
       "dependsOn": ["prebuild", "^build:types"]
     },
+    "build:types:downlevel": {
+      "outputs": ["dist-types/ts3.4/**"],
+      "dependsOn": ["build:types"]
+    },
     "test": {
       "dependsOn": ["build", "^build"],
       "cache": false
@@ -51,7 +55,7 @@
       "cache": false
     },
     "stage-release": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build", "build:types:downlevel"]
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes: https://github.com/smithy-lang/smithy-typescript/issues/2138

*Description of changes:*

The `build:types:downlevel` step was dropped from the build pipeline in
a35b0ac4f, leaving `dist-types/ts3.4` empty in published packages while
typesVersions still references it for TypeScript <4.5 users.

Add `build:types:downlevel` as a turbo task that depends on `build:types`,
and make stage-release depend on it so downlevel declarations are
generated before packaging.

```console
$ smithy-typescript> git clean -dfx && yarn && yarn stage-release

$ smithy-typescript> ls packages/core/dist-types
index.d.ts  legacy-root-exports  normalizeProvider.d.ts  setFeature.d.ts  submodules  ts3.4

$ smithy-typescript> ls packages/core/dist-types/ts3.4
index.d.ts  legacy-root-exports  normalizeProvider.d.ts  setFeature.d.ts  submodules
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
