### PR TITLE
ci: hand off npm record refresh via dispatch

### DIFF
--- a/.github/workflows/npm-package-existence.yml
+++ b/.github/workflows/npm-package-existence.yml
@@ -13,16 +13,19 @@ on:
   # on the registry by the time they are probed. Refreshing on push to main instead
   # would race that release and record its versions as absent.
   #
-  # workflow_run also happens to be the trigger this needs for cache access: it
-  # runs in the context of the default branch, and only trusted triggers like it
-  # may write to the default branch's cache scope, which is the scope pull request
-  # runs restore from. The record is therefore always written from main and never
-  # from a pull request.
-  workflow_run:
-    workflows:
-      - release-npm-packages
+  # release-npm-packages.yml raises this event, rather than this workflow listening
+  # for it to complete, for cache access: only a trusted trigger may write to the
+  # default branch's cache scope, which is what pull request runs restore from, and
+  # workflow_run is untrusted - a fork pull request can cascade into it - so its
+  # save is denied. repository_dispatch is trusted, GITHUB_TOKEN may raise it, and
+  # it always runs the default branch. See
+  # https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/.
+  #
+  # A dispatch of a type not listed below starts no run and reports no error, so
+  # keep the type in step with the step that raises it.
+  repository_dispatch:
     types:
-      - completed
+      - npm-release-published
 
 permissions:
   contents: read
@@ -92,17 +95,15 @@ jobs:
   refresh-npm-package-record:
     runs-on: ubuntu-latest
     name: Refresh record of published packages
-    # A release that failed, was cancelled or published nothing leaves the versions
-    # on main absent from the registry, which is what the next release PR's check
-    # must discover for itself - so there is nothing to record.
-    if: github.event.workflow_run.conclusion == 'success'
+    # The release raises the event only once it has published, so a release that
+    # failed, was cancelled or published nothing never gets here: those versions
+    # stay absent from the registry, which is what the next release PR's check must
+    # discover for itself - so there is nothing to record.
+    if: github.event_name == 'repository_dispatch'
     steps:
+      # main, which is what repository_dispatch always runs, and the branch whose
+      # cache scope the record below is stored under.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        # workflow_run checks out the default branch by default, but the release was
-        # triggered by a merged pull request, so name main explicitly to be sure the
-        # versions read here are the ones that were just published.
-        with:
-          ref: main
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node >= 24 runs the .mts script directly via native type stripping.

--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -55,6 +55,20 @@ jobs:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Hand off to npm-package-existence.yml, which records the versions just
+      # published so the next release PR's check can skip the registry for them.
+      # It must list this event type; see the rationale for the hand-off there.
+      #
+      # Nothing to record if the publish did not happen, and best-effort because
+      # failing here would fire the notification below for a release that
+      # succeeded, while the record is only an optimization.
+      - name: Refresh record of published packages
+        if: steps.release.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # $GITHUB_REPOSITORY, not a ${{ }} expansion, to keep interpolation out of the shell command.
+        run: gh api "repos/$GITHUB_REPOSITORY/dispatches" -f event_type=npm-release-published
       - name: Failure Nofitication
         if: ${{ failure() }}
         run: aws cloudwatch put-metric-data --namespace SmithyTypeScriptPublish --metric-name NpmPackagePublishFailure --value 1


### PR DESCRIPTION
_Issue #, if available:_

The refresh of the cached record of published npm packages ran on workflow_run and could no longer save the cache:
```console
Failed to save: Unable to reserve cache with key published-packages-v2-1813ec8ac5d1157a53c0d378310bbd63e462f1f0b6848559f7a9feca078bc78d. More details: cache write denied: token has no writable scopes
```
Workflow run: https://github.com/smithy-lang/smithy-typescript/actions/runs/30466471816

_Description of changes:_

GitHub now issues read-only cache tokens to runs that write to the default branch's cache scope from an untrusted trigger, and workflow_run is untrusted because a fork pull request can cascade into it. The save was denied, so the record was never written and every release PR check fell back to probing the registry for every package.

Have `release-npm-packages.yml` raise a `repository_dispatch` event once it has published instead. That trigger keeps read-write access to the scope, `GITHUB_TOKEN` may raise it with the `contents: write` the release job already holds, and it always runs the default branch - so the ordering the refresh depends on, running only after the publish finished, is preserved. The hand-off is best-effort, since failing it would fire the release failure notification for a release that succeeded.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
