### PR TITLE
feat(server-common): make SchemaServiceHandler directly instantiable

### DIFF
--- a/.changeset/spotty-books-cry.md
+++ b/.changeset/spotty-books-cry.md
@@ -1,0 +1,5 @@
+---
+"@smithy/server-common": minor
+---
+
+make SchemaServiceHandler directly instantiable without a generated extending class

--- a/packages/server-common/src/service-handler/SchemaServiceHandler.spec.ts
+++ b/packages/server-common/src/service-handler/SchemaServiceHandler.spec.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it, vi } from "vitest";
+import { HttpRequest, HttpResponse } from "@smithy/core/protocols";
+import type { StaticOperationSchema } from "@smithy/types";
+
+import { SchemaServiceHandler } from "./SchemaServiceHandler";
+import type { SchemaServiceHandlerOptions, ServerRequestContext } from "./SchemaServiceHandler";
+import { ServiceException } from "../validation/errors";
+import { SmithyRpcV2CborServerProtocol } from "../protocols-schema/layer-2-protocols/SmithyRpcV2CborServerProtocol";
+
+function makeOpSchema(name: string): StaticOperationSchema {
+  return [9, "test.ns", name, 0, "unit", "unit"] satisfies StaticOperationSchema;
+}
+
+function makeMinimalOptions(overrides: Partial<SchemaServiceHandlerOptions> = {}): SchemaServiceHandlerOptions {
+  return {
+    protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+    operationSchemas: [makeOpSchema("TestOp")],
+    handlers: {
+      TestOp: async () => ({}),
+    },
+    ...overrides,
+  };
+}
+
+function makeRpcRequest(operationName: string, body?: Uint8Array): HttpRequest {
+  return new HttpRequest({
+    method: "POST",
+    path: `/service/test.ns%23TestService/operation/${operationName}`,
+    headers: {
+      "content-type": "application/cbor",
+      "smithy-protocol": "rpc-v2-cbor",
+      accept: "application/cbor",
+    },
+    body: body ?? new Uint8Array(0),
+  });
+}
+
+describe("SchemaServiceHandler", () => {
+  describe("constructor validation", () => {
+    it("succeeds when all operations have handlers", () => {
+      expect(() => new SchemaServiceHandler(makeMinimalOptions())).not.toThrow();
+    });
+
+    it("succeeds with multiple operations", () => {
+      expect(
+        () =>
+          new SchemaServiceHandler({
+            protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+            operationSchemas: [makeOpSchema("OpA"), makeOpSchema("OpB")],
+            handlers: {
+              OpA: async () => ({}),
+              OpB: async () => ({}),
+            },
+          })
+      ).not.toThrow();
+    });
+
+    it("throws when an operation schema is missing a handler", () => {
+      expect(
+        () =>
+          new SchemaServiceHandler({
+            protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+            operationSchemas: [makeOpSchema("OpA"), makeOpSchema("OpB")],
+            handlers: {
+              OpA: async () => ({}),
+            },
+          })
+      ).toThrow(/missing handlers.*OpB/);
+    });
+
+    it("throws when a handler has no corresponding operation schema", () => {
+      expect(
+        () =>
+          new SchemaServiceHandler({
+            protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+            operationSchemas: [makeOpSchema("OpA")],
+            handlers: {
+              OpA: async () => ({}),
+              Orphan: async () => ({}),
+            },
+          })
+      ).toThrow(/no corresponding operation schema.*Orphan/);
+    });
+
+    it("throws listing all missing handlers", () => {
+      expect(
+        () =>
+          new SchemaServiceHandler({
+            protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+            operationSchemas: [makeOpSchema("OpA"), makeOpSchema("OpB"), makeOpSchema("OpC")],
+            handlers: {
+              OpA: async () => ({}),
+            },
+          })
+      ).toThrow(/OpB.*OpC|OpC.*OpB/);
+    });
+
+    it("builds operationSchemas map from the array using schema[2] as key", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      // The handler should successfully route a request to TestOp.
+      // This indirectly proves the map was built correctly.
+      expect(handler).toBeDefined();
+    });
+
+    it("defaults validationEnabled to true", () => {
+      // We can't access private fields directly, but we can verify behavior:
+      // construct without specifying validationEnabled, it should be true (default).
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      expect(handler).toBeDefined();
+    });
+
+    it("accepts validationEnabled=false", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions({ validationEnabled: false }));
+      expect(handler).toBeDefined();
+    });
+  });
+
+  describe("addOperation", () => {
+    it("adds a new operation dynamically", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const newSchema = makeOpSchema("NewOp");
+      const newHandler = async () => ({ result: "dynamic" });
+
+      expect(() => handler.addOperation(newSchema, newHandler)).not.toThrow();
+    });
+
+    it("throws when adding a duplicate operation", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const duplicateSchema = makeOpSchema("TestOp");
+
+      expect(() => handler.addOperation(duplicateSchema, async () => ({}))).toThrow(/already registered/);
+    });
+
+    it("returns this for chaining", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const result = handler.addOperation(makeOpSchema("NewOp"), async () => ({}));
+      expect(result).toBe(handler);
+    });
+
+    it("allows handling requests to dynamically added operations", async () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const newSchema = makeOpSchema("DynamicOp");
+      handler.addOperation(newSchema, async () => ({ message: "hello" }));
+
+      const request = makeRpcRequest("DynamicOp");
+      const response = await handler.handle(request, {});
+      // Should not be a 400 (malformed) which means routing worked
+      expect(response).toBeInstanceOf(HttpResponse);
+    });
+  });
+
+  describe("handle", () => {
+    it("returns 400 for unroutable requests", async () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const request = new HttpRequest({
+        method: "GET",
+        path: "/completely/unknown/path",
+        headers: {},
+      });
+
+      const response = await handler.handle(request, {});
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("invokes the correct handler based on operation name", async () => {
+      const handlerFn = vi.fn(async () => ({}));
+      const handler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: { MyOp: handlerFn },
+      });
+
+      await handler.handle(makeRpcRequest("MyOp"), {});
+      expect(handlerFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes ServerRequestContext to handler", async () => {
+      let capturedContext: ServerRequestContext | undefined;
+      const handler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: {
+          MyOp: async (_input, ctx) => {
+            capturedContext = ctx;
+            return {};
+          },
+        },
+      });
+
+      await handler.handle(makeRpcRequest("MyOp"), {});
+      expect(capturedContext).toBeDefined();
+      expect(capturedContext!.operation).toBe("MyOp");
+      expect(capturedContext!.request.method).toBe("POST");
+      expect(capturedContext!.request.headers["smithy-protocol"]).toBe("rpc-v2-cbor");
+    });
+
+    it("passes user context to handler", async () => {
+      let capturedUserCtx: any;
+      const handler = new SchemaServiceHandler<{ userId: string }>({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: {
+          MyOp: async (_input, _ctx, userCtx) => {
+            capturedUserCtx = userCtx;
+            return {};
+          },
+        },
+      });
+
+      await handler.handle(makeRpcRequest("MyOp"), { userId: "u123" });
+      expect(capturedUserCtx).toEqual({ userId: "u123" });
+    });
+
+    it("returns error response when handler throws", async () => {
+      const handler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: {
+          MyOp: async () => {
+            throw new Error("boom");
+          },
+        },
+      });
+
+      const response = await handler.handle(makeRpcRequest("MyOp"), {});
+      expect(response.statusCode).toBeGreaterThanOrEqual(500);
+    });
+  });
+
+  describe("fluent API", () => {
+    it("withMetrics returns this", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const result = handler.withMetrics({ create: () => ({}) as any });
+      expect(result).toBe(handler);
+    });
+
+    it("withAuth returns this", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const result = handler.withAuth({ name: "test", authenticate: async () => null });
+      expect(result).toBe(handler);
+    });
+
+    it("addInterceptor returns this", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const result = handler.addInterceptor({});
+      expect(result).toBe(handler);
+    });
+
+    it("addInterceptors returns this", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const result = handler.addInterceptors({}, {});
+      expect(result).toBe(handler);
+    });
+
+    it("withRouter returns this", () => {
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      const result = handler.withRouter(() => undefined);
+      expect(result).toBe(handler);
+    });
+  });
+
+  describe("interceptors", () => {
+    it("calls readBeforeExecution on each request", async () => {
+      const interceptor = { readBeforeExecution: vi.fn() };
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      handler.addInterceptor(interceptor);
+
+      await handler.handle(makeRpcRequest("TestOp"), {});
+      expect(interceptor.readBeforeExecution).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls readAfterExecution on success", async () => {
+      const interceptor = { readAfterExecution: vi.fn() };
+      const handler = new SchemaServiceHandler(makeMinimalOptions());
+      handler.addInterceptor(interceptor);
+
+      await handler.handle(makeRpcRequest("TestOp"), {});
+      expect(interceptor.readAfterExecution).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls readAfterExecution on error with error field", async () => {
+      const interceptor = { readAfterExecution: vi.fn() };
+      const handler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: {
+          MyOp: async () => {
+            throw new Error("fail");
+          },
+        },
+      });
+      handler.addInterceptor(interceptor);
+
+      await handler.handle(makeRpcRequest("MyOp"), {});
+      expect(interceptor.readAfterExecution).toHaveBeenCalledTimes(1);
+      expect(interceptor.readAfterExecution.mock.calls[0][0]).toHaveProperty("error");
+    });
+  });
+
+  describe("auth", () => {
+    it("calls auth schemes and passes caller to handler context", async () => {
+      let capturedContext: ServerRequestContext | undefined;
+      const handler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: {
+          MyOp: async (_input, ctx) => {
+            capturedContext = ctx;
+            return {};
+          },
+        },
+      });
+      handler.withAuth({
+        name: "test-auth",
+        authenticate: async () => ({ principal: "user-1" }),
+      });
+
+      await handler.handle(makeRpcRequest("MyOp"), {});
+      expect(capturedContext!.caller).toEqual({ principal: "user-1" });
+    });
+
+    it("returns error response when all auth schemes reject", async () => {
+      const handler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: {
+          MyOp: async () => ({}),
+        },
+      });
+      handler.withAuth({
+        name: "reject-auth",
+        authenticate: async () => null,
+      });
+
+      const response = await handler.handle(makeRpcRequest("MyOp"), {});
+      expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe("onError hook", () => {
+    it("replaces handler errors via onError", async () => {
+      const onErrorFn = vi.fn((_op: any, _err: any) => {
+        return new ServiceException({ name: "CustomError", $fault: "client", message: "replaced" });
+      });
+      const handler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "test.ns" })],
+        operationSchemas: [makeOpSchema("MyOp")],
+        handlers: {
+          MyOp: async () => {
+            throw new Error("original");
+          },
+        },
+        onError: onErrorFn,
+      });
+
+      const response = await handler.handle(makeRpcRequest("MyOp"), {});
+      // onError should have been called
+      expect(onErrorFn).toHaveBeenCalledTimes(1);
+      expect(onErrorFn.mock.calls[0][0]).toBe("MyOp");
+      // Should get an error response
+      expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    });
+  });
+});

--- a/packages/server-common/src/service-handler/SchemaServiceHandler.ts
+++ b/packages/server-common/src/service-handler/SchemaServiceHandler.ts
@@ -115,10 +115,12 @@ export interface SchemaServiceHandlerOptions<Context = {}> {
  *
  * @example
  * ```ts
+ * import { MyOperationShape$ } from ...;
+ *
  * const handler = new SchemaServiceHandler({
  *   protocols: [new SmithyRpcV2CborServerProtocol(...)],
- *   operationSchemas: { MyOp: MyOp$ },
- *   handlers: { MyOp: async (input, ctx) => ({ ... }) },
+ *   operationSchemas: [MyOperationShape$],
+ *   handlers: { MyOperationShape: async (input, ctx) => ({ ... }) },
  * });
  * handler.withMetrics(myFactory).addInterceptor(myInterceptor);
  * const response = await handler.handle(request, {});

--- a/packages/server-common/src/service-handler/SchemaServiceHandler.ts
+++ b/packages/server-common/src/service-handler/SchemaServiceHandler.ts
@@ -65,6 +65,23 @@ export interface SchemaServiceHandlerOptions<Context = {}> {
   handlers: Record<string, (input: any, context: ServerRequestContext, userContext: Context) => Promise<any>>;
 
   /**
+   * Operation schemas for request routing, serde, and validation.
+   * The handler derives the operation name from each schema (index 2 of the tuple).
+   *
+   * @defaultValue []
+   */
+  operationSchemas?: StaticOperationSchema[];
+
+  /**
+   * Whether input validation is enabled. When `true` (the default), the
+   * handler validates deserialized input against schema constraints before
+   * invoking the operation handler.
+   *
+   * @defaultValue true
+   */
+  validationEnabled?: boolean;
+
+  /**
    * Custom router. When omitted the handler uses {@link combinedRouter},
    * which matches RPC-style paths like `/service/{ns}/operation/{op}`.
    */
@@ -89,17 +106,18 @@ export interface SchemaServiceHandlerOptions<Context = {}> {
 }
 
 /**
- * Base class for schema-based service handlers.
+ * Schema-based service handler.
  *
- * Generated handler subclasses extend this to supply typed constructor
- * signatures and operation schemas. The base class provides the request
- * pipeline: protocol resolution, routing, auth, deserialization, validation,
- * invocation, serialization, interceptors, and metrics.
+ * Provides the full request pipeline: protocol resolution, routing, auth,
+ * deserialization, validation, invocation, serialization, interceptors, and
+ * metrics. Can be instantiated directly or extended by generated subclasses
+ * that supply typed constructor signatures.
  *
  * @example
  * ```ts
- * const handler = new MyServiceHandler({
+ * const handler = new SchemaServiceHandler({
  *   protocols: [new SmithyRpcV2CborServerProtocol(...)],
+ *   operationSchemas: { MyOp: MyOp$ },
  *   handlers: { MyOp: async (input, ctx) => ({ ... }) },
  * });
  * handler.withMetrics(myFactory).addInterceptor(myInterceptor);
@@ -108,13 +126,15 @@ export interface SchemaServiceHandlerOptions<Context = {}> {
  *
  * @public
  */
-export abstract class SchemaServiceHandler<Context = {}> {
+export class SchemaServiceHandler<Context = {}> {
   private router: RouterFunction;
   private readonly protocols: Record<string, ServerProtocol<HttpRequest, HttpResponse>>;
+  private readonly operationSchemas: Record<string, StaticOperationSchema>;
   private readonly handlers: Record<
     string,
     (input: any, context: ServerRequestContext, userContext: Context) => Promise<any>
   >;
+  private readonly validationEnabled: boolean;
   private interceptors: ServerInterceptor<Context>[] = [];
   private authSchemes: AuthScheme<Context>[] = [];
   private metricsRecorderFactory?: MetricsRecorderFactory<any>;
@@ -126,20 +146,39 @@ export abstract class SchemaServiceHandler<Context = {}> {
     for (const protocol of options.protocols) {
       this.protocols[protocol.getShapeId()] = protocol;
     }
-    this.handlers = options.handlers;
+    this.operationSchemas = {};
+    for (const schema of options.operationSchemas ?? []) {
+      this.operationSchemas[schema[2]] = schema;
+    }
+    this.handlers = { ...options.handlers };
+    this.validationEnabled = options.validationEnabled ?? true;
     this.router = options.router ?? createCombinedRouter(this.protocols);
     this.logger = options.logger ?? new NoOpLogger();
     this.onError = options.onError;
+
+    // Validate that every operation schema has a corresponding handler.
+    const schemaKeys = Object.keys(this.operationSchemas);
+    const handlerKeys = Object.keys(this.handlers);
+    const missingHandlers = schemaKeys.filter((op) => !(op in this.handlers));
+    const orphanHandlers = handlerKeys.filter((op) => !(op in this.operationSchemas));
+    if (missingHandlers.length > 0) {
+      throw new Error(
+        `@smithy/server-common::SchemaServiceHandler: the following operations are missing handlers: ${missingHandlers.join(", ")}`
+      );
+    }
+    if (orphanHandlers.length > 0) {
+      throw new Error(
+        `@smithy/server-common::SchemaServiceHandler: the following handlers have no corresponding operation schema: ${orphanHandlers.join(", ")}`
+      );
+    }
   }
 
   /**
    * Handles an incoming HTTP request through the full pipeline:
    * route → authenticate → deserialize → validate → invoke → serialize.
-   *
-   * @public
    */
   public async handle(request: HttpRequest, context: Context): Promise<HttpResponse> {
-    const operationSchemas = this.getOperationSchemas();
+    const operationSchemas = this.operationSchemas;
     const routeResult = this.router(request, this.protocols, operationSchemas, this.logger);
 
     if (!routeResult) {
@@ -239,7 +278,7 @@ export abstract class SchemaServiceHandler<Context = {}> {
       }
 
       // Validate
-      if (this.isValidationEnabled()) {
+      if (this.validationEnabled) {
         recordTimedSync(recorder, "Validate", () => {
           const inputSchema = operationSchema[4];
           if (inputSchema) {
@@ -397,8 +436,6 @@ export abstract class SchemaServiceHandler<Context = {}> {
   /**
    * Register a metrics recorder factory. The framework creates one recorder
    * per request and records lifecycle timings.
-   *
-   * @public
    */
   public withMetrics<Native>(metricsRecorderFactory: MetricsRecorderFactory<Native>): this {
     this.metricsRecorderFactory = metricsRecorderFactory;
@@ -408,8 +445,6 @@ export abstract class SchemaServiceHandler<Context = {}> {
   /**
    * Register auth schemes. Schemes are tried in registration order; the first
    * to return a non-null {@link Caller} wins.
-   *
-   * @public
    */
   public withAuth(...schemes: AuthScheme<Context>[]): this {
     this.authSchemes.push(...schemes);
@@ -418,8 +453,6 @@ export abstract class SchemaServiceHandler<Context = {}> {
 
   /**
    * Register a single interceptor. Later registrations run before earlier ones.
-   *
-   * @public
    */
   public addInterceptor(interceptor: ServerInterceptor<Context>): this {
     this.interceptors.unshift(interceptor);
@@ -428,8 +461,6 @@ export abstract class SchemaServiceHandler<Context = {}> {
 
   /**
    * Register multiple interceptors. Later registrations run before earlier ones.
-   *
-   * @public
    */
   public addInterceptors(...interceptors: ServerInterceptor<Context>[]): this {
     this.interceptors.unshift(...[...interceptors].reverse());
@@ -438,8 +469,6 @@ export abstract class SchemaServiceHandler<Context = {}> {
 
   /**
    * Replace the router with a custom implementation.
-   *
-   * @public
    */
   public withRouter(router: RouterFunction): this {
     this.router = router;
@@ -447,20 +476,19 @@ export abstract class SchemaServiceHandler<Context = {}> {
   }
 
   /**
-   * Returns the operation schemas for this service.
-   * Generated subclasses implement this to provide the static schema map.
-   *
-   * @internal
+   * Dynamically register an operation schema and its handler.
+   * Throws if an operation with the same name is already registered.
    */
-  protected abstract getOperationSchemas(): Record<string, StaticOperationSchema>;
-
-  /**
-   * Whether input validation is enabled. Generated subclasses override this
-   * to return `false` when `disableDefaultValidation` is set.
-   *
-   * @internal
-   */
-  protected isValidationEnabled(): boolean {
-    return true;
+  public addOperation(
+    schema: StaticOperationSchema,
+    handler: (input: any, context: ServerRequestContext, userContext: Context) => Promise<any>
+  ): this {
+    const operationName = schema[2];
+    if (operationName in this.operationSchemas) {
+      throw new Error(`SchemaServiceHandler: operation "${operationName}" is already registered.`);
+    }
+    this.operationSchemas[operationName] = schema;
+    this.handlers[operationName] = handler;
+    return this;
   }
 }

--- a/packages/server-common/test/schema-server.integ.spec.ts
+++ b/packages/server-common/test/schema-server.integ.spec.ts
@@ -8,10 +8,16 @@ import {
   HttpLabelCommandCommand,
   ValidatedOperationCommand,
 } from "xyz-schema";
-import { SmithyRpcV2CborServerProtocol, AwsRestJsonServerProtocol, AwsJsonRpcServerProtocol } from "../src/index";
+import {
+  SmithyRpcV2CborServerProtocol,
+  AwsRestJsonServerProtocol,
+  AwsJsonRpcServerProtocol,
+  SchemaServiceHandler,
+} from "../src/index";
 import type { HttpResponse } from "@smithy/core/protocols";
 import { HttpRequest } from "@smithy/core/protocols";
 import { AwsRestJsonProtocol, AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
+import { GetNumbers$, camelCaseOperation$ } from "xyz-schema-server";
 
 /**
  * End-to-end integration test that stands up a real Node.js HTTP server
@@ -498,6 +504,129 @@ describe("Multi-protocol schema SSDK over HTTP", () => {
         "modifyBeforeSerialization",
         "modifyBeforeCompletion",
       ]);
+    });
+  });
+
+  describe("direct SchemaServiceHandler instantiation (no subclass)", () => {
+    let directServer: http.Server;
+    let directClient: XYZServiceClient;
+    let directBaseUrl: string;
+
+    beforeAll(async () => {
+      const directHandler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "org.xyz.v1" })],
+        operationSchemas: [GetNumbers$, camelCaseOperation$],
+        handlers: {
+          GetNumbers: async (input: any) => {
+            const inputNumbers = input.numbers ?? {};
+            const tripled = Object.values(inputNumbers).map((n: any) => n * 3);
+            return { numbers: tripled };
+          },
+          camelCaseOperation: async (input: any) => {
+            return { token: `direct-${input.token ?? "none"}` };
+          },
+        },
+      });
+
+      directServer = http.createServer(async (req, res) => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+          chunks.push(chunk);
+        }
+        const body = Buffer.concat(chunks);
+
+        const httpRequest = new HttpRequest({
+          method: req.method ?? "POST",
+          path: req.url ?? "/",
+          headers: Object.fromEntries(
+            Object.entries(req.headers)
+              .filter(([, v]) => v !== undefined)
+              .map(([k, v]) => [k, Array.isArray(v) ? v.join(", ") : v!])
+          ),
+          body,
+        });
+
+        const httpResponse = await directHandler.handle(httpRequest, {});
+        res.writeHead(httpResponse.statusCode, httpResponse.headers);
+        if (httpResponse.body) {
+          res.end(httpResponse.body);
+        } else {
+          res.end();
+        }
+      });
+
+      await new Promise<void>((resolve) => {
+        directServer.listen(0, "127.0.0.1", () => resolve());
+      });
+
+      const addr = directServer.address() as { port: number };
+      directBaseUrl = `http://127.0.0.1:${addr.port}`;
+
+      directClient = new XYZServiceClient({
+        endpoint: directBaseUrl,
+        apiKey: { apiKey: "test-key" },
+      });
+    });
+
+    afterAll(async () => {
+      directClient.destroy();
+      await new Promise<void>((resolve, reject) => {
+        directServer.close((err) => (err ? reject(err) : resolve()));
+      });
+    });
+
+    it("GetNumbers: triples input numbers", async () => {
+      const response = await directClient.send(new GetNumbersCommand({ numbers: { a: 2, b: 5 } }));
+      expect(response.numbers).toEqual([6, 15]);
+    });
+
+    it("camelCaseOperation: prefixes token with 'direct-'", async () => {
+      const response = await directClient.send(new CamelCaseOperationCommand({ token: "hello" }));
+      expect(response.token).toBe("direct-hello");
+    });
+
+    it("returns error for operations not in the subset", async () => {
+      // ValidatedOperation is not registered on this handler
+      await expect(
+        directClient.send(
+          new ValidatedOperationCommand({
+            username: "alice",
+            age: 30,
+            email: "a@b.com",
+            tags: ["x"],
+            address: { zipCode: "12345", state: "WA" },
+          })
+        )
+      ).rejects.toThrow();
+    });
+
+    it("dynamically adds an operation via addOperation", async () => {
+      const dynamicHandler = new SchemaServiceHandler({
+        protocols: [new SmithyRpcV2CborServerProtocol({ defaultNamespace: "org.xyz.v1" })],
+        operationSchemas: [GetNumbers$],
+        handlers: {
+          GetNumbers: async () => ({ numbers: [99] }),
+        },
+      });
+
+      // Dynamically add camelCaseOperation
+      dynamicHandler.addOperation(camelCaseOperation$, async (input: any) => ({
+        token: `added-${input.token ?? ""}`,
+      }));
+
+      const request = new HttpRequest({
+        method: "POST",
+        path: `/service/org.xyz.v1%23XYZService/operation/camelCaseOperation`,
+        headers: {
+          "content-type": "application/cbor",
+          "smithy-protocol": "rpc-v2-cbor",
+          accept: "application/cbor",
+        },
+        body: new Uint8Array(0),
+      });
+
+      const response = await dynamicHandler.handle(request, {});
+      expect(response.statusCode).toBeLessThan(400);
     });
   });
 });

--- a/private/my-local-model-schema-server/src/server/XYZServiceHandler.ts
+++ b/private/my-local-model-schema-server/src/server/XYZServiceHandler.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { type SchemaServiceHandlerOptions, type ServerRequestContext, SchemaServiceHandler } from "@smithy/server-common";
+import {
+  type SchemaServiceHandlerOptions,
+  type ServerRequestContext,
+  SchemaServiceHandler,
+} from "@smithy/server-common";
 import type { StaticOperationSchema } from "@smithy/types";
 
 import type {
@@ -26,14 +30,14 @@ import {
 } from "../schemas/schemas_0";
 
 
-const OPERATION_SCHEMAS: Record<string, StaticOperationSchema> = {
-  "HttpLabelCommand": HttpLabelCommand$,
-  "camelCaseOperation": camelCaseOperation$,
-  "GetNumbers": GetNumbers$,
-  "HostPrefixOperation": HostPrefixOperation$,
-  "TradeEventStream": TradeEventStream$,
-  "ValidatedOperation": ValidatedOperation$,
-} as const;
+const OPERATION_SCHEMAS: StaticOperationSchema[] = [
+  HttpLabelCommand$,
+  camelCaseOperation$,
+  GetNumbers$,
+  HostPrefixOperation$,
+  TradeEventStream$,
+  ValidatedOperation$,
+];
 
 /**
  * Schema-based service handler for XYZService.
@@ -52,10 +56,7 @@ export class XYZServiceHandler<Context = {}> extends SchemaServiceHandler<Contex
       ValidatedOperation: (input: ValidatedInput, context: ServerRequestContext, userContext: Context) => Promise<ValidatedOutput>;
     };
   }) {
-    super(options);
+    super({ ...options, validationEnabled: options.validationEnabled ?? true, operationSchemas: options.operationSchemas ?? OPERATION_SCHEMAS });
   }
 
-  protected getOperationSchemas(): Record<string, StaticOperationSchema> {
-    return OPERATION_SCHEMAS;
-  }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/schema/SchemaServerGenerator.java
@@ -80,6 +80,7 @@ public class SchemaServerGenerator {
         // Import base class from server-common.
         writer.addImport("SchemaServiceHandler", null, TypeScriptDependency.SERVER_COMMON);
         writer.addTypeImport("SchemaServiceHandlerOptions", null, TypeScriptDependency.SERVER_COMMON);
+        writer.addTypeImport("ServerRequestContext", null, TypeScriptDependency.SERVER_COMMON);
         writer.addTypeImport("StaticOperationSchema", null, TypeScriptDependency.SMITHY_TYPES);
 
         Path schemasPath = Paths.get(".", "src", "schemas", "schemas_0");
@@ -107,13 +108,12 @@ public class SchemaServerGenerator {
 
     private void writeOperationSchemaMap(Set<OperationShape> operations) {
         writer.openBlock(
-            "const OPERATION_SCHEMAS: Record<string, StaticOperationSchema> = {",
-            "} as const;",
+            "const OPERATION_SCHEMAS: StaticOperationSchema[] = [",
+            "];",
             () -> {
                 for (OperationShape operation : operations) {
-                    String opName = operation.getId().getName();
                     String schemaVarName = getOperationSchemaVarName(operation);
-                    writer.write("$S: $L,", opName, schemaVarName);
+                    writer.write("$L,", schemaVarName);
                 }
             }
         );
@@ -135,54 +135,51 @@ public class SchemaServerGenerator {
             serviceName,
             () -> {
                 // Constructor with typed handlers
-                writeConstructor(serviceName, operations);
-
-                // getOperationSchemas() override
-                writer.openBlock(
-                    "protected getOperationSchemas(): Record<string, StaticOperationSchema> {",
-                    "}",
-                    () -> writer.write("return OPERATION_SCHEMAS;")
-                );
-
-                // isValidationEnabled() override if validation is disabled
-                if (!validationEnabled) {
-                    writer.write("");
-                    writer.openBlock(
-                        "protected isValidationEnabled(): boolean {",
-                        "}",
-                        () -> writer.write("return false;")
-                    );
-                }
+                writeConstructor(serviceName, operations, validationEnabled);
             }
         );
     }
 
-    private void writeConstructor(String serviceName, Set<OperationShape> operations) {
-        writer.openBlock("constructor(options: SchemaServiceHandlerOptions<Context> & {", "}) {", () -> {
-            writer.write(
-                "handlers: {"
-            );
-            writer.indent();
-            for (OperationShape operation : operations) {
-                String opName = operation.getId().getName();
-                String inputName = symbolProvider.toSymbol(
-                    model.expectShape(operation.getInputShape())
-                ).getName();
-                String outputName = symbolProvider.toSymbol(
-                    model.expectShape(operation.getOutputShape())
-                ).getName();
+    private void writeConstructor(String serviceName, Set<OperationShape> operations, boolean validationEnabled) {
+        writer.openBlock(
+            "constructor(options: SchemaServiceHandlerOptions<Context> & {",
+            "}) {",
+            () -> {
                 writer.write(
-                    "$L: (input: $L, context: Context) => Promise<$L>;",
-                    opName,
-                    inputName,
-                    outputName
+                    "handlers: {"
                 );
+                writer.indent();
+                for (OperationShape operation : operations) {
+                    String opName = operation.getId().getName();
+                    String inputName = symbolProvider.toSymbol(
+                        model.expectShape(operation.getInputShape())
+                    ).getName();
+                    String outputName = symbolProvider.toSymbol(
+                        model.expectShape(operation.getOutputShape())
+                    ).getName();
+                    writer.write(
+                        "$L: (input: $L, context: ServerRequestContext, userContext: Context) => Promise<$L>;",
+                        opName,
+                        inputName,
+                        outputName
+                    );
+                }
+                writer.dedent();
+                writer.write("};");
             }
-            writer.dedent();
-            writer.write("};");
-        });
+        );
         writer.indent();
-        writer.write("super(options);");
+        if (validationEnabled) {
+            writer.write(
+                "super({ ...options, validationEnabled: options.validationEnabled ?? true,"
+                    + " operationSchemas: options.operationSchemas ?? OPERATION_SCHEMAS });"
+            );
+        } else {
+            writer.write(
+                "super({ ...options, validationEnabled: options.validationEnabled ?? false,"
+                    + " operationSchemas: options.operationSchemas ?? OPERATION_SCHEMAS });"
+            );
+        }
         writer.closeBlock("}");
         writer.write("");
     }


### PR DESCRIPTION
Making the abstract base class directly instantiable means users don't necessarily need to generate a server SDK.

They can use operation schema to dynamically create a ServiceHandler.