### PR TITLE
fix(codegen): omit staticContextParams on ClientInputEndpointParameters

### DIFF
--- a/private/my-local-model-schema-server/src/models/models_0.ts
+++ b/private/my-local-model-schema-server/src/models/models_0.ts
@@ -26,6 +26,7 @@ export interface Alpha {
  */
 export interface CamelCaseOperationInput {
   token?: string | undefined;
+  overloadedParam?: string | undefined;
 }
 
 /**

--- a/private/my-local-model-schema-server/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema-server/src/schemas/schemas_0.ts
@@ -64,6 +64,7 @@ const _n = "name";
 const _nT = "nextToken";
 const _nu = "number";
 const _num = "numbers";
+const _oP = "overloadedParam";
 const _p = "pattern";
 const _r = "results";
 const _ra = "range";
@@ -174,8 +175,8 @@ export var Alpha$: StaticStructureSchema = [3, n0, _A,
 ];
 export var camelCaseOperationInput$: StaticStructureSchema = [3, n0, _cCOI,
   0,
-  [_to],
-  [0]
+  [_to, _oP],
+  [0, 0]
 ];
 export var camelCaseOperationOutput$: StaticStructureSchema = [3, n0, _cCOO,
   0,

--- a/private/my-local-model-schema/src/commandBuilder.ts
+++ b/private/my-local-model-schema/src/commandBuilder.ts
@@ -15,7 +15,9 @@ export const command = makeBuilder<XYZServiceClientResolvedConfig, ServiceInputT
 /**
  * @internal
  */
-export const _ep0: EndpointParameterInstructions = {};
+export const _ep0: EndpointParameterInstructions = {
+  OverloadedParam: { type: "contextParams", name: "overloadedParam" },
+};
 
 /**
  * @internal
@@ -23,6 +25,18 @@ export const _ep0: EndpointParameterInstructions = {};
 export const _ep1: EndpointParameterInstructions = {
   CustomHeaderValue: { type: "contextParams", name: "customHeaderInput" },
 };
+
+/**
+ * @internal
+ */
+export const _ep2: EndpointParameterInstructions = {
+  OverloadedParam: { type: "staticContextParams", value: `from-host-prefix-operation` },
+};
+
+/**
+ * @internal
+ */
+export const _ep3: EndpointParameterInstructions = {};
 
 /**
  * @internal

--- a/private/my-local-model-schema/src/commands/CamelCaseOperationCommand.ts
+++ b/private/my-local-model-schema/src/commands/CamelCaseOperationCommand.ts
@@ -35,6 +35,7 @@ export interface CamelCaseOperationCommandOutput extends CamelCaseOperationOutpu
  * const client = new XYZServiceClient(config);
  * const input = { // camelCaseOperationInput
  *   token: "STRING_VALUE",
+ *   overloadedParam: "STRING_VALUE",
  * };
  * const command = new CamelCaseOperationCommand(input);
  * const response = await client.send(command);

--- a/private/my-local-model-schema/src/commands/HostPrefixOperationCommand.ts
+++ b/private/my-local-model-schema/src/commands/HostPrefixOperationCommand.ts
@@ -1,7 +1,7 @@
 // smithy-typescript generated code
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { _ep0, _mw0, command } from "../commandBuilder";
+import { _ep2, _mw0, command } from "../commandBuilder";
 import type { HostPrefixOperationInput } from "../models/models_0";
 import { HostPrefixOperation$ } from "../schemas/schemas_0";
 
@@ -56,7 +56,7 @@ export interface HostPrefixOperationCommandOutput extends __MetadataBearer {}
  *
  */
 export class HostPrefixOperationCommand extends command<HostPrefixOperationCommandInput, HostPrefixOperationCommandOutput>(
-  _ep0,
+  _ep2,
   _mw0,
   "HostPrefixOperation",
   HostPrefixOperation$

--- a/private/my-local-model-schema/src/commands/HttpLabelCommandCommand.ts
+++ b/private/my-local-model-schema/src/commands/HttpLabelCommandCommand.ts
@@ -1,7 +1,7 @@
 // smithy-typescript generated code
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { _ep0, _mw0, command } from "../commandBuilder";
+import { _ep3, _mw0, command } from "../commandBuilder";
 import type { HttpLabelCommandInput, HttpLabelCommandOutput } from "../models/models_0";
 import { HttpLabelCommand$ } from "../schemas/schemas_0";
 
@@ -56,7 +56,7 @@ export interface HttpLabelCommandCommandOutput extends HttpLabelCommandOutput, _
  *
  */
 export class HttpLabelCommandCommand extends command<HttpLabelCommandCommandInput, HttpLabelCommandCommandOutput>(
-  _ep0,
+  _ep3,
   _mw0,
   "HttpLabelCommand",
   HttpLabelCommand$

--- a/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
+++ b/private/my-local-model-schema/src/commands/TradeEventStreamCommand.ts
@@ -1,7 +1,7 @@
 // smithy-typescript generated code
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { _ep0, _mw0, command } from "../commandBuilder";
+import { _ep3, _mw0, command } from "../commandBuilder";
 import type { TradeEventStreamRequest, TradeEventStreamResponse } from "../models/models_0";
 import { TradeEventStream$ } from "../schemas/schemas_0";
 
@@ -80,7 +80,7 @@ export interface TradeEventStreamCommandOutput extends TradeEventStreamResponse,
  *
  */
 export class TradeEventStreamCommand extends command<TradeEventStreamCommandInput, TradeEventStreamCommandOutput>(
-  _ep0,
+  _ep3,
   _mw0,
   "TradeEventStream",
   TradeEventStream$

--- a/private/my-local-model-schema/src/commands/ValidatedOperationCommand.ts
+++ b/private/my-local-model-schema/src/commands/ValidatedOperationCommand.ts
@@ -1,7 +1,7 @@
 // smithy-typescript generated code
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
 
-import { _ep0, _mw0, command } from "../commandBuilder";
+import { _ep3, _mw0, command } from "../commandBuilder";
 import type { ValidatedInput, ValidatedOutput } from "../models/models_0";
 import { ValidatedOperation$ } from "../schemas/schemas_0";
 
@@ -70,7 +70,7 @@ export interface ValidatedOperationCommandOutput extends ValidatedOutput, __Meta
  * @public
  */
 export class ValidatedOperationCommand extends command<ValidatedOperationCommandInput, ValidatedOperationCommandOutput>(
-  _ep0,
+  _ep3,
   _mw0,
   "ValidatedOperation",
   ValidatedOperation$

--- a/private/my-local-model-schema/src/endpoint/EndpointParameters.ts
+++ b/private/my-local-model-schema/src/endpoint/EndpointParameters.ts
@@ -84,4 +84,5 @@ export interface EndpointParameters extends __EndpointParameters {
   nonConflictingParam?: string | undefined;
   logger?: string | undefined;
   CustomHeaderValue?: string | undefined;
+  OverloadedParam?: string | undefined;
 }

--- a/private/my-local-model-schema/src/models/models_0.ts
+++ b/private/my-local-model-schema/src/models/models_0.ts
@@ -26,6 +26,7 @@ export interface Alpha {
  */
 export interface CamelCaseOperationInput {
   token?: string | undefined;
+  overloadedParam?: string | undefined;
 }
 
 /**

--- a/private/my-local-model-schema/src/schemas/schemas_0.ts
+++ b/private/my-local-model-schema/src/schemas/schemas_0.ts
@@ -59,6 +59,7 @@ const _n = "name";
 const _nT = "nextToken";
 const _nu = "number";
 const _num = "numbers";
+const _oP = "overloadedParam";
 const _r = "results";
 const _s = "smithy.ts.sdk.synthetic.org.xyz.v1";
 const _sN = "sparseNumbers";
@@ -163,8 +164,8 @@ export var Alpha$: StaticStructureSchema = [3, n0, _A,
 ];
 export var camelCaseOperationInput$: StaticStructureSchema = [3, n0, _cCOI,
   0,
-  [_to],
-  [0]
+  [_to, _oP],
+  [0, 0]
 ];
 export var camelCaseOperationOutput$: StaticStructureSchema = [3, n0, _cCOO,
   0,

--- a/private/my-local-model-schema/test/snapshots/req/CamelCaseOperation.txt
+++ b/private/my-local-model-schema/test/snapshots/req/CamelCaseOperation.txt
@@ -5,15 +5,18 @@ x-api-key: [object Object]
 content-type: application/cbor
 smithy-protocol: rpc-v2-cbor
 accept: application/cbor
-content-length: 17
+content-length: 53
 amz-sdk-invocation-id: 1111abcd-uuid-uuid-uuid-000000001111
 amz-sdk-request: attempt=1; max=3
 X-Api-Key: MOCK_api_key
 
 [Uint8Array (cbor object view)]
 {
-  "token": "__token__"
+  "token": "__token__",
+  "overloadedParam": "__overloadedParam__"
 }
 
 [actual bytes]
-161, 101, 116, 111, 107, 101, 110, 105, 95, 95, 116, 111, 107, 101, 110, 95, 95
+162, 101, 116, 111, 107, 101, 110, 105, 95, 95, 116, 111, 107, 101, 110, 95, 95, 111, 111, 118, 101, 114, 108, 111,
+97, 100, 101, 100, 80, 97, 114, 97, 109, 115, 95, 95, 111, 118, 101, 114, 108, 111, 97, 100, 101, 100, 80, 97,
+114, 97, 109, 95, 95

--- a/private/my-local-model/src/commands/CamelCaseOperationCommand.ts
+++ b/private/my-local-model/src/commands/CamelCaseOperationCommand.ts
@@ -39,6 +39,7 @@ export interface CamelCaseOperationCommandOutput extends CamelCaseOperationOutpu
  * const client = new XYZServiceClient(config);
  * const input = { // camelCaseOperationInput
  *   token: "STRING_VALUE",
+ *   overloadedParam: "STRING_VALUE",
  * };
  * const command = new CamelCaseOperationCommand(input);
  * const response = await client.send(command);
@@ -72,7 +73,10 @@ export class CamelCaseOperationCommand extends $Command
     ServiceInputTypes,
     ServiceOutputTypes
   >()
-  .ep(commonParams)
+  .ep({
+    ...commonParams,
+    OverloadedParam: { type: "contextParams", name: "overloadedParam" },
+  })
   .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
     return [
       getSerdePlugin(config, this.serialize, this.deserialize),

--- a/private/my-local-model/src/commands/HostPrefixOperationCommand.ts
+++ b/private/my-local-model/src/commands/HostPrefixOperationCommand.ts
@@ -67,7 +67,10 @@ export class HostPrefixOperationCommand extends $Command
     ServiceInputTypes,
     ServiceOutputTypes
   >()
-  .ep(commonParams)
+  .ep({
+    ...commonParams,
+    OverloadedParam: { type: "staticContextParams", value: `from-host-prefix-operation` },
+  })
   .m(function (this: any, Command: any, cs: any, config: XYZServiceClientResolvedConfig, o: any) {
     return [
       getSerdePlugin(config, this.serialize, this.deserialize),

--- a/private/my-local-model/src/endpoint/EndpointParameters.ts
+++ b/private/my-local-model/src/endpoint/EndpointParameters.ts
@@ -84,4 +84,5 @@ export interface EndpointParameters extends __EndpointParameters {
   nonConflictingParam?: string | undefined;
   logger?: string | undefined;
   CustomHeaderValue?: string | undefined;
+  OverloadedParam?: string | undefined;
 }

--- a/private/my-local-model/src/models/models_0.ts
+++ b/private/my-local-model/src/models/models_0.ts
@@ -26,6 +26,7 @@ export interface Alpha {
  */
 export interface CamelCaseOperationInput {
   token?: string | undefined;
+  overloadedParam?: string | undefined;
 }
 
 /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -194,10 +194,13 @@ public final class EndpointsV2Generator implements Runnable {
                                  ): T & ClientResolvedEndpointParameters => {""", "};", () -> {
                     writer.openBlock("return Object.assign(options, {", "});", () -> {
                         ObjectNode ruleSet = endpointRuleSetTrait.getRuleSet().expectObjectNode();
+                        Set<String> clientLevelParams = new HashSet<>();
+                        clientLevelParams.addAll(ruleSetParameterFinder.getBuiltInParams().keySet());
+                        clientLevelParams.addAll(ruleSetParameterFinder.getClientContextParams().keySet());
                         ruleSet
                             .getObjectMember("parameters")
                             .ifPresent(parameters -> {
-                                parameters.accept(new RuleSetParametersVisitor(writer, true));
+                                parameters.accept(new RuleSetParametersVisitor(writer, true, clientLevelParams));
                             });
                         writer.write(
                             "defaultSigningName: \"$L\",",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.typescript.codegen.endpointsV2;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeVisitor;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -22,6 +23,7 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
     private final Map<String, String> clientContextParams;
     private boolean useLocalNames = false;
     private boolean writeDefaults = false;
+    private Set<String> clientLevelParams = null;
 
     public RuleSetParametersVisitor(TypeScriptWriter writer) {
         this.writer = writer;
@@ -42,6 +44,16 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
         this(writer);
         this.writeDefaults = writeDefaults;
         this.useLocalNames = true;
+    }
+
+    /**
+     * @param clientLevelParams - the set of parameter names that are valid at the client level
+     *                            (built-ins and client context params). When writing defaults,
+     *                            only parameters in this set will have defaults emitted.
+     */
+    public RuleSetParametersVisitor(TypeScriptWriter writer, boolean writeDefaults, Set<String> clientLevelParams) {
+        this(writer, writeDefaults);
+        this.clientLevelParams = clientLevelParams;
     }
 
     @Override
@@ -66,7 +78,12 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
             if (writeDefaults) {
                 if (parameterGenerator.hasDefault()) {
                     // Don't write root-level defaults for conflicting parameters
-                    if (!ClientConfigKeys.isKnownConfigKey(key)) {
+                    // Don't write defaults for params not available at the client level
+                    // (e.g. static context params that are only set per-command)
+                    if (
+                        !ClientConfigKeys.isKnownConfigKey(key)
+                            && (clientLevelParams == null || clientLevelParams.contains(key))
+                    ) {
                         writer.write(parameterGenerator.defaultAsCodeString());
                     }
                 }

--- a/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
+++ b/smithy-typescript-protocol-test-codegen/model/my-local-model/my-local-model.smithy
@@ -7,6 +7,7 @@ use smithy.protocols#rpcv2Cbor
 use smithy.rules#clientContextParams
 use smithy.rules#contextParam
 use smithy.rules#endpointRuleSet
+use smithy.rules#staticContextParams
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 use smithy.waiters#waitable
@@ -35,6 +36,7 @@ use smithy.waiters#waitable
         nonConflictingParam: { type: "string", required: true, default: "non-conflict-default", documentation: "Non-conflicting with default" }
         logger: { type: "string", required: true, default: "default-logger", documentation: "Conflicting logger with default" }
         CustomHeaderValue: { type: "string", required: false, documentation: "Value to send as x-custom-header" }
+        OverloadedParam: { type: "string", required: true, default: "overloaded!", documentation: "both a static and non-static context param." }
     }
     rules: [
         {
@@ -401,7 +403,11 @@ structure CompletelyUnlinkedError {}
 operation camelCaseOperation {
     input := {
         token: String
+
+        @contextParam(name: "OverloadedParam")
+        overloadedParam: String
     }
+
     output := {
         token: String
         results: Blobs
@@ -412,6 +418,9 @@ list Blobs {
     member: Blob
 }
 
+@staticContextParams(
+    OverloadedParam: { value: "from-host-prefix-operation" }
+)
 @endpoint(hostPrefix: "{AccountId}.")
 operation HostPrefixOperation {
     input: HostPrefixOperationInput


### PR DESCRIPTION
staticContextParams, operation level constants, are being generated onto the client level endpoint parameters type, which is incorrect.