### PR TITLE
chore(codegen): smithy-typescript-codegen 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 [Commit logs](https://github.com/smithy-lang/smithy-typescript/commits/main/smithy-typescript-codegen)
 
+## 0.52.0 (2026-08-07)
+
+### Features
+
+- Added types-only codegen mode driven by Smithy shape closures ([#2158](https://github.com/smithy-lang/smithy-typescript/pull/2158))
+- Enabled creation of RPCv2 SSDK in schema mode ([#2208](https://github.com/smithy-lang/smithy-typescript/pull/2208))
+- Supported additional server protocols in schema mode ([#2210](https://github.com/smithy-lang/smithy-typescript/pull/2210))
+
+### Chores
+
+- Renamed '@aws-smithy/server-*' packages to '@smithy/server-*' ([#2156](https://github.com/smithy-lang/smithy-typescript/pull/2156))
+- Updated server package dependencies for '@smithy/server-*@0.1.0' release ([#2157](https://github.com/smithy-lang/smithy-typescript/pull/2157))
+
 ## 0.51.0 (2026-07-13)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.51.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.52.0"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -159,7 +159,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.51.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.52.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.51.0"
+    version = "0.52.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
Bumps the Maven version of `smithy-typescript-codegen` to 0.52.0.

## Changes

see changelog diff