### PR TITLE
fix(serde): accept RFC 8259 exponent notation in NumericValue

### DIFF
--- a/.changeset/fifty-bears-accept.md
+++ b/.changeset/fifty-bears-accept.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+set NumericValue accepted values to Smithy RPCv2 JSON spec

--- a/.changeset/fix-numeric-exponent.md
+++ b/.changeset/fix-numeric-exponent.md
@@ -1,5 +1,0 @@
----
-"@smithy/core": patch
----
-
-fix(serde): accept RFC 8259 exponent notation in NumericValue

--- a/.changeset/fix-numeric-exponent.md
+++ b/.changeset/fix-numeric-exponent.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix(serde): accept RFC 8259 exponent notation in NumericValue

--- a/packages/core/src/submodules/serde/value/NumericValue.spec.ts
+++ b/packages/core/src/submodules/serde/value/NumericValue.spec.ts
@@ -13,8 +13,33 @@ describe(NumericValue.name, () => {
   it("allows only numeric digits and at most one decimal point", () => {
     expect(() => nv("a")).toThrow();
     expect(() => nv("1.0.1")).toThrow();
+    expect(() => nv("007")).toThrow(); // not valid: no leading zeros
+    expect(() => nv("-01")).toThrow(); // not valid: no leading zeros
+    expect(() => nv("-")).toThrow(); // not valid: no digits
+    expect(() => nv("")).toThrow(); // not valid: empty
     expect(() => nv("-10.1")).not.toThrow();
-    expect(() => nv("-.101")).not.toThrow();
+    expect(() => nv("-0.101")).not.toThrow();
+    expect(() => nv("-.101")).not.toThrow(); // leading-dot: allowed for backwards compat
+    expect(() => nv(".5")).not.toThrow(); // leading-dot: allowed for backwards compat
+    expect(() => nv("0")).not.toThrow();
+    expect(() => nv("0.5")).not.toThrow();
+    expect(() => nv("-0")).not.toThrow();
+  });
+
+  // Regression: https://github.com/aws/aws-sdk-js-v3/issues/8224
+  // JSON exponent notation (RFC 8259) must be accepted because AWS services
+  // emit numbers like "1.784316439424E9" for epoch-second timestamps.
+  it("should accept valid JSON exponent notation", () => {
+    expect(() => nv("1E9")).not.toThrow();
+    expect(() => nv("1e9")).not.toThrow();
+    expect(() => nv("1E+9")).not.toThrow();
+    expect(() => nv("1e-9")).not.toThrow();
+    expect(() => nv("1.784316439424E9")).not.toThrow();
+    expect(() => nv("1.5e+3")).not.toThrow();
+    expect(() => nv("1.5e-3")).not.toThrow();
+    expect(() => nv("-1.5E9")).not.toThrow();
+    expect(() => nv("-1E9")).not.toThrow();
+    expect(() => nv("-1.5e+3")).not.toThrow();
   });
 
   it("has a custom instanceof check", () => {

--- a/packages/core/src/submodules/serde/value/NumericValue.ts
+++ b/packages/core/src/submodules/serde/value/NumericValue.ts
@@ -9,9 +9,16 @@
 export type NumericType = "bigDecimal";
 
 /**
+ * Matches Smithy's bigDecimal string format (ABNF):
+ *   big-decimal = big-integer ["." fraction-part] [exponent]
+ *   big-integer = ["-"] ("0" / NON-ZERO-DIGIT *DIGIT)
+ *   fraction-part = 1*DIGIT
+ *   exponent = ("e" / "E") ["+" / "-"] 1*DIGIT
+ *
+ * Also allows leading-dot form (e.g. "-.5", ".5") for backwards compatibility.
  * @internal
  */
-const format = /^-?\d*(\.\d+)?$/;
+const format = /^-?((0|[1-9]\d*)(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/;
 
 /**
  * Serialization container for Smithy simple types that do not have a
@@ -32,7 +39,7 @@ export class NumericValue {
   ) {
     if (!format.test(string)) {
       throw new Error(
-        `@smithy/core/serde - NumericValue must only contain [0-9], at most one decimal point ".", and an optional negation prefix "-".`
+        `@smithy/core/serde - NumericValue string must conform to the Smithy bigDecimal format. Received: "${string}"`
       );
     }
   }


### PR DESCRIPTION
## Summary

Related to https://github.com/aws/aws-sdk-js-v3/issues/8224

`NumericValue`'s format regex rejected valid JSON exponent notation (e.g. `1.784316439424E9`, `1E+9`, `1.5e-3`). 

## Changes

- Widen the format regex

