### PR TITLE
fix(node-http-handler): destroy isolated HTTP/2 sessions and type timeout errors

### DIFF
--- a/.changeset/clean-berries-march.md
+++ b/.changeset/clean-berries-march.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": minor
+---
+
+destroy isolated http2 session and manage timeout

--- a/packages/node-http-handler/src/node-http2-connection-manager.ts
+++ b/packages/node-http-handler/src/node-http2-connection-manager.ts
@@ -116,9 +116,11 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
     session.on("frameError", ensureDestroyed);
     session.on("close", ensureDestroyed);
 
-    if (connectionConfiguration.requestTimeout) {
-      session.setTimeout(connectionConfiguration.requestTimeout, ensureDestroyed);
-    }
+    // Arm a session timeout as a safety net to reap orphaned sessions.
+    // Uses the configured sessionTimeout if provided, otherwise defaults to
+    // 5 minutes to prevent indefinite leaks when other cleanup paths fail.
+    const timeout = connectionConfiguration.requestTimeout ?? 300_000;
+    session.setTimeout(timeout, ensureDestroyed);
 
     ref.retain();
     return ref;

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -251,9 +251,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
 
           // Ensure the isolated session is destroyed when the response body stream ends.
           // The stream "close" event (below) is the primary cleanup path, but it may not
-          // fire if the consumer never reads the body (e.g. deserialization error, dropped
-          // reference) or on certain Node.js versions/platforms. This provides a reliable
-          // secondary cleanup path.
+          // fire if the consumer never reads the body. This provides a secondary cleanup path.
           clientHttp2Stream.on("end", () => {
             ref.destroy();
           });
@@ -271,8 +269,7 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
         }
         if (!fulfilled) {
           // If the session was destroyed (e.g. by sessionTimeout) before the response
-          // arrived, this is a timeout — type it accordingly so the SDK retry logic
-          // can classify it as transient.
+          // arrived, type it as a Timeout so the retry logic kicks in.
           const error = new Error("Unexpected error: http2 request did not get a response");
           if (session.destroyed) {
             error.name = "TimeoutError";

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -248,6 +248,15 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
           // Gracefully closes the Http2Session, allowing any existing streams to complete
           // on their own and preventing new Http2Stream instances from being created.
           session.close();
+
+          // Ensure the isolated session is destroyed when the response body stream ends.
+          // The stream "close" event (below) is the primary cleanup path, but it may not
+          // fire if the consumer never reads the body (e.g. deserialization error, dropped
+          // reference) or on certain Node.js versions/platforms. This provides a reliable
+          // secondary cleanup path.
+          clientHttp2Stream.on("end", () => {
+            ref.destroy();
+          });
         }
       });
 
@@ -261,7 +270,14 @@ export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
           this.connectionManager.release(requestContext, ref);
         }
         if (!fulfilled) {
-          rejectWithDestroy(new Error("Unexpected error: http2 request did not get a response"));
+          // If the session was destroyed (e.g. by sessionTimeout) before the response
+          // arrived, this is a timeout — type it accordingly so the SDK retry logic
+          // can classify it as transient.
+          const error = new Error("Unexpected error: http2 request did not get a response");
+          if (session.destroyed) {
+            error.name = "TimeoutError";
+          }
+          rejectWithDestroy(error);
         }
       });
 


### PR DESCRIPTION
_Issue #, if available:_
#2202 

_Description of changes:_
- Add stream 'end' listener to destroy isolated sessions when body ends
- Type close-without-response error as TimeoutError when session was destroyed by timeout
- Arm a default 5-minute idle timeout on isolated sessions as a fallback

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
