### PR TITLE
chore: remove check for legacy '@aws-smithy/*' scope

### DIFF
--- a/scripts/post-protocol-test-codegen.js
+++ b/scripts/post-protocol-test-codegen.js
@@ -17,7 +17,7 @@ const private = path.join(root, "private");
 
 const privatePackages = fs.readdirSync(private);
 
-const isWorkspaceDep = (dep) => dep.startsWith("@smithy/") || dep.startsWith("@aws-smithy/");
+const isWorkspaceDep = (dep) => dep.startsWith("@smithy/");
 
 // Dependencies the deps-used validation always treats as used.
 const IMPLICIT_DEPS = new Set(["tslib"]);


### PR DESCRIPTION
_Issue #, if available:_

Missed in https://github.com/smithy-lang/smithy-typescript/pull/2156

_Description of changes:_

The `isWorkspaceDep` helper in post-protocol-test-codegen.js previously
matched both the `@smithy/` and legacy `@aws-smithy/` scopes when deciding
which dependencies to pin to `workspace:^`. The `@aws-smithy/*` scope is no
longer used by any packages in this repo, so the extra check is dead code.

Drop the `@aws-smithy/` branch so the helper only recognizes the current
`@smithy/` scope.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
