### PR TITLE
chore(core/cbor): update large map deser threshold

### DIFF
--- a/.changeset/silent-lobsters-applaud.md
+++ b/.changeset/silent-lobsters-applaud.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+update large map threshold in cbor

--- a/packages/core/src/submodules/cbor/cbor-decode.ts
+++ b/packages/core/src/submodules/cbor/cbor-decode.ts
@@ -203,7 +203,7 @@ export function bytesToFloat16(a: Uint8, b: Uint8): Float32 {
  */
 function decodeMap(at: Uint32, to: Uint32): CborMapType {
   const mapDataLength = decodeCount(at, to);
-  if (mapDataLength < 15) {
+  if (mapDataLength < 25) {
     return decodeMapSmall(at, to, mapDataLength);
   }
   return decodeMapLarge(at, to, mapDataLength);


### PR DESCRIPTION
incidental testing showed 25 as a better cutover threshold for small and large maps.