### PR TITLE
refactor: rename '@aws-smithy/server-*' packages to '@smithy/server-*'

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@aws-smithy/*"],
+  "ignore": ["@smithy/server-*"],
   "privatePackages": {
     "tag": false,
     "version": false

--- a/private/interceptor-example-ssdk/package.json
+++ b/private/interceptor-example-ssdk/package.json
@@ -16,9 +16,9 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-smithy/server-common": "workspace:^",
     "@smithy/core": "workspace:^",
     "@smithy/node-http-handler": "workspace:^",
+    "@smithy/server-common": "workspace:^",
     "@smithy/types": "workspace:^",
     "tslib": "^2.6.2"
   },

--- a/private/interceptor-example-ssdk/src/models/models_0.ts
+++ b/private/interceptor-example-ssdk/src/models/models_0.ts
@@ -5,7 +5,7 @@ import {
   NoOpValidator as __NoOpValidator,
   RequiredValidator as __RequiredValidator,
   ValidationFailure as __ValidationFailure,
-} from "@aws-smithy/server-common";
+} from "@smithy/server-common";
 
 /**
  * @public

--- a/private/interceptor-example-ssdk/src/protocols/Fakeprotocol.ts
+++ b/private/interceptor-example-ssdk/src/protocols/Fakeprotocol.ts
@@ -5,7 +5,7 @@ import {
   ServerSerdeContext,
   SmithyFrameworkException as __SmithyFrameworkException,
   UnsupportedMediaTypeException as __UnsupportedMediaTypeException,
-} from "@aws-smithy/server-common";
+} from "@smithy/server-common";
 import { isSerializableHeaderValue, map } from "@smithy/core/client";
 import { collectBody, HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
 import {

--- a/private/interceptor-example-ssdk/src/server/InterceptorExampleService.ts
+++ b/private/interceptor-example-ssdk/src/server/InterceptorExampleService.ts
@@ -23,7 +23,7 @@ import {
   UnknownOperationException as __UnknownOperationException,
   ValidationCustomizer as __ValidationCustomizer,
   ValidationFailure as __ValidationFailure,
-} from "@aws-smithy/server-common";
+} from "@smithy/server-common";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
 import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
 import { NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";

--- a/private/interceptor-example-ssdk/src/server/operations/GetItem.ts
+++ b/private/interceptor-example-ssdk/src/server/operations/GetItem.ts
@@ -24,7 +24,7 @@ import {
   UnknownOperationException as __UnknownOperationException,
   ValidationCustomizer as __ValidationCustomizer,
   ValidationFailure as __ValidationFailure,
-} from "@aws-smithy/server-common";
+} from "@smithy/server-common";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
 import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
 import { NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";

--- a/private/interceptor-example-ssdk/src/server/operations/Ping.ts
+++ b/private/interceptor-example-ssdk/src/server/operations/Ping.ts
@@ -24,7 +24,7 @@ import {
   UnknownOperationException as __UnknownOperationException,
   ValidationCustomizer as __ValidationCustomizer,
   ValidationFailure as __ValidationFailure,
-} from "@aws-smithy/server-common";
+} from "@smithy/server-common";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/core/protocols";
 import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
 import { NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";

--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -45,6 +45,20 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
     // top-level package.json. Adding an empty lock file allows it to be treated
     // as its own package.
     await spawnProcess("touch", ["yarn.lock"], { cwd: codegenDir });
+
+    // Rewrite the generated `@smithy/server-common` dependency to point at the
+    // local workspace copy via yarn's `link:` protocol so we use the local
+    // artifact instead of resolving from npm. `link:` symlinks the folder without
+    // installing its own dependencies; its transitive `@smithy/*` deps are
+    // satisfied by the packages copied into node_modules below.
+    const serverCommonDir = path.join(__dirname, "..", "smithy-typescript-ssdk-libs", "server-common");
+    const packageJsonPath = path.join(codegenDir, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    if (packageJson.dependencies && packageJson.dependencies["@smithy/server-common"]) {
+      packageJson.dependencies["@smithy/server-common"] = `link:${path.relative(codegenDir, serverCommonDir)}`;
+      fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    }
+
     await spawnProcess("yarn", { cwd: codegenDir });
     const smithyPackages = path.join(__dirname, "..", "packages");
     const node_modules = path.join(codegenDir, "node_modules");
@@ -61,17 +75,6 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
             path.join(smithyPackages, smithyPkg, folder),
             path.join(node_modules, "@smithy", smithyPkg),
           ])
-        )
-      );
-    }
-
-    const serverCommonDir = path.join(__dirname, "..", "smithy-typescript-ssdk-libs", "server-common");
-    const serverCommonTarget = path.join(node_modules, "@aws-smithy", "server-common");
-    if (fs.existsSync(path.join(serverCommonDir, "dist")) && fs.existsSync(serverCommonTarget)) {
-      await spawnProcess("rm", ["-rf", path.join(serverCommonTarget, "dist")]);
-      await Promise.all(
-        ["dist", "package.json"].map((entry) =>
-          spawnProcess("cp", ["-r", path.join(serverCommonDir, entry), serverCommonTarget])
         )
       );
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -266,7 +266,7 @@ final class StructureGenerator implements Runnable {
      * import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
      * import { FooServiceException as __BaseException } from "./FooServiceException";
      * // In server SDK:
-     * // import { ServiceException as __BaseException } from "@aws-smithy/server-common";
+     * // import { ServiceException as __BaseException } from "@smithy/server-common";
      *
      * export class NoSuchResource extends __BaseException {
      *   name: "NoSuchResource";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -66,7 +66,7 @@ public enum TypeScriptDependency implements Dependency {
     // devtools
     @Deprecated
     EXPERIMENTAL_IDENTITY_AND_AUTH("dependencies", "@smithy/experimental-identity-and-auth", false),
-    SERVER_COMMON("dependencies", "@aws-smithy/server-common", false),
+    SERVER_COMMON("dependencies", "@smithy/server-common", false),
     SNAPSHOTS("devDependencies", "@smithy/snapshot-testing", false),
     TYPEDOC("devDependencies", "typedoc", "0.23.23", false),
     VITEST("devDependencies", "vitest", "^4.0.17", false),

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/default_readme_server.md.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/default_readme_server.md.template
@@ -28,7 +28,7 @@ import {
   ${commandName}Output,
   get${serviceId}ServiceHandler
 } from "${packageName}";
-import { convertEvent, convertResponse } from "@aws-smithy/server-node";
+import { convertEvent, convertResponse } from "@smithy/server-node";
 
 class ${serviceId}Service implements __${serviceId}Service {
   ${commandName}(input: ${commandName}Input, request: HttpRequest): ${commandName}Output {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDependencyTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDependencyTest.java
@@ -46,6 +46,6 @@ public class TypeScriptDependencyTest {
 
         assertThat(serverCommon.size(), equalTo(1));
         assertThat(serverCommon.get(0).getVersion(), not(startsWith("^")));
-        assertThat(serverCommon.get(0).getPackageName(), equalTo("@aws-smithy/server-common"));
+        assertThat(serverCommon.get(0).getPackageName(), equalTo("@smithy/server-common"));
     }
 }

--- a/smithy-typescript-ssdk-libs/server-apigateway/README.md
+++ b/smithy-typescript-ssdk-libs/server-apigateway/README.md
@@ -8,7 +8,7 @@ apigateway.
 ### Example
 
 ```typescript
-import { convertEvent, convertResponse } from "@aws-smithy/server-apigateway";
+import { convertEvent, convertResponse } from "@smithy/server-apigateway";
 import {
   SayHelloInput,
   SayHelloOutput,

--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-smithy/server-apigateway",
+  "name": "@smithy/server-apigateway",
   "version": "1.0.0-alpha.10",
   "description": "Base components for Smithy services behind APIGateway",
   "homepage": "https://github.com/smithy-lang/smithy-typescript#readme",

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-smithy/server-common",
+  "name": "@smithy/server-common",
   "version": "1.0.0-alpha.10",
   "description": "Base components for Smithy services",
   "homepage": "https://github.com/smithy-lang/smithy-typescript#readme",

--- a/smithy-typescript-ssdk-libs/server-node/README.md
+++ b/smithy-typescript-ssdk-libs/server-node/README.md
@@ -8,7 +8,7 @@ This package provides glue code to enable using a server sdk with NodeJS.
 
 ```typescript
 import { IncomingMessage, ServerResponse, createServer } from "http";
-import { convertEvent, convertResponse } from "@aws-smithy/server-node";
+import { convertEvent, convertResponse } from "@smithy/server-node";
 import {
   SayHelloInput,
   SayHelloOutput,

--- a/smithy-typescript-ssdk-libs/server-node/package.json
+++ b/smithy-typescript-ssdk-libs/server-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-smithy/server-node",
+  "name": "@smithy/server-node",
   "version": "1.0.0-alpha.10",
   "description": "Base components for Smithy services running on NodeJS",
   "homepage": "https://github.com/smithy-lang/smithy-typescript#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,57 +57,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-smithy/server-apigateway@workspace:smithy-typescript-ssdk-libs/server-apigateway":
-  version: 0.0.0-use.local
-  resolution: "@aws-smithy/server-apigateway@workspace:smithy-typescript-ssdk-libs/server-apigateway"
-  dependencies:
-    "@smithy/protocol-http": "workspace:^"
-    "@smithy/types": "workspace:^"
-    "@types/aws-lambda": "npm:^8.10.72"
-    "@types/node": "npm:^18.11.9"
-    concurrently: "npm:7.0.0"
-    downlevel-dts: "npm:^0.7.0"
-    jest: "npm:29.7.0"
-    premove: "npm:4.0.0"
-    tslib: "npm:^1.8.0"
-    typescript: "npm:~5.8.3"
-  languageName: unknown
-  linkType: soft
-
-"@aws-smithy/server-common@workspace:^, @aws-smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common":
-  version: 0.0.0-use.local
-  resolution: "@aws-smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common"
-  dependencies:
-    "@smithy/core": "workspace:^"
-    "@smithy/protocol-http": "workspace:^"
-    "@smithy/types": "workspace:^"
-    "@types/node": "npm:^18.11.9"
-    concurrently: "npm:7.0.0"
-    downlevel-dts: "npm:^0.7.0"
-    jest: "npm:29.7.0"
-    premove: "npm:4.0.0"
-    re2-wasm: "npm:^1.0.2"
-    tslib: "npm:^1.8.0"
-    typescript: "npm:~5.8.3"
-  languageName: unknown
-  linkType: soft
-
-"@aws-smithy/server-node@workspace:smithy-typescript-ssdk-libs/server-node":
-  version: 0.0.0-use.local
-  resolution: "@aws-smithy/server-node@workspace:smithy-typescript-ssdk-libs/server-node"
-  dependencies:
-    "@smithy/protocol-http": "workspace:^"
-    "@smithy/types": "workspace:^"
-    "@types/node": "npm:^18.11.9"
-    concurrently: "npm:7.0.0"
-    downlevel-dts: "npm:^0.7.0"
-    jest: "npm:29.7.0"
-    premove: "npm:4.0.0"
-    tslib: "npm:^1.8.0"
-    typescript: "npm:~5.8.3"
-  languageName: unknown
-  linkType: soft
-
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.24.2, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
@@ -2908,6 +2857,57 @@ __metadata:
     "@smithy/core": "workspace:^"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
+  languageName: unknown
+  linkType: soft
+
+"@smithy/server-apigateway@workspace:smithy-typescript-ssdk-libs/server-apigateway":
+  version: 0.0.0-use.local
+  resolution: "@smithy/server-apigateway@workspace:smithy-typescript-ssdk-libs/server-apigateway"
+  dependencies:
+    "@smithy/protocol-http": "workspace:^"
+    "@smithy/types": "workspace:^"
+    "@types/aws-lambda": "npm:^8.10.72"
+    "@types/node": "npm:^18.11.9"
+    concurrently: "npm:7.0.0"
+    downlevel-dts: "npm:^0.7.0"
+    jest: "npm:29.7.0"
+    premove: "npm:4.0.0"
+    tslib: "npm:^1.8.0"
+    typescript: "npm:~5.8.3"
+  languageName: unknown
+  linkType: soft
+
+"@smithy/server-common@workspace:^, @smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common":
+  version: 0.0.0-use.local
+  resolution: "@smithy/server-common@workspace:smithy-typescript-ssdk-libs/server-common"
+  dependencies:
+    "@smithy/core": "workspace:^"
+    "@smithy/protocol-http": "workspace:^"
+    "@smithy/types": "workspace:^"
+    "@types/node": "npm:^18.11.9"
+    concurrently: "npm:7.0.0"
+    downlevel-dts: "npm:^0.7.0"
+    jest: "npm:29.7.0"
+    premove: "npm:4.0.0"
+    re2-wasm: "npm:^1.0.2"
+    tslib: "npm:^1.8.0"
+    typescript: "npm:~5.8.3"
+  languageName: unknown
+  linkType: soft
+
+"@smithy/server-node@workspace:smithy-typescript-ssdk-libs/server-node":
+  version: 0.0.0-use.local
+  resolution: "@smithy/server-node@workspace:smithy-typescript-ssdk-libs/server-node"
+  dependencies:
+    "@smithy/protocol-http": "workspace:^"
+    "@smithy/types": "workspace:^"
+    "@types/node": "npm:^18.11.9"
+    concurrently: "npm:7.0.0"
+    downlevel-dts: "npm:^0.7.0"
+    jest: "npm:29.7.0"
+    premove: "npm:4.0.0"
+    tslib: "npm:^1.8.0"
+    typescript: "npm:~5.8.3"
   languageName: unknown
   linkType: soft
 
@@ -6543,9 +6543,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "interceptor-example-ssdk@workspace:private/interceptor-example-ssdk"
   dependencies:
-    "@aws-smithy/server-common": "workspace:^"
     "@smithy/core": "workspace:^"
     "@smithy/node-http-handler": "workspace:^"
+    "@smithy/server-common": "workspace:^"
     "@smithy/types": "workspace:^"
     "@tsconfig/node20": "npm:20.1.8"
     "@types/node": "npm:^20.14.8"


### PR DESCRIPTION
_Issue #, if available:_

Internal JS-6999

_Description of changes:_

Change the package scope for the three server SDK codegen packages
from `@aws-smithy` to `@smithy` for consistency with the rest of the
workspace:

- `@aws-smithy/server-common` -> `@smithy/server-common`
- `@aws-smithy/server-node` -> `@smithy/server-node`
- `@aws-smithy/server-apigateway` -> `@smithy/server-apigateway`

Update all consumer imports in the interceptor-example-ssdk package,
the codegen `SERVER_COMMON` dependency and its test, the server readme
template, package READMEs, and regenerate the lockfile.

The updates to the CHANGELOG.md will be done in a follow-up PR, which will
change the starting version to `0.1.0` and perform manual publish. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
