### PR TITLE
fix(core): add typesVersions entries for submodules

### DIFF
--- a/.changeset/pretty-peaches-kiss.md
+++ b/.changeset/pretty-peaches-kiss.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Add typesVersions entries for submodules so TypeScript <4.5 consumers resolve submodule types

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -189,6 +189,39 @@
     "<4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
+      ],
+      "cbor": [
+        "dist-types/ts3.4/submodules/cbor/index.d.ts"
+      ],
+      "checksum": [
+        "dist-types/ts3.4/submodules/checksum/index.d.ts"
+      ],
+      "client": [
+        "dist-types/ts3.4/submodules/client/index.d.ts"
+      ],
+      "config": [
+        "dist-types/ts3.4/submodules/config/index.d.ts"
+      ],
+      "endpoints": [
+        "dist-types/ts3.4/submodules/endpoints/index.d.ts"
+      ],
+      "event-streams": [
+        "dist-types/ts3.4/submodules/event-streams/index.d.ts"
+      ],
+      "protocols": [
+        "dist-types/ts3.4/submodules/protocols/index.d.ts"
+      ],
+      "retry": [
+        "dist-types/ts3.4/submodules/retry/index.d.ts"
+      ],
+      "schema": [
+        "dist-types/ts3.4/submodules/schema/index.d.ts"
+      ],
+      "serde": [
+        "dist-types/ts3.4/submodules/serde/index.d.ts"
+      ],
+      "transport": [
+        "dist-types/ts3.4/submodules/transport/index.d.ts"
       ]
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -190,38 +190,8 @@
       "dist-types/*": [
         "dist-types/ts3.4/*"
       ],
-      "cbor": [
-        "dist-types/ts3.4/submodules/cbor/index.d.ts"
-      ],
-      "checksum": [
-        "dist-types/ts3.4/submodules/checksum/index.d.ts"
-      ],
-      "client": [
-        "dist-types/ts3.4/submodules/client/index.d.ts"
-      ],
-      "config": [
-        "dist-types/ts3.4/submodules/config/index.d.ts"
-      ],
-      "endpoints": [
-        "dist-types/ts3.4/submodules/endpoints/index.d.ts"
-      ],
-      "event-streams": [
-        "dist-types/ts3.4/submodules/event-streams/index.d.ts"
-      ],
-      "protocols": [
-        "dist-types/ts3.4/submodules/protocols/index.d.ts"
-      ],
-      "retry": [
-        "dist-types/ts3.4/submodules/retry/index.d.ts"
-      ],
-      "schema": [
-        "dist-types/ts3.4/submodules/schema/index.d.ts"
-      ],
-      "serde": [
-        "dist-types/ts3.4/submodules/serde/index.d.ts"
-      ],
-      "transport": [
-        "dist-types/ts3.4/submodules/transport/index.d.ts"
+      "*": [
+        "dist-types/ts3.4/submodules/*/index.d.ts"
       ]
     }
   },

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -58,25 +58,6 @@ const submodulePackages = process.argv.includes("--all")
           pkgJson.files = [...new Set(pkgJson.files)].sort();
           pushPkgJson();
         }
-
-        // typesVersions metadata for downlevel (TypeScript <4.5) resolution.
-        const expectedTypesVersion = `dist-types/ts3.4/submodules/${submodule}/index.d.ts`;
-        pkgJson.typesVersions = pkgJson.typesVersions ?? {};
-        pkgJson.typesVersions["<4.5"] = pkgJson.typesVersions["<4.5"] ?? {
-          "dist-types/*": ["dist-types/ts3.4/*"],
-        };
-
-        const submoduleTypesVersion = pkgJson.typesVersions["<4.5"][submodule];
-        if (
-          !Array.isArray(submoduleTypesVersion) ||
-          submoduleTypesVersion.length !== 1 ||
-          submoduleTypesVersion[0] !== expectedTypesVersion
-        ) {
-          errors.push(`${submodule} submodule is missing typesVersions entry in package.json`);
-          pkgJson.typesVersions["<4.5"][submodule] = [expectedTypesVersion];
-          pushPkgJson();
-        }
-
         // tsconfig metadata.
         for (const [kind, tsconfig] of Object.entries(tsconfigs)) {
           if (!tsconfig.compilerOptions?.paths?.[`@smithy/${submodulePackage}/${submodule}`]) {
@@ -108,6 +89,23 @@ const submodulePackages = process.argv.includes("--all")
           compatibilityTypesFile,
           `/**\n * Do not edit:\n * This is a compatibility redirect for contexts that do not understand package.json exports field.\n */\nexport * from "./dist-types/submodules/${submodule}/index";\n`
         );
+      }
+    }
+
+    /**
+     * typesVersions metadata for downlevel (TypeScript <4.5) resolution.
+     * A single wildcard entry covers all submodules instead of one entry per submodule.
+     */
+    if (submodules.length > 0) {
+      const expectedTypesVersions = {
+        "dist-types/*": ["dist-types/ts3.4/*"],
+        "*": ["dist-types/ts3.4/submodules/*/index.d.ts"],
+      };
+      pkgJson.typesVersions = pkgJson.typesVersions ?? {};
+      if (JSON.stringify(pkgJson.typesVersions["<4.5"]) !== JSON.stringify(expectedTypesVersions)) {
+        errors.push(`package.json typesVersions is missing the wildcard submodules entry`);
+        pkgJson.typesVersions["<4.5"] = expectedTypesVersions;
+        fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
       }
     }
 

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -58,6 +58,25 @@ const submodulePackages = process.argv.includes("--all")
           pkgJson.files = [...new Set(pkgJson.files)].sort();
           pushPkgJson();
         }
+
+        // typesVersions metadata for downlevel (TypeScript <4.5) resolution.
+        const expectedTypesVersion = `dist-types/ts3.4/submodules/${submodule}/index.d.ts`;
+        pkgJson.typesVersions = pkgJson.typesVersions ?? {};
+        pkgJson.typesVersions["<4.5"] = pkgJson.typesVersions["<4.5"] ?? {
+          "dist-types/*": ["dist-types/ts3.4/*"],
+        };
+
+        const submoduleTypesVersion = pkgJson.typesVersions["<4.5"][submodule];
+        if (
+          !Array.isArray(submoduleTypesVersion) ||
+          submoduleTypesVersion.length !== 1 ||
+          submoduleTypesVersion[0] !== expectedTypesVersion
+        ) {
+          errors.push(`${submodule} submodule is missing typesVersions entry in package.json`);
+          pkgJson.typesVersions["<4.5"][submodule] = [expectedTypesVersion];
+          pushPkgJson();
+        }
+
         // tsconfig metadata.
         for (const [kind, tsconfig] of Object.entries(tsconfigs)) {
           if (!tsconfig.compilerOptions?.paths?.[`@smithy/${submodulePackage}/${submodule}`]) {


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-7055

*Description of changes:*

Extend the submodules linter to add and repair a typesVersions "<4.5"
entry for each submodule, pointing to its downleveled ts3.4 declaration
file. This keeps typesVersions in sync with the exports, files, and
tsconfig paths the linter already manages, so TypeScript <4.5 consumers
resolve submodule types correctly.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
