### PR TITLE
ci: fold npm name check into the version check

### DIFF
--- a/scripts/npm-packages/ensure-packages-exist-on-npm.mts
+++ b/scripts/npm-packages/ensure-packages-exist-on-npm.mts
@@ -33,9 +33,10 @@
  * the one being superseded; a package the branch adds supersedes nothing, so only
  * its name is checked.
  *
- * Packages and versions already recorded as published (see shared.mts) skip their
- * registry check; the rest are queried. Runs directly via Node type stripping
- * (Node >= 24, no build step).
+ * Each package costs one registry check: the version it supersedes, since a
+ * published version implies a published name. Checks already answered by the
+ * record (see shared.mts) are skipped; the rest are queried. Runs directly via
+ * Node type stripping (Node >= 24, no build step).
  *
  * Usage:
  *   node ensure-packages-exist-on-npm.mts [compareRef]   # defaults to origin/main
@@ -48,12 +49,11 @@ import path from "node:path";
 import {
   fail,
   formatPackageVersion,
-  isPublishable,
   loadRecord,
+  type PackageCheck,
   type PackageJson,
-  type PackageVersion,
   partitionByExistence,
-  partitionVersionsByExistence,
+  readPublishablePackage,
   root,
   warnUnknown,
   WORKSPACE_ROOTS,
@@ -155,13 +155,13 @@ function getPackagesToPublish(): PackageToPublish[] {
     if (!fs.existsSync(abs)) {
       continue; // package.json deleted in this PR.
     }
-    const pkgJson = JSON.parse(fs.readFileSync(abs, "utf-8")) as PackageJson;
-    if (!isPublishable(pkgJson)) {
+    const pkg = readPublishablePackage(abs);
+    if (!pkg) {
       continue;
     }
     const previousVersion = getBaseVersion(baseRef, relPath);
-    if (pkgJson.version !== previousVersion) {
-      toPublish.push({ name: pkgJson.name as string, previousVersion });
+    if (pkg.version !== previousVersion) {
+      toPublish.push({ name: pkg.name, previousVersion });
     }
   }
   return toPublish;
@@ -184,28 +184,23 @@ if (packages.length === 0) {
 
 const record = loadRecord();
 
-// Do the package names exist on npm at all? Nothing can be published under a name
-// the registry does not have.
-const namesToVerify = packages.map((pkg) => pkg.name).filter((name) => !record.has(name));
-const names = await partitionByExistence(namesToVerify);
-warnUnknown(names.unknown);
-const neverPublished = new Set(names.missing);
+// One check per package: the version it supersedes, or - for a package this PR
+// adds, which supersedes nothing - its name alone. Verifying the superseded version
+// covers the name too, since nothing can be published under a name the registry
+// does not have. What the record already confirms needs no check at all.
+const toVerify: PackageCheck[] = packages
+  .map(({ name, previousVersion }) => ({ name, version: previousVersion }))
+  .filter(({ name, version }) => (version === null ? !record.has(name) : record.get(name) !== version));
 
-// Are the versions being superseded published? A package whose name is missing
-// entirely has nothing published to supersede, so it is left to the check above.
-const supersededVersions: PackageVersion[] = packages
-  .filter((pkg) => pkg.previousVersion !== null && !neverPublished.has(pkg.name))
-  .map((pkg) => ({ name: pkg.name, version: pkg.previousVersion as string }));
-const versionsToVerify = supersededVersions.filter(({ name, version }) => record.get(name) !== version);
-const versions = await partitionVersionsByExistence(versionsToVerify);
-warnUnknown(versions.unknown.map(formatPackageVersion));
+const { missingNames, missingVersions, unknown } = await partitionByExistence(toVerify);
+warnUnknown(unknown.map(formatPackageVersion));
 
-if (names.missing.length || versions.missing.length) {
+if (missingNames.length || missingVersions.length) {
   const report: string[] = [];
-  if (names.missing.length) {
+  if (missingNames.length) {
     report.push(
-      `${names.missing.length} package(s) this PR will publish have never been published to npm:`,
-      ...names.missing.map((n) => `  - ${n}`),
+      `${missingNames.length} package(s) this PR will publish have never been published to npm:`,
+      ...missingNames.map(({ name }) => `  - ${name}`),
       "",
       "npm trusted publishing (OIDC) only works for packages that already",
       "exist on the registry, so the automated release workflow cannot",
@@ -223,13 +218,13 @@ if (names.missing.length || versions.missing.length) {
       "Refer internal runbook for npm credentials."
     );
   }
-  if (versions.missing.length) {
+  if (missingVersions.length) {
     if (report.length) {
       report.push("", "");
     }
     report.push(
-      `${versions.missing.length} version(s) this PR supersedes are not published on npm:`,
-      ...versions.missing.map((v) => `  - ${formatPackageVersion(v)}`),
+      `${missingVersions.length} version(s) this PR supersedes are not published on npm:`,
+      ...missingVersions.map((v) => `  - ${formatPackageVersion(v)}`),
       "",
       "A previous release PR versioned these, but the release that should have",
       "published them did not complete. Merging this PR bumps past them, and no",
@@ -245,12 +240,10 @@ if (names.missing.length || versions.missing.length) {
   fail(report.join("\n"));
 }
 
-const queried = namesToVerify.length + versionsToVerify.length;
-const fromRecord = packages.length - namesToVerify.length + supersededVersions.length - versionsToVerify.length;
-const newPackages = packages.length - supersededVersions.length;
+const newPackages = packages.filter((pkg) => pkg.previousVersion === null).length;
 console.log(
-  `✅ All ${packages.length} package(s) to publish exist on npm, and the ${supersededVersions.length} version(s) ` +
+  `✅ All ${packages.length} package(s) to publish exist on npm, and the ${packages.length - newPackages} version(s) ` +
     `they supersede are published` +
     (newPackages ? ` (${newPackages} package(s) are new in this PR and supersede nothing)` : "") +
-    `: ${fromRecord} check(s) from the cached record, ${queried} verified via registry.`
+    `: ${packages.length - toVerify.length} check(s) from the cached record, ${toVerify.length} verified via registry.`
 );

--- a/scripts/npm-packages/refresh-npm-package-record.mts
+++ b/scripts/npm-packages/refresh-npm-package-record.mts
@@ -29,7 +29,7 @@ import {
   formatPackageVersion,
   getAllPublishablePackages,
   loadRecord,
-  partitionVersionsByExistence,
+  partitionByExistence,
   type PublishedRecord,
   RECORD_DISPLAY,
   saveRecord,
@@ -57,7 +57,9 @@ if (toVerify.length === 0) {
   process.exit(0);
 }
 
-const { exists, missing, unknown } = await partitionVersionsByExistence(toVerify);
+const { exists, missingNames, missingVersions, unknown } = await partitionByExistence(toVerify);
+// Why a version is absent does not matter here: either way it is left unrecorded.
+const missing = [...missingNames, ...missingVersions];
 for (const { name, version } of exists) {
   // The newest confirmed version replaces the previous one, since it is the
   // version a release PR forked from main will look up.

--- a/scripts/npm-packages/shared.mts
+++ b/scripts/npm-packages/shared.mts
@@ -37,6 +37,9 @@ import { fileURLToPath } from "node:url";
 
 type ExistStatus = "exists" | "missing" | "unknown";
 
+/** A missing name and a missing version are different problems, so kept apart. */
+type CheckStatus = "exists" | "missingName" | "missingVersion" | "unknown";
+
 export interface PackageJson {
   name?: string;
   version?: string;
@@ -47,6 +50,16 @@ export interface PackageJson {
 export interface PackageVersion {
   name: string;
   version: string;
+}
+
+/**
+ * What to ask the registry about one package: whether that exact version is
+ * published or, when version is null, only whether the name exists at all, in any
+ * version.
+ */
+export interface PackageCheck {
+  name: string;
+  version: string | null;
 }
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -61,19 +74,37 @@ export function fail(message: string): never {
   process.exit(1);
 }
 
-/** Renders a package version the way npm does, e.g. @smithy/core@3.31.0. */
-export function formatPackageVersion({ name, version }: PackageVersion): string {
-  return `${name}@${version}`;
+/**
+ * Renders a package version the way npm does, e.g. @smithy/core@3.31.0, or the
+ * name alone when there is no version in question.
+ */
+export function formatPackageVersion({ name, version }: PackageCheck): string {
+  return version === null ? name : `${name}@${version}`;
 }
 
 /**
- * A package is publishable if it has a name and is not private. Private
- * packages are never released: .changeset/config.json sets
+ * The name and version a manifest declares, or null when its package is private.
+ * Private packages are never released: .changeset/config.json sets
  * privatePackages.version to false, so changesets neither versions nor
  * publishes them.
+ *
+ * A manifest that is not private must declare both, since changesets versions and
+ * publishes every non-private workspace package: skipping one that does not would
+ * silently drop it from every check here.
  */
-export function isPublishable(pkgJson: PackageJson): boolean {
-  return Boolean(pkgJson.name) && pkgJson.private !== true;
+export function readPublishablePackage(pkgJsonPath: string): PackageVersion | null {
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")) as PackageJson;
+  if (pkgJson.private === true) {
+    return null;
+  }
+  if (!pkgJson.name || !pkgJson.version) {
+    fail(
+      `${path.relative(root, pkgJsonPath)} is not private but declares no ${!pkgJson.name ? "name" : "version"}, ` +
+        `so it cannot be checked against the npm registry. Add the missing field, or mark the package private if ` +
+        `it is not meant to be released.`
+    );
+  }
+  return { name: pkgJson.name, version: pkgJson.version };
 }
 
 /**
@@ -102,8 +133,8 @@ export const WORKSPACE_ROOTS = getWorkspaceRoots();
 
 /**
  * Returns every publishable package in every workspace root, at the version it
- * currently declares. A manifest without a version is skipped: there is nothing
- * to look up on the registry for it.
+ * currently declares. A workspace root also holds entries that are not packages,
+ * such as a README, which have no manifest to read.
  */
 export function getAllPublishablePackages(): PackageVersion[] {
   const packages: PackageVersion[] = [];
@@ -114,9 +145,9 @@ export function getAllPublishablePackages(): PackageVersion[] {
       if (!fs.existsSync(pkgJsonPath)) {
         continue;
       }
-      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")) as PackageJson;
-      if (isPublishable(pkgJson) && pkgJson.version) {
-        packages.push({ name: pkgJson.name as string, version: pkgJson.version });
+      const pkg = readPublishablePackage(pkgJsonPath);
+      if (pkg) {
+        packages.push(pkg);
       }
     }
   }
@@ -153,35 +184,40 @@ function packageUrl(name: string): string {
   return `${REGISTRY}/${name.replace("/", "%2F")}`;
 }
 
-/** Whether the package name exists on npm, in any version. */
-function checkExists(name: string): Promise<ExistStatus> {
-  return probe(packageUrl(name));
-}
-
-/** Whether that exact version of the package is published on npm. */
-function checkVersionExists({ name, version }: PackageVersion): Promise<ExistStatus> {
-  return probe(`${packageUrl(name)}/${encodeURIComponent(version)}`);
-}
-
-async function partition<T>(items: T[], check: (item: T) => Promise<ExistStatus>) {
-  const results = await Promise.all(items.map(async (item) => ({ item, status: await check(item) })));
-  const withStatus = (status: ExistStatus) => results.filter((r) => r.status === status).map((r) => r.item);
-  return { exists: withStatus("exists"), missing: withStatus("missing"), unknown: withStatus("unknown") };
+/**
+ * Resolves one check against the registry. A published version implies a
+ * published name, so probing the version answers both questions whenever it finds
+ * it. The name is probed on its own only when there is no version to ask about,
+ * or when the version is absent and the two problems have to be told apart - and
+ * a name probe the registry cannot answer counts as a missing version, since the
+ * 404 on the version is definitive either way.
+ */
+async function check({ name, version }: PackageCheck): Promise<CheckStatus> {
+  if (version === null) {
+    const nameOnly = await probe(packageUrl(name));
+    return nameOnly === "missing" ? "missingName" : nameOnly;
+  }
+  const status = await probe(`${packageUrl(name)}/${encodeURIComponent(version)}`);
+  if (status !== "missing") {
+    return status;
+  }
+  return (await probe(packageUrl(name))) === "missing" ? "missingName" : "missingVersion";
 }
 
 /**
- * Queries the registry for the given package names and splits them by existence.
+ * Queries the registry for the given checks and splits them by what it found:
+ * names that do not exist at all, versions that are not published under a name
+ * that does, and checks the registry could not answer.
  */
-export function partitionByExistence(names: string[]) {
-  return partition(names, checkExists);
-}
-
-/**
- * Queries the registry for the given package versions and splits them by
- * existence.
- */
-export function partitionVersionsByExistence(versions: PackageVersion[]) {
-  return partition(versions, checkVersionExists);
+export async function partitionByExistence<T extends PackageCheck>(checks: T[]) {
+  const results = await Promise.all(checks.map(async (item) => ({ item, status: await check(item) })));
+  const withStatus = (status: CheckStatus) => results.filter((r) => r.status === status).map((r) => r.item);
+  return {
+    exists: withStatus("exists"),
+    missingNames: withStatus("missingName"),
+    missingVersions: withStatus("missingVersion"),
+    unknown: withStatus("unknown"),
+  };
 }
 
 /** Warns about entries the registry could not answer for. */


### PR DESCRIPTION
_Issue #, if available:_

Refs: https://github.com/smithy-lang/smithy-typescript/pull/2192#issuecomment-5109680020

_Description of changes:_

The release PR check asked the registry two questions per package: does
the name exist, and is the version it supersedes published. A published
version already implies a published name, so the name probe was
redundant on every passing check - 118 requests for 59 packages.

Collapse both into one list of checks, where a null version means the
package is new in this PR and only its name can be checked. The name is
probed on its own only when a version comes back missing, to keep the
two failures distinguishable: a package that was never published needs a
manual first publish plus trusted publisher setup, while an absent
version means an earlier release never finished. partitionByExistence
now covers both cases and reports missingNames separately from
missingVersions; partitionVersionsByExistence is gone, and the record
refresh merges the two buckets since it leaves anything unconfirmed
unrecorded either way.

Replace isPublishable with readPublishablePackage, which reads a
manifest and requires a name and version unless it is private. A
publishable package missing either was previously skipped, dropping it
silently from both the record and the release check; it now fails with
the manifest path and what to fix.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
