### PR TITLE
ci: check superseded versions exist on npm (attempt 1)

### DIFF
--- a/.github/workflows/npm-package-existence.yml
+++ b/.github/workflows/npm-package-existence.yml
@@ -2,14 +2,16 @@ name: npm-package-existence
 
 on:
   # Verify the changesets release PR: every package it will publish must already
-  # exist on npm, since trusted publishing (OIDC) cannot create a new name.
+  # exist on npm, since trusted publishing (OIDC) cannot create a new name, and
+  # every version it bumps past must already be published, since merging it means
+  # no later release will ever publish those.
   pull_request:
     branches:
       - main
-  # Refresh the cached record of packages known to exist on npm. Only push and
-  # similar trusted triggers may write to the default branch's cache scope, which
-  # is the scope pull request runs restore from, so the record is always written
-  # from main and never from a pull request.
+  # Refresh the cached record of packages and versions known to exist on npm. Only
+  # push and similar trusted triggers may write to the default branch's cache
+  # scope, which is the scope pull request runs restore from, so the record is
+  # always written from main and never from a pull request.
   push:
     branches:
       - main
@@ -21,18 +23,22 @@ env:
   # Cache entries are immutable, so the key embeds a hash of every releasable
   # package's CHANGELOG.md and the prefix is used as a restore-key to pick up the
   # most recent record when that exact key is absent. The changelogs are the
-  # signal because the record only describes which package names exist on npm:
-  # adding, removing or renaming a package changes the set of changelog files,
-  # while dependency bumps and other package.json edits - which have no bearing
-  # on the record - leave it untouched. This assumes every package has a
-  # CHANGELOG.md; if one ever lacks it, the only cost is that its name is not
-  # recorded and the release PR verifies it against the registry directly.
+  # signal because they change exactly when the record can: `changeset version`
+  # writes a changelog entry for every package whose version it bumps, and adding,
+  # removing or renaming a package changes the set of changelog files, while
+  # dependency bumps and other package.json edits - which have no bearing on the
+  # record - leave them untouched. This assumes every package has a CHANGELOG.md;
+  # if one ever lacks it, the only cost is that it is not recorded and the release
+  # PR verifies it against the registry directly.
+  #
+  # The prefix is versioned: bump it when the record's format changes, so runs do
+  # not restore a record written in the previous shape.
   #
   # The key globs cover the workspace roots from the root package.json that hold
   # releasable packages. private/* is deliberately left out: those packages are
   # all private, and .changeset/config.json sets privatePackages.version to
   # false, so they are never published and cannot affect the record.
-  CACHE_KEY_PREFIX: published-packages-v1-
+  CACHE_KEY_PREFIX: published-packages-v2-
   CACHE_PATH_SUFFIX: published-packages
 
 jobs:
@@ -41,11 +47,14 @@ jobs:
     name: Ensure packages to publish exist on npm
     # Only relevant on the changesets release PR, which is what actually
     # triggers the OIDC publish. New package names must be published manually
-    # once and configured as trusted publishers before that release runs.
+    # once and configured as trusted publishers before that release runs, and the
+    # versions the PR bumps past must already be on npm, since merging it means no
+    # later release will publish them.
     if: github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        # Include full git history so the set to publish can be diffed against main.
+        # Include full git history so the set to publish, and the versions it
+        # supersedes, can be diffed against main.
         with:
           ref: ${{github.event.pull_request.head.sha}}
           fetch-depth: 0
@@ -54,8 +63,8 @@ jobs:
           # Node >= 24 runs the .mts script directly via native type stripping.
           node-version: 24
       # Restore only: a pull request cannot write to the cache scope this reads
-      # from, and the record is just an optimization. On a miss every package to
-      # publish is verified against the registry instead.
+      # from, and the record is just an optimization. On a miss everything is
+      # verified against the registry instead.
       - name: Restore record of published packages
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -86,11 +95,16 @@ jobs:
           path: ${{ runner.temp }}/${{ env.CACHE_PATH_SUFFIX }}
           key: ${{ env.CACHE_KEY_PREFIX }}${{ hashFiles('packages/*/CHANGELOG.md', 'smithy-typescript-ssdk-libs/*/CHANGELOG.md') }}
           restore-keys: ${{ env.CACHE_KEY_PREFIX }}
-      # An exact key hit means the record already covers this set of packages, so
-      # there is nothing to query or save. Otherwise the registry is queried for
-      # the names not in the restored record and the updated record is saved by
-      # this action's post step.
-      - name: Record which packages exist on npm
+      # An exact key hit means the record already covers this set of packages and
+      # versions, so there is nothing to query or save. Otherwise the registry is
+      # queried for whatever the restored record does not cover and the updated
+      # record is saved by this action's post step.
+      #
+      # A version can still be missing from the record after a hit: this refresh
+      # races the release workflow that publishes it. The record then catches up on
+      # the next bump, and until it does the release PR checks query the registry,
+      # which is authoritative either way.
+      - name: Record which packages and versions exist on npm
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           PUBLISHED_PACKAGES_RECORD: ${{ runner.temp }}/${{ env.CACHE_PATH_SUFFIX }}/record.json

--- a/scripts/npm-packages/ensure-packages-exist-on-npm.mts
+++ b/scripts/npm-packages/ensure-packages-exist-on-npm.mts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Fails when a package this PR will publish does not yet exist on npm.
+ * Fails when a package this PR will publish does not yet exist on npm, or when
+ * the version it supersedes was never published.
  *
  * npm trusted publishing (OIDC) can only be configured for a package that
  * already exists on the registry. A brand-new package name therefore cannot
@@ -9,9 +10,16 @@
  * be published manually, after which a maintainer configures this repository's
  * GitHub Actions workflow as a trusted publisher.
  *
+ * The release workflow only publishes the new versions, so if a previous release
+ * never reached the registry - its publish job failed, was cancelled, or only
+ * got part of the way through - merging this PR strands the versions it bumps
+ * past: they exist in git, in the changelogs and in the release tags, but never
+ * on npm, and no later release will publish them.
+ *
  * This check runs on the changesets "Version NPM packages" release PR, so
  * maintainers complete that one-time manual setup *before* the PR is merged
- * instead of discovering a confusing auth failure during release.
+ * instead of discovering a confusing auth failure during release, and so an
+ * incomplete release is caught while it can still be finished.
  *
  * The set of packages to publish is derived from the changeset-release/main
  * branch itself: `changeset version` commits a bump to the `version` field of
@@ -21,10 +29,12 @@
  * package.json under a workspace root declared in the root package.json
  * (packages/*, smithy-typescript-ssdk-libs/*, private/*) whose version differs
  * from that fork point, or is newly added, will be published - excluding
- * private packages, which are never released.
+ * private packages, which are never released. The version at that fork point is
+ * the one being superseded; a package the branch adds supersedes nothing, so only
+ * its name is checked.
  *
- * Packages already recorded as published (see shared.mts) skip their registry
- * check; the rest are queried. Runs directly via Node type stripping
+ * Packages and versions already recorded as published (see shared.mts) skip their
+ * registry check; the rest are queried. Runs directly via Node type stripping
  * (Node >= 24, no build step).
  *
  * Usage:
@@ -37,14 +47,24 @@ import path from "node:path";
 
 import {
   fail,
+  formatPackageVersion,
   isPublishable,
   loadRecord,
   type PackageJson,
+  type PackageVersion,
   partitionByExistence,
+  partitionVersionsByExistence,
   root,
   warnUnknown,
   WORKSPACE_ROOTS,
 } from "./shared.mts";
+
+/** A package this PR will publish, with the version it supersedes. */
+interface PackageToPublish {
+  name: string;
+  /** The version at the fork point from main; null when the PR adds the package. */
+  previousVersion: string | null;
+}
 
 const args = process.argv.slice(2);
 for (const arg of args) {
@@ -102,13 +122,13 @@ function isWorkspaceManifest(relPath: string): boolean {
 }
 
 /**
- * Returns the publishable package names whose new versions this PR will publish:
+ * Returns the publishable packages whose new versions this PR will publish:
  * those whose <root>/<package>/package.json version differs from the fork point
- * or is newly added. Exits non-zero when the base ref or diff cannot be
- * resolved, since the set to publish cannot be determined and the check must
- * not silently pass.
+ * or is newly added, each with the version it supersedes. Exits non-zero when
+ * the base ref or diff cannot be resolved, since the set to publish cannot be
+ * determined and the check must not silently pass.
  */
-function getPackageNamesToPublish(): string[] {
+function getPackagesToPublish(): PackageToPublish[] {
   const baseRef = getBaseRef();
   if (!baseRef) {
     fail(`Could not resolve the merge-base of ${COMPARE_REF} and HEAD; ensure full git history is available.`);
@@ -126,7 +146,7 @@ function getPackageNamesToPublish(): string[] {
     fail(`Could not diff packages against ${COMPARE_REF}: ${(e as Error).message}`);
   }
 
-  const toPublish: string[] = [];
+  const toPublish: PackageToPublish[] = [];
   for (const relPath of changedFiles) {
     if (!isWorkspaceManifest(relPath)) {
       continue;
@@ -139,14 +159,15 @@ function getPackageNamesToPublish(): string[] {
     if (!isPublishable(pkgJson)) {
       continue;
     }
-    if (pkgJson.version !== getBaseVersion(baseRef, relPath)) {
-      toPublish.push(pkgJson.name as string);
+    const previousVersion = getBaseVersion(baseRef, relPath);
+    if (pkgJson.version !== previousVersion) {
+      toPublish.push({ name: pkgJson.name as string, previousVersion });
     }
   }
   return toPublish;
 }
 
-const packages = getPackageNamesToPublish();
+const packages = getPackagesToPublish();
 
 if (packages.length === 0) {
   fail(
@@ -156,31 +177,35 @@ if (packages.length === 0) {
       'This check is expected to run on the changesets "Version NPM packages"',
       "release PR, where at least one package.json version is bumped. An empty",
       "set to publish usually means it ran on the wrong ref or the branch is not",
-      "a release branch. Failing to avoid silently skipping the new-package check.",
+      "a release branch. Failing to avoid silently skipping the checks below.",
     ].join("\n")
   );
 }
 
-const confirmed = loadRecord();
-const toVerify = packages.filter((name) => !confirmed.has(name));
-const knownCount = packages.length - toVerify.length;
+const record = loadRecord();
 
-if (toVerify.length === 0) {
-  console.log(
-    `✅ All ${packages.length} package(s) to publish are recorded as published in the cached record; skipped npm registry checks.`
-  );
-  process.exit(0);
-}
+// Do the package names exist on npm at all? Nothing can be published under a name
+// the registry does not have.
+const namesToVerify = packages.map((pkg) => pkg.name).filter((name) => !record.has(name));
+const names = await partitionByExistence(namesToVerify);
+warnUnknown(names.unknown);
+const neverPublished = new Set(names.missing);
 
-const { missing, unknown } = await partitionByExistence(toVerify);
+// Are the versions being superseded published? A package whose name is missing
+// entirely has nothing published to supersede, so it is left to the check above.
+const supersededVersions: PackageVersion[] = packages
+  .filter((pkg) => pkg.previousVersion !== null && !neverPublished.has(pkg.name))
+  .map((pkg) => ({ name: pkg.name, version: pkg.previousVersion as string }));
+const versionsToVerify = supersededVersions.filter(({ name, version }) => record.get(name) !== version);
+const versions = await partitionVersionsByExistence(versionsToVerify);
+warnUnknown(versions.unknown.map(formatPackageVersion));
 
-warnUnknown(unknown);
-
-if (missing.length) {
-  fail(
-    [
-      `${missing.length} package(s) this PR will publish have never been published to npm:`,
-      ...missing.map((n) => `  - ${n}`),
+if (names.missing.length || versions.missing.length) {
+  const report: string[] = [];
+  if (names.missing.length) {
+    report.push(
+      `${names.missing.length} package(s) this PR will publish have never been published to npm:`,
+      ...names.missing.map((n) => `  - ${n}`),
       "",
       "npm trusted publishing (OIDC) only works for packages that already",
       "exist on the registry, so the automated release workflow cannot",
@@ -195,12 +220,37 @@ if (missing.length) {
       "After that one-time setup, re-run this check. Every subsequent release",
       "will publish automatically via OIDC.",
       "",
-      "Refer internal runbook for npm credentials.",
-    ].join("\n")
-  );
+      "Refer internal runbook for npm credentials."
+    );
+  }
+  if (versions.missing.length) {
+    if (report.length) {
+      report.push("", "");
+    }
+    report.push(
+      `${versions.missing.length} version(s) this PR supersedes are not published on npm:`,
+      ...versions.missing.map((v) => `  - ${formatPackageVersion(v)}`),
+      "",
+      "A previous release PR versioned these, but the release that should have",
+      "published them did not complete. Merging this PR bumps past them, and no",
+      "later release will ever publish them. A maintainer must:",
+      "",
+      "  1. Open the most recent release-npm-packages.yml run and find out why",
+      "     the publish did not finish.",
+      "  2. Get the versions above onto npm, by re-running that workflow or by",
+      "     publishing them manually from the release commit.",
+      "  3. Re-run this check."
+    );
+  }
+  fail(report.join("\n"));
 }
 
+const queried = namesToVerify.length + versionsToVerify.length;
+const fromRecord = packages.length - namesToVerify.length + supersededVersions.length - versionsToVerify.length;
+const newPackages = packages.length - supersededVersions.length;
 console.log(
-  `✅ All ${packages.length} package(s) to publish exist on npm ` +
-    `(${knownCount} from the cached record, ${toVerify.length} verified via registry).`
+  `✅ All ${packages.length} package(s) to publish exist on npm, and the ${supersededVersions.length} version(s) ` +
+    `they supersede are published` +
+    (newPackages ? ` (${newPackages} package(s) are new in this PR and supersede nothing)` : "") +
+    `: ${fromRecord} check(s) from the cached record, ${queried} verified via registry.`
 );

--- a/scripts/npm-packages/refresh-npm-package-record.mts
+++ b/scripts/npm-packages/refresh-npm-package-record.mts
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
 
 /**
- * Records which of this repository's publishable packages exist on npm.
+ * Records which of this repository's publishable packages, and which of their
+ * versions, exist on npm.
  *
- * Runs on push to main so release PRs can skip the registry check for names
- * already known to exist (see ensure-packages-exist-on-npm.mts). The record is
- * carried between runs by the GitHub Actions cache; only pushes to main may
- * write to the cache scope that pull requests restore from, which is why the
- * refresh happens here and not on the release PR itself.
+ * Runs on push to main so release PRs can skip the registry check for names and
+ * versions already known to exist (see ensure-packages-exist-on-npm.mts). The
+ * version recorded for a package is the one on main, which is the version the
+ * next release PR supersedes. The record is carried between runs by the GitHub
+ * Actions cache; only pushes to main may write to the cache scope that pull
+ * requests restore from, which is why the refresh happens here and not on the
+ * release PR itself.
  *
- * Packages that have never been published are reported but never fail the run:
- * a package can legitimately sit on main unpublished until a maintainer does its
- * one-time manual first publish. Enforcing that is the release PR check's job.
+ * Versions that are not on npm are reported but never fail the run: the release
+ * publishing them may still be in flight, and a package can legitimately sit on
+ * main unpublished until a maintainer does its one-time manual first publish.
+ * Enforcing that is the release PR check's job.
  *
  * Runs directly via Node type stripping (Node >= 24, no build step).
  *
@@ -21,9 +25,11 @@
 
 import {
   fail,
-  getAllPublishablePackageNames,
+  formatPackageVersion,
+  getAllPublishablePackages,
   loadRecord,
-  partitionByExistence,
+  partitionVersionsByExistence,
+  type PublishedRecord,
   RECORD_DISPLAY,
   saveRecord,
   warnUnknown,
@@ -33,31 +39,37 @@ if (process.argv.length > 2) {
   fail(`Unexpected argument ${process.argv[2]}. Usage: node refresh-npm-package-record.mts`);
 }
 
-const packages = getAllPublishablePackageNames();
+const packages = getAllPublishablePackages();
 const record = loadRecord();
-// Only keep names still present in the repository, so the record stays a
+// Only keep packages still present in the repository, so the record stays a
 // description of this repository rather than growing forever.
-const confirmed = new Set(packages.filter((name) => record.has(name)));
-const toVerify = packages.filter((name) => !confirmed.has(name));
+const confirmed: PublishedRecord = new Map(
+  packages.filter((pkg) => record.has(pkg.name)).map((pkg) => [pkg.name, record.get(pkg.name) as string])
+);
+const toVerify = packages.filter((pkg) => confirmed.get(pkg.name) !== pkg.version);
 
 if (toVerify.length === 0) {
   saveRecord(confirmed);
-  console.log(`✅ All ${packages.length} publishable package(s) are already recorded as published on npm.`);
+  console.log(
+    `✅ All ${packages.length} publishable package(s) are already recorded as published on npm at their current version.`
+  );
   process.exit(0);
 }
 
-const { exists, missing, unknown } = await partitionByExistence(toVerify);
-for (const name of exists) {
-  confirmed.add(name);
+const { exists, missing, unknown } = await partitionVersionsByExistence(toVerify);
+for (const { name, version } of exists) {
+  // The newest confirmed version replaces the previous one, since it is the
+  // version a release PR forked from main will look up.
+  confirmed.set(name, version);
 }
 saveRecord(confirmed);
+warnUnknown(unknown.map(formatPackageVersion));
 
-warnUnknown(unknown);
 if (missing.length) {
   console.log(
-    `ℹ️  ${missing.length} package(s) have never been published to npm and need a one-time manual first ` +
-      `publish before a release can include them:\n  ` +
-      missing.join("\n  ")
+    `ℹ️  ${missing.length} version(s) on main are not on npm, either because the release publishing them has ` +
+      `not finished or because the package has never been published at all:\n  ` +
+      missing.map(formatPackageVersion).join("\n  ")
   );
 }
 console.log(

--- a/scripts/npm-packages/shared.mts
+++ b/scripts/npm-packages/shared.mts
@@ -1,24 +1,30 @@
 /**
- * Shared helpers for the two npm package existence entrypoints in this folder:
- * ensure-packages-exist-on-npm.mts (release PR check) and
- * refresh-npm-package-record.mts (cache refresh on main).
+ * Shared helpers for the two npm registry entrypoints in this folder:
  *
- * Both answer the same question - which of this repository's package names
- * already exist on the npm registry - so the registry probe, the record format
- * and the workspace enumeration live here.
+ * - ensure-packages-exist-on-npm.mts - release PR check: the package names it
+ *                                      will publish, and the versions it bumps
+ *                                      past, already exist on npm.
+ * - refresh-npm-package-record.mts   - refreshes the cached record on main.
  *
- * The record is a list of package names confirmed to exist on npm. npm
- * publishes are immutable (a published name can never be unpublished or
- * reused), so a recorded name is guaranteed to still exist and its registry
- * check can be skipped. Its location comes from PUBLISHED_PACKAGES_RECORD; in
- * CI that file is a GitHub Actions cache entry (see
- * .github/workflows/npm-package-existence.yml): the refresh run on main writes
- * it and release PRs restore it read-only. It is only an optimization, so a
- * cache miss just means every package is verified against the registry.
+ * Both answer variations of one question - which of this repository's package
+ * names and versions exist on the npm registry - so the registry probe, the record
+ * format and the workspace enumeration live here. What each entrypoint does with
+ * those - which packages it looks at, and what it does when one is missing - stays
+ * in the entrypoint.
  *
- * Only names the registry confirmed present are ever recorded. A missing or
- * unreachable package must never be written to the record, otherwise a real
- * check would be skipped later.
+ * The record maps a package name confirmed to exist on npm to the version of it
+ * most recently confirmed published. npm publishes are immutable (neither a name
+ * nor a version can ever be unpublished or reused), so anything recorded is
+ * guaranteed to still exist and its registry check can be skipped. The record's
+ * location comes from PUBLISHED_PACKAGES_RECORD; in CI that file is a GitHub
+ * Actions cache entry (see
+ * .github/workflows/npm-package-existence.yml): the refresh run on main writes it
+ * and release PRs restore it read-only. It is only an optimization, so a cache
+ * miss just means everything is verified against the registry.
+ *
+ * Only what the registry confirmed present is ever recorded. A missing or
+ * unreachable package or version must never be written to the record, otherwise a
+ * real check would be skipped later.
  *
  * These files run directly via Node type stripping (Node >= 24, no build step)
  * and use top-level await, hence the .mts extension.
@@ -29,12 +35,18 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type ExistStatus = "exists" | "missing" | "unknown";
+type ExistStatus = "exists" | "missing" | "unknown";
 
 export interface PackageJson {
   name?: string;
   version?: string;
   private?: boolean;
+}
+
+/** One version of one package, as probed against the registry and reported. */
+export interface PackageVersion {
+  name: string;
+  version: string;
 }
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -49,14 +61,10 @@ export function fail(message: string): never {
   process.exit(1);
 }
 
-// Not checked in: CI restores it from (and refreshes it into) the GitHub Actions
-// cache, and a local run without PUBLISHED_PACKAGES_RECORD just starts from an
-// empty record.
-const RECORD_PATH =
-  process.env.PUBLISHED_PACKAGES_RECORD || path.join(os.tmpdir(), "smithy-typescript", "published-packages.json");
-
-/** The record location, relative to the repository root when it is inside it. */
-export const RECORD_DISPLAY = RECORD_PATH.startsWith(root + path.sep) ? path.relative(root, RECORD_PATH) : RECORD_PATH;
+/** Renders a package version the way npm does, e.g. @smithy/core@3.31.0. */
+export function formatPackageVersion({ name, version }: PackageVersion): string {
+  return `${name}@${version}`;
+}
 
 /**
  * A package is publishable if it has a name and is not private. Private
@@ -93,10 +101,12 @@ function getWorkspaceRoots(): string[] {
 export const WORKSPACE_ROOTS = getWorkspaceRoots();
 
 /**
- * Returns the names of every publishable package in every workspace root.
+ * Returns every publishable package in every workspace root, at the version it
+ * currently declares. A manifest without a version is skipped: there is nothing
+ * to look up on the registry for it.
  */
-export function getAllPublishablePackageNames(): string[] {
-  const names: string[] = [];
+export function getAllPublishablePackages(): PackageVersion[] {
+  const packages: PackageVersion[] = [];
   for (const workspaceRoot of WORKSPACE_ROOTS) {
     const workspaceDir = path.join(root, workspaceRoot);
     for (const dir of fs.readdirSync(workspaceDir)) {
@@ -105,20 +115,20 @@ export function getAllPublishablePackageNames(): string[] {
         continue;
       }
       const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")) as PackageJson;
-      if (isPublishable(pkgJson)) {
-        names.push(pkgJson.name as string);
+      if (isPublishable(pkgJson) && pkgJson.version) {
+        packages.push({ name: pkgJson.name as string, version: pkgJson.version });
       }
     }
   }
-  return names;
+  return packages;
 }
 
 /**
  * Resolves to "exists", "missing", or "unknown" (network/registry error).
  */
-async function checkExists(name: string, attempt = 0): Promise<ExistStatus> {
+async function probe(url: string, attempt = 0): Promise<ExistStatus> {
   try {
-    const res = await fetch(`${REGISTRY}/${name.replace("/", "%2F")}`, { method: "HEAD" });
+    const res = await fetch(url, { method: "HEAD" });
     if (res.status === 404) {
       return "missing";
     }
@@ -127,30 +137,54 @@ async function checkExists(name: string, attempt = 0): Promise<ExistStatus> {
     }
     // Unexpected status: retry before giving up.
     if (attempt < 2) {
-      return checkExists(name, attempt + 1);
+      return probe(url, attempt + 1);
     }
     return "unknown";
   } catch {
     if (attempt < 2) {
-      return checkExists(name, attempt + 1);
+      return probe(url, attempt + 1);
     }
     return "unknown";
   }
 }
 
-/**
- * Queries the registry for the given names and splits them by existence.
- */
-export async function partitionByExistence(names: string[]) {
-  const results = await Promise.all(names.map(async (name) => ({ name, status: await checkExists(name) })));
-  return {
-    exists: results.filter((r) => r.status === "exists").map((r) => r.name),
-    missing: results.filter((r) => r.status === "missing").map((r) => r.name),
-    unknown: results.filter((r) => r.status === "unknown").map((r) => r.name),
-  };
+/** The registry URL of a package, i.e. its packument. */
+function packageUrl(name: string): string {
+  return `${REGISTRY}/${name.replace("/", "%2F")}`;
 }
 
-/** Warns about names the registry could not answer for. */
+/** Whether the package name exists on npm, in any version. */
+function checkExists(name: string): Promise<ExistStatus> {
+  return probe(packageUrl(name));
+}
+
+/** Whether that exact version of the package is published on npm. */
+function checkVersionExists({ name, version }: PackageVersion): Promise<ExistStatus> {
+  return probe(`${packageUrl(name)}/${encodeURIComponent(version)}`);
+}
+
+async function partition<T>(items: T[], check: (item: T) => Promise<ExistStatus>) {
+  const results = await Promise.all(items.map(async (item) => ({ item, status: await check(item) })));
+  const withStatus = (status: ExistStatus) => results.filter((r) => r.status === status).map((r) => r.item);
+  return { exists: withStatus("exists"), missing: withStatus("missing"), unknown: withStatus("unknown") };
+}
+
+/**
+ * Queries the registry for the given package names and splits them by existence.
+ */
+export function partitionByExistence(names: string[]) {
+  return partition(names, checkExists);
+}
+
+/**
+ * Queries the registry for the given package versions and splits them by
+ * existence.
+ */
+export function partitionVersionsByExistence(versions: PackageVersion[]) {
+  return partition(versions, checkVersionExists);
+}
+
+/** Warns about entries the registry could not answer for. */
 export function warnUnknown(unknown: string[]): void {
   if (unknown.length) {
     console.warn(
@@ -161,23 +195,52 @@ export function warnUnknown(unknown: string[]): void {
 }
 
 /**
- * Loads the set of package names already confirmed published. Returns an empty
- * set if the record is absent or unreadable, in which case every package is
- * verified against the registry.
+ * Package names confirmed to exist on npm, mapped to the version of them most
+ * recently confirmed published. One version per package is enough: the only
+ * version ever looked up is the one a release PR bumps past, which is the version
+ * on main that the last refresh recorded. A recorded name implies the name exists
+ * on npm, whether or not the recorded version is the one being looked up.
  */
-export function loadRecord(): Set<string> {
+export type PublishedRecord = Map<string, string>;
+
+// Not checked in: CI restores it from (and refreshes it into) the GitHub Actions
+// cache, and a local run without PUBLISHED_PACKAGES_RECORD just starts from an
+// empty record.
+const RECORD_PATH =
+  process.env.PUBLISHED_PACKAGES_RECORD || path.join(os.tmpdir(), "smithy-typescript", "published-packages.json");
+
+/** The record location, relative to the repository root when it is inside it. */
+export const RECORD_DISPLAY = RECORD_PATH.startsWith(root + path.sep) ? path.relative(root, RECORD_PATH) : RECORD_PATH;
+
+/**
+ * Loads the record. Returns an empty record if it is absent, unreadable or not
+ * in the expected shape, in which case everything is verified against the
+ * registry.
+ */
+export function loadRecord(): PublishedRecord {
   try {
-    const data = JSON.parse(fs.readFileSync(RECORD_PATH, "utf-8"));
-    return new Set<string>(Array.isArray(data.packages) ? data.packages : []);
+    const { packages } = JSON.parse(fs.readFileSync(RECORD_PATH, "utf-8")) as {
+      packages?: Record<string, string>;
+    };
+    if (!packages || typeof packages !== "object" || Array.isArray(packages)) {
+      return new Map();
+    }
+    return new Map(Object.entries(packages).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
   } catch {
-    return new Set<string>();
+    return new Map();
   }
 }
 
 /**
  * Writes the record so the workflow can store it in the GitHub Actions cache.
+ * Paired with loadRecord, which must read back what this writes; how the record
+ * is filled in between is up to its only writer, refresh-npm-package-record.mts.
  */
-export function saveRecord(names: Iterable<string>): void {
+export function saveRecord(record: PublishedRecord): void {
+  const packages: Record<string, string> = {};
+  for (const name of [...record.keys()].sort()) {
+    packages[name] = record.get(name) as string;
+  }
   fs.mkdirSync(path.dirname(RECORD_PATH), { recursive: true });
   fs.writeFileSync(
     RECORD_PATH,
@@ -185,9 +248,10 @@ export function saveRecord(names: Iterable<string>): void {
       {
         "//":
           "Generated by scripts/npm-packages/refresh-npm-package-record.mts and cached by " +
-          ".github/workflows/npm-package-existence.yml. Packages confirmed published to npm; " +
-          "their registry existence check is skipped, since npm publishes are immutable. Do not edit by hand.",
-        packages: [...names].sort(),
+          ".github/workflows/npm-package-existence.yml. Package names confirmed published to npm, mapped to " +
+          "the version of them most recently confirmed published; their registry checks are skipped, since " +
+          "npm publishes are immutable. Do not edit by hand.",
+        packages,
       },
       null,
       2


### PR DESCRIPTION
_Issue #, if available:_

Internal JS-7089

_Description of changes:_

The release workflow publishes only the versions a release PR adds. If a
previous release never reached the registry, merging the next release PR
bumps past the versions it should have published: they stay in git, in the
changelogs and in the tags, but never appear on npm, and no later release
will publish them.

Extend the release PR check so that, for every package it publishes, the
version at the branch's fork point from main must exist on npm. Failures
are reported in two groups, because they need different fixes: packages
never published at all still need their one-time manual first publish,
while a published package missing the version on main means the last
release did not finish.

The cached record now maps each confirmed package name to the version of
it most recently confirmed published, so both halves of the check can skip
registry queries. Only main's current version is ever looked up, so one
version per package is enough. Bump the cache key prefix to v2 for the new
shape.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
