### PR TITLE
fix: update tsconfig paths for smithy-typescript-ssdk-libs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "@aws-smithy/*": ["smithy-typescript-ssdk-libs/*/src"],
-      "@smithy/*": ["packages/*/src"]
+      "@smithy/*": ["packages/*/src", "smithy-typescript-ssdk-libs/*/src"]
     },
     "preserveConstEnums": true,
     "removeComments": true,


### PR DESCRIPTION
_Issue #, if available:_

Missed in https://github.com/smithy-lang/smithy-typescript/pull/2156

_Description of changes:_

Consolidate the `@aws-smithy/*` path mapping into the `@smithy/*` entry so
that both `packages/*` and `smithy-typescript-ssdk-libs/*` sources resolve
under the `@smithy/*` namespace. The ssdk-libs packages were renamed from
the `@aws-smithy` scope to `@smithy`, so the dedicated `@aws-smithy/*` mapping
is no longer needed and the source directories are added as a second
lookup location for `@smithy/*`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
