### PR TITLE
chore: move build back to top of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: build build-packages sync api-snapshot ct cti cwt cwti dist lint format
 
-dist:
-	node scripts/compilation/build-es-cjs-batch.js --all
-
 build:
 	./gradlew clean build publishToMavenLocal
+
+dist:
+	node scripts/compilation/build-es-cjs-batch.js --all
 
 # @smithy/undici-http-handler depends on undici@7, which requires Node.js >= 20.
 # Skip building it on older Node versions so the rest of the workspace still builds.


### PR DESCRIPTION
I'm used to `make` with no args running the Java build. I recently put a different target at the top which changed the default, but it wasn't intentional.