### PR TITLE
fix(codegen): support event streams in server SDK serde context

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -44,6 +44,7 @@ import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeProviderGenerator;
 import software.amazon.smithy.typescript.codegen.endpointsV2.EndpointsV2Generator;
+import software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -258,9 +259,10 @@ final class DirectedTypeScriptCodegen
         }
 
         if (settings.generateServerSdk()) {
+            boolean hasEventStream = AddEventStreamDependency.hasEventStream(directive.model(), service);
             for (OperationShape operation : directive.operations()) {
                 delegator.useShapeWriter(operation, w -> {
-                    ServerGenerator.generateOperationHandler(symbolProvider, service, operation, w);
+                    ServerGenerator.generateOperationHandler(symbolProvider, service, operation, w, hasEventStream);
                 });
             }
         }
@@ -736,7 +738,13 @@ final class DirectedTypeScriptCodegen
             .useShapeWriter(service, writer -> {
                 ServerGenerator.generateOperationsType(symbolProvider, service, operations, writer);
                 ServerGenerator.generateServerInterfaces(symbolProvider, service, operations, writer);
-                ServerGenerator.generateServiceHandler(symbolProvider, service, operations, writer);
+                ServerGenerator.generateServiceHandler(
+                    symbolProvider,
+                    service,
+                    operations,
+                    writer,
+                    AddEventStreamDependency.hasEventStream(directive.model(), service)
+                );
             });
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -39,7 +39,8 @@ final class ServerGenerator {
         SymbolProvider symbolProvider,
         Shape serviceShape,
         Set<OperationShape> operations,
-        TypeScriptWriter writer
+        TypeScriptWriter writer,
+        boolean hasEventStream
     ) {
         addCommonHandlerImports(writer);
 
@@ -47,7 +48,7 @@ final class ServerGenerator {
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
         Symbol operationsType = serviceSymbol.expectProperty("operations", Symbol.class);
 
-        writeSerdeContextBase(writer);
+        writeSerdeContextBase(writer, hasEventStream);
 
         writer.openBlock(
             "const $LValidators: { [K in $T]: (input: any) => __ValidationFailure[] } = {",
@@ -211,12 +212,13 @@ final class ServerGenerator {
         SymbolProvider symbolProvider,
         Shape serviceShape,
         OperationShape operation,
-        TypeScriptWriter writer
+        TypeScriptWriter writer,
+        boolean hasEventStream
     ) {
         addCommonHandlerImports(writer);
         writer.addImport("Operation", "__Operation", TypeScriptDependency.SERVER_COMMON);
 
-        writeSerdeContextBase(writer);
+        writeSerdeContextBase(writer, hasEventStream);
 
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         Symbol operationSymbol = symbolProvider.toSymbol(operation);
@@ -670,7 +672,7 @@ final class ServerGenerator {
         writer.addImport("MetricsRecorderFactory", "__MetricsRecorderFactory", TypeScriptDependency.SMITHY_TYPES);
     }
 
-    private static void writeSerdeContextBase(TypeScriptWriter writer) {
+    private static void writeSerdeContextBase(TypeScriptWriter writer, boolean hasEventStream) {
         writer.addImport("ServerSerdeContext", "__ServerSerdeContext", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("NodeHttpHandler", null, TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
         writer.addImport("streamCollector", null, TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
@@ -678,6 +680,14 @@ final class ServerGenerator {
         writer.addImportSubmodule("toBase64", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
         writer.addImportSubmodule("fromUtf8", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
         writer.addImportSubmodule("toUtf8", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        if (hasEventStream) {
+            writer.addImportSubmodule(
+                "eventStreamSerdeProvider",
+                null,
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.EVENT_STREAMS
+            );
+        }
 
         writer.openBlock("const serdeContextBase = {", "};", () -> {
             writer.write("base64Encoder: toBase64,");
@@ -685,6 +695,12 @@ final class ServerGenerator {
             writer.write("utf8Encoder: toUtf8,");
             writer.write("utf8Decoder: fromUtf8,");
             writer.write("streamCollector: streamCollector,");
+            if (hasEventStream) {
+                writer.write(
+                    "eventStreamMarshaller: eventStreamSerdeProvider("
+                        + "{ utf8Encoder: toUtf8, utf8Decoder: fromUtf8 }),"
+                );
+            }
             writer.write("requestHandler: new NodeHttpHandler(),");
             writer.write("disableHostPrefix: true");
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -142,7 +142,7 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
         );
     }
 
-    private static boolean hasEventStream(Model model, ServiceShape service) {
+    public static boolean hasEventStream(Model model, ServiceShape service) {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
         EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -698,12 +698,23 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
         writer.addImport("ServerSerdeContext", null, TypeScriptDependency.SERVER_COMMON);
 
+        String ctxType = "ServerSerdeContext";
+        if (EventStreamGenerator.hasEventStreamOutput(context, operation)) {
+            writer.addTypeImport(
+                "EventStreamSerdeContext",
+                "__EventStreamSerdeContext",
+                TypeScriptDependency.SMITHY_TYPES
+            );
+            ctxType += " & __EventStreamSerdeContext";
+        }
+
         writer.openBlock(
-            "export const $L = async (\n" + "  input: $T,\n" + "  ctx: ServerSerdeContext\n"
+            "export const $L = async (\n" + "  input: $T,\n" + "  ctx: $L\n"
                 + "): Promise<$T> => {",
             "};",
             methodName,
             outputType,
+            ctxType,
             responseType,
             () -> {
                 writeEmptyEndpoint(context, operation);
@@ -834,8 +845,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         String contextType = "__SerdeContext";
         boolean hasEventStreamResponse = EventStreamGenerator.hasEventStreamOutput(context, operation);
         if (hasEventStreamResponse) {
-            // todo: unsupported SSDK feature.
-            contextType += "& any /*event stream context unsupported in ssdk*/";
+            context.getWriter()
+                .addTypeImport(
+                    "EventStreamSerdeContext",
+                    "__EventStreamSerdeContext",
+                    TypeScriptDependency.SMITHY_TYPES
+                );
+            contextType += " & __EventStreamSerdeContext";
         }
         context
             .getWriter()

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/HttpBindingEventStreamServerTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/HttpBindingEventStreamServerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+public class HttpBindingEventStreamServerTest {
+
+    /**
+     * A minimal concrete {@link HttpBindingProtocolGenerator} for exercising the shared
+     * server-side generation paths. Document-body serde is stubbed because event stream
+     * payloads are handled through the payload/event-stream path, not document bodies.
+     */
+    private static final class TestHttpBindingProtocolGenerator extends HttpBindingProtocolGenerator {
+        TestHttpBindingProtocolGenerator() {
+            super(false);
+        }
+
+        @Override
+        public ShapeId getProtocol() {
+            return ShapeId.from("smithy.example#fakeProtocol");
+        }
+
+        @Override
+        public void generateProtocolTests(GenerationContext context) {}
+
+        @Override
+        protected Format getDocumentTimestampFormat() {
+            return Format.EPOCH_SECONDS;
+        }
+
+        @Override
+        protected String getDocumentContentType() {
+            return "application/json";
+        }
+
+        @Override
+        protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {}
+
+        @Override
+        protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {}
+
+        @Override
+        protected void serializeInputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+        ) {}
+
+        @Override
+        protected void serializeInputEventDocumentPayload(GenerationContext context) {}
+
+        @Override
+        protected void serializeOutputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+        ) {}
+
+        @Override
+        protected void serializeErrorDocumentBody(
+            GenerationContext context,
+            StructureShape error,
+            List<HttpBinding> documentBindings
+        ) {}
+
+        @Override
+        protected void writeErrorCodeParser(GenerationContext context) {}
+
+        @Override
+        protected void deserializeInputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+        ) {}
+
+        @Override
+        protected void deserializeOutputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+        ) {}
+
+        @Override
+        protected void deserializeErrorDocumentBody(
+            GenerationContext context,
+            StructureShape error,
+            List<HttpBinding> documentBindings
+        ) {}
+
+        @Override
+        protected boolean requiresNumericEpochSecondsInPayload() {
+            return false;
+        }
+    }
+
+    private GenerationContext serverContext() {
+        Model model = Model.assembler(getClass().getClassLoader())
+            .discoverModels(getClass().getClassLoader())
+            .addImport(getClass().getResource("server-event-stream-http.smithy"))
+            .assemble()
+            .unwrap();
+        ServiceShape service = model.expectShape(ShapeId.from("smithy.example#Example"), ServiceShape.class);
+        TypeScriptSettings settings = TypeScriptSettings.from(
+            model,
+            Node.objectNodeBuilder()
+                .withMember("service", Node.from("smithy.example#Example"))
+                .withMember("package", Node.from("example-ssdk"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .withMember("disableDefaultValidation", Node.from(true))
+                .build()
+        );
+        GenerationContext context = new GenerationContext();
+        context.setModel(model);
+        context.setService(service);
+        context.setSettings(settings);
+        context.setSymbolProvider(new SymbolVisitor(model, settings));
+        context.setProtocolName("fakeProtocol");
+        context.setWriter(new TypeScriptWriter("./Publish"));
+        return context;
+    }
+
+    @Test
+    public void responseSerializerUsesTypedEventStreamContext() {
+        GenerationContext context = serverContext();
+        new TestHttpBindingProtocolGenerator().generateResponseSerializers(context);
+        String generated = context.getWriter().toString();
+        // The response serializer's serde context must be typed with __EventStreamSerdeContext
+        // rather than the previous `& any` escape hatch.
+        assertThat(generated, containsString("ctx: ServerSerdeContext & __EventStreamSerdeContext"));
+        assertThat(generated, not(containsString("unsupported in ssdk")));
+        assertThat(generated, not(containsString("& any")));
+    }
+
+    @Test
+    public void requestDeserializerUsesTypedEventStreamContext() {
+        GenerationContext context = serverContext();
+        new TestHttpBindingProtocolGenerator().generateRequestDeserializers(context);
+        String generated = context.getWriter().toString();
+        // The request deserializer's serde context must include __EventStreamSerdeContext
+        // for operations with an event stream input.
+        assertThat(generated, containsString("__EventStreamSerdeContext"));
+        assertThat(generated, not(containsString("& any")));
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServerEventStreamTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServerEventStreamTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+
+public class ServerEventStreamTest {
+
+    private MockManifest generateServer() {
+        Model model = Model.assembler(getClass().getClassLoader())
+            .discoverModels(getClass().getClassLoader())
+            .addImport(getClass().getResource("server-event-stream.smithy"))
+            .assemble()
+            .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+            .model(model)
+            .fileManifest(manifest)
+            .pluginClassLoader(getClass().getClassLoader())
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#Example"))
+                    .withMember("package", Node.from("example-ssdk"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .withMember("disableDefaultValidation", Node.from(true))
+                    .build()
+            )
+            .build();
+        new TypeScriptServerCodegenPlugin().execute(context);
+        return manifest;
+    }
+
+    @Test
+    public void wiresEventStreamMarshallerIntoServerSerdeContext() {
+        MockManifest manifest = generateServer();
+        String handler = manifest.getFileString(
+            CodegenUtils.SOURCE_FOLDER + "/server/operations/Publish.ts"
+        ).get();
+        // The server handler's serde context base must supply an event stream marshaller,
+        // reusing the Node event stream serde provider (which only needs utf8 encode/decode).
+        assertThat(handler, containsString("eventStreamSerdeProvider"));
+        assertThat(handler, containsString("eventStreamMarshaller: eventStreamSerdeProvider("));
+    }
+
+    @Test
+    public void generatesEventStreamSerdeWithTypedContext() {
+        MockManifest manifest = generateServer();
+        String protocol = manifest.getFileString(
+            CodegenUtils.SOURCE_FOLDER + "/protocols/Rpcv2cbor.ts"
+        ).get();
+        // Event stream serde functions are generated and use the strongly typed
+        // __EventStreamSerdeContext rather than an untyped `any` escape hatch.
+        assertThat(protocol, containsString("__EventStreamSerdeContext"));
+        assertThat(protocol, not(containsString("unsupported in ssdk")));
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServerGeneratorMetricsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServerGeneratorMetricsTest.java
@@ -43,13 +43,13 @@ public class ServerGeneratorMetricsTest {
     private String generateOperationHandler() {
         OperationShape operation = model.expectShape(ShapeId.from("smithy.example#GetFoo"), OperationShape.class);
         TypeScriptWriter writer = new TypeScriptWriter("./GetFoo");
-        ServerGenerator.generateOperationHandler(symbolProvider, service, operation, writer);
+        ServerGenerator.generateOperationHandler(symbolProvider, service, operation, writer, false);
         return writer.toString();
     }
 
     private String generateServiceHandler() {
         TypeScriptWriter writer = new TypeScriptWriter("./Example");
-        ServerGenerator.generateServiceHandler(symbolProvider, service, model.getOperationShapes(), writer);
+        ServerGenerator.generateServiceHandler(symbolProvider, service, model.getOperationShapes(), writer, false);
         return writer.toString();
     }
 

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/server-event-stream-http.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/server-event-stream-http.smithy
@@ -1,0 +1,41 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@trait(selector: "service")
+@protocolDefinition
+structure fakeProtocol {}
+
+@fakeProtocol
+service Example {
+    version: "1.0.0"
+    operations: [Publish]
+}
+
+@http(method: "POST", uri: "/publish")
+operation Publish {
+    input: PublishInput
+    output: PublishOutput
+}
+
+structure PublishInput {
+    @httpPayload
+    events: PublishEvents
+}
+
+structure PublishOutput {
+    @httpPayload
+    events: PublishEvents
+}
+
+@streaming
+union PublishEvents {
+    message: MessageEvent
+    leave: LeaveEvent
+}
+
+structure MessageEvent {
+    message: String
+}
+
+structure LeaveEvent {}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/server-event-stream.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/server-event-stream.smithy
@@ -1,0 +1,36 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.protocols#rpcv2Cbor
+
+@rpcv2Cbor
+service Example {
+    version: "1.0.0"
+    operations: [Publish]
+}
+
+operation Publish {
+    input: PublishInput
+    output: PublishOutput
+}
+
+structure PublishInput {
+    events: PublishEvents
+}
+
+structure PublishOutput {
+    events: PublishEvents
+}
+
+@streaming
+union PublishEvents {
+    message: MessageEvent
+    leave: LeaveEvent
+}
+
+structure MessageEvent {
+    message: String
+}
+
+structure LeaveEvent {}


### PR DESCRIPTION
**The problem:** make a Smithy model with an event stream, generate a server from it, and the code you get is broken. Two reasons:
1. The response side of the stream is typed as `any` — which tells the compiler "don't check this." So that error was there, just hidden. (The request side was typed correctly, which is why the package as a whole already failed to compile.)
2. The server is never handed the thing that actually encodes and decodes stream events (the marshaller). So even at runtime there's nothing to do the work.

Related to #959.

**The fix** — two small changes, both in the code generator. No npm packages touched:
1. The generated response serializer now uses the real type, `__EventStreamSerdeContext`, instead of `any`. Now the compiler checks it for real. (The request side already used the right type.)
2. The generated server now gets a marshaller, built with `eventStreamSerdeProvider`. All it needs is the utf8 helpers the server already had, so nothing new at runtime.

**Who this affects:** only servers generated from models that have event streams — and their code was already broken, so this is strictly an improvement. Everyone else gets byte-for-byte the same output as before. `smithy-aws-typescript-codegen` keeps compiling unchanged; restJson1 will need its own follow-up PR in aws-sdk-js-v3.

**How it was tested:** added the first-ever server event stream codegen tests, the full gradle build passes, and a sample of the new generated output compiles clean under `tsc --strict`. The old output fails that same check with `eventStreamMarshaller is missing` — exactly the error the `any` was hiding.

**Not fixed here:** the rpcv2Cbor-based test in this diff only exercises the handler wiring — that protocol's own server codegen is still stubbed. Stream validation is still skipped (events arrive after up-front validation runs, so supporting it needs a design decision). And there's no live end-to-end test yet — that needs a concrete protocol, which lives in aws-sdk-js-v3.

**Why I'm doing this / where it's heading:** I want to build Smithy services that stream to clients over Server-Sent Events (`text/event-stream`), which smithy-typescript has no story for today (smithy-java gained SSE handling for MCP; TypeScript has nothing). The marshaller is injected through the handler's serde context on purpose: all framing runs through that one object, so a protocol generator that wires in an SSE marshaller instead gets `text/event-stream` framing with the rest of the machinery unchanged. (To be precise: the plug-in point is the protocol-generator layer at codegen time, not a runtime hook in the emitted server.) I'm planning to prototype that as a third-party protocol generator and bring it back as an RFC — this PR is the first step, but it also stands on its own as a bugfix for #959.

