### PR TITLE
fix(core): use Object.keys() in toEndpointV1 to avoid inherited property iteration

### DIFF
--- a/.changeset/fix-toEndpointV1-prototype.md
+++ b/.changeset/fix-toEndpointV1-prototype.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+use Object.keys() in toEndpointV1 to avoid iterating inherited Object.prototype properties

--- a/packages/core/src/submodules/transport/toEndpointV1.spec.ts
+++ b/packages/core/src/submodules/transport/toEndpointV1.spec.ts
@@ -45,6 +45,29 @@ describe(toEndpointV1.name, () => {
     });
   });
 
+  it("does not iterate inherited Object.prototype properties in headers", () => {
+    Object.defineProperty(Object.prototype, "testProp", {
+      value: "not-an-array",
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const result = toEndpointV1({
+        url: new URL("https://example.com/path"),
+        headers: {},
+      });
+
+      expect(result.protocol).toBe("https:");
+      expect(result.hostname).toBe("example.com");
+      expect(result.path).toBe("/path");
+      expect(Object.keys(result.headers!)).toEqual([]);
+    } finally {
+      delete (Object.prototype as any).testProp;
+    }
+  });
+
   it("passes through EndpointV1", () => {
     const v1Endpoint = {
       protocol: "https:",

--- a/packages/core/src/submodules/transport/toEndpointV1.ts
+++ b/packages/core/src/submodules/transport/toEndpointV1.ts
@@ -13,7 +13,7 @@ export const toEndpointV1 = (endpoint: string | Endpoint | EndpointV2): Endpoint
       const v1Endpoint = parseUrl(endpoint.url);
       if (endpoint.headers) {
         v1Endpoint.headers = {};
-        for (const name in endpoint.headers) {
+        for (const name of Object.keys(endpoint.headers)) {
           v1Endpoint.headers[name.toLowerCase()] = endpoint.headers[name].join(", ");
         }
       }


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws/aws-sdk-js-v3/issues/8115
https://github.com/smithy-lang/smithy-typescript/issues/2182

_Description of changes:_

The `for...in` loop in `toEndpointV1` iterates inherited enumerable properties from `Object.prototype`, causing a TypeError when any library extends `Object.prototype` with enum properties.
  
Reverts to `Object.keys(`) which only iterates own properties, matching the original behavior before the perf optimization in #1961.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
