### PR TITLE
chore: guard for-in loops

### DIFF
--- a/.changeset/nasty-walls-tap.md
+++ b/.changeset/nasty-walls-tap.md
@@ -1,0 +1,10 @@
+---
+"@smithy/undici-http-handler": patch
+"@smithy/node-http-handler": patch
+"@smithy/server-common": patch
+"@smithy/signature-v4": patch
+"@smithy/middleware-apply-body-checksum": patch
+"@smithy/core": patch
+---
+
+switch for-in loops to guarded

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,6 +10,7 @@
   "rules": {
     "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-import-type-side-effects": "error",
+    "guard-for-in": "error",
     "no-sparse-arrays": "off",
     "no-unused-vars": ["error", { "args": "none", "caughtErrorsIgnorePattern": "^ignored", "varsIgnorePattern": "^_" }],
     "unicorn/no-new-array": "off",

--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -499,6 +499,7 @@
     "getSerdePlugin": "function",
     "handleFloat": "function",
     "Hash": "function(node-only)",
+    "hasOwn": "function",
     "headStream": "function",
     "isArrayBuffer": "function",
     "isBlob": "function",
@@ -543,6 +544,7 @@
   },
   "@smithy/core/transport": {
     "getSmithyContext": "function",
+    "hasOwn": "function",
     "HttpRequest": "function",
     "HttpResponse": "function",
     "IHttpRequest": "type(interface)",

--- a/packages/core/planning/checksums.md
+++ b/packages/core/planning/checksums.md
@@ -2,7 +2,7 @@
 
 Platform: Node.js v22.22.2 (linux x64)
 
-Date: 2026-06-24T17:04:04.733Z
+Date: 2026-08-14T17:38:50.553Z
 
 Iterations per size: [10000, 5000, 2000, 200, 20, 5, 3], Warmup: 1s per algo
 
@@ -10,37 +10,37 @@ Iterations per size: [10000, 5000, 2000, 200, 20, 5, 3], Warmup: 1s per algo
 
 | Size | Crc32Js (JS) | Crc32Node (node:zlib) | @aws-crypto/crc32 |
 | ---- | ------------ | --------------------- | ----------------- |
-| 32B  | 35.3 MB/s    | 34.4 MB/s             | 28.8 MB/s         |
-| 256B | 96.0 MB/s    | 307.9 MB/s            | 77.9 MB/s         |
-| 1KB  | 116.1 MB/s   | 1.31 GB/s             | 90.4 MB/s         |
-| 64KB | 121.0 MB/s   | 4.52 GB/s             | 101.4 MB/s        |
-| 1MB  | 121.2 MB/s   | 4.76 GB/s             | 100.8 MB/s        |
-| 10MB | 121.2 MB/s   | 4.76 GB/s             | 100.3 MB/s        |
-| 50MB | 121.2 MB/s   | 4.74 GB/s             | 100.9 MB/s        |
+| 32B  | 34.0 MB/s    | 30.8 MB/s             | 29.1 MB/s         |
+| 256B | 95.2 MB/s    | 306.5 MB/s            | 77.5 MB/s         |
+| 1KB  | 113.7 MB/s   | 1.19 GB/s             | 91.0 MB/s         |
+| 64KB | 121.0 MB/s   | 4.53 GB/s             | 98.7 MB/s         |
+| 1MB  | 121.2 MB/s   | 4.74 GB/s             | 99.6 MB/s         |
+| 10MB | 121.2 MB/s   | 4.76 GB/s             | 99.4 MB/s         |
+| 50MB | 121.2 MB/s   | 4.73 GB/s             | 99.3 MB/s         |
 
 ## SHA-256 (hash)
 
 | Size | Sha256Js (JS) | Sha256Node (node:crypto) | @aws-crypto/sha256-js |
 | ---- | ------------- | ------------------------ | --------------------- |
-| 32B  | 9.4 MB/s      | 11.5 MB/s                | 5.2 MB/s              |
-| 256B | 49.0 MB/s     | 71.8 MB/s                | 35.0 MB/s             |
-| 1KB  | 92.4 MB/s     | 211.5 MB/s               | 69.8 MB/s             |
-| 64KB | 116.4 MB/s    | 1.58 GB/s                | 99.9 MB/s             |
-| 1MB  | 118.8 MB/s    | 1.69 GB/s                | 100.4 MB/s            |
-| 10MB | 118.9 MB/s    | 1.70 GB/s                | 100.6 MB/s            |
-| 50MB | 118.7 MB/s    | 1.70 GB/s                | 100.6 MB/s            |
+| 32B  | 9.8 MB/s      | 11.2 MB/s                | 5.1 MB/s              |
+| 256B | 49.7 MB/s     | 68.7 MB/s                | 38.2 MB/s             |
+| 1KB  | 94.2 MB/s     | 247.2 MB/s               | 73.5 MB/s             |
+| 64KB | 117.8 MB/s    | 1.55 GB/s                | 99.8 MB/s             |
+| 1MB  | 118.5 MB/s    | 1.69 GB/s                | 100.4 MB/s            |
+| 10MB | 118.7 MB/s    | 1.70 GB/s                | 100.6 MB/s            |
+| 50MB | 118.4 MB/s    | 1.70 GB/s                | 100.6 MB/s            |
 
 ## SHA-256 (HMAC)
 
 | Size | Sha256Js (JS) | Sha256Node (node:crypto) | @aws-crypto/sha256-js |
 | ---- | ------------- | ------------------------ | --------------------- |
-| 32B  | 3.0 MB/s      | 10.6 MB/s                | 2.7 MB/s              |
-| 256B | 20.2 MB/s     | 76.7 MB/s                | 20.0 MB/s             |
-| 1KB  | 60.4 MB/s     | 344.0 MB/s               | 55.3 MB/s             |
-| 64KB | 115.9 MB/s    | 1.59 GB/s                | 99.6 MB/s             |
-| 1MB  | 118.5 MB/s    | 1.69 GB/s                | 100.4 MB/s            |
-| 10MB | 119.0 MB/s    | 1.70 GB/s                | 100.2 MB/s            |
-| 50MB | 115.4 MB/s    | 1.70 GB/s                | 100.6 MB/s            |
+| 32B  | 3.0 MB/s      | 10.6 MB/s                | 2.8 MB/s              |
+| 256B | 20.7 MB/s     | 78.8 MB/s                | 20.6 MB/s             |
+| 1KB  | 61.8 MB/s     | 321.8 MB/s               | 56.0 MB/s             |
+| 64KB | 117.3 MB/s    | 1.60 GB/s                | 99.5 MB/s             |
+| 1MB  | 118.5 MB/s    | 1.68 GB/s                | 100.4 MB/s            |
+| 10MB | 118.8 MB/s    | 1.70 GB/s                | 100.5 MB/s            |
+| 50MB | 118.8 MB/s    | 1.70 GB/s                | 100.6 MB/s            |
 
 ## MD5
 
@@ -48,10 +48,10 @@ Md5Js vs old @smithy/md5-js (unrolled rounds): 0.9x (32B), 2.2x (256B), 2.2x (1K
 
 | Size | Md5Js (JS) | Md5Node (node:crypto) |
 | ---- | ---------- | --------------------- |
-| 32B  | 10.9 MB/s  | 13.3 MB/s             |
-| 256B | 58.4 MB/s  | 87.6 MB/s             |
-| 1KB  | 114.3 MB/s | 261.1 MB/s            |
-| 64KB | 142.7 MB/s | 756.4 MB/s            |
-| 1MB  | 143.4 MB/s | 775.8 MB/s            |
+| 32B  | 11.1 MB/s  | 13.3 MB/s             |
+| 256B | 58.5 MB/s  | 89.6 MB/s             |
+| 1KB  | 114.1 MB/s | 260.6 MB/s            |
+| 64KB | 142.6 MB/s | 758.0 MB/s            |
+| 1MB  | 143.5 MB/s | 775.4 MB/s            |
 | 10MB | 143.6 MB/s | 777.4 MB/s            |
-| 50MB | 143.3 MB/s | 777.6 MB/s            |
+| 50MB | 143.1 MB/s | 777.8 MB/s            |

--- a/packages/core/src/legacy-root-exports/util-identity-and-auth/DefaultIdentityProviderConfig.ts
+++ b/packages/core/src/legacy-root-exports/util-identity-and-auth/DefaultIdentityProviderConfig.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import type { HttpAuthSchemeId, Identity, IdentityProvider, IdentityProviderConfig } from "@smithy/types";
 
 /**
@@ -14,6 +15,7 @@ export class DefaultIdentityProviderConfig implements IdentityProviderConfig {
    */
   constructor(config: Record<HttpAuthSchemeId, IdentityProvider<Identity> | undefined>) {
     for (const key in config) {
+      if (!hasOwn(config, key)) continue;
       const value = config[key];
       if (value !== undefined) {
         this.authSchemes.set(key, value);

--- a/packages/core/src/submodules/cbor/codec-v1/CborShapeDeserializer.ts
+++ b/packages/core/src/submodules/cbor/codec-v1/CborShapeDeserializer.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { SerdeContext } from "@smithy/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
 import { NumericValue, _parseEpochTimestamp, fromBase64 } from "@smithy/core/serde";
@@ -80,6 +81,7 @@ export class CborShapeDeserializer extends SerdeContext implements ShapeDeserial
         const targetSchema = ns.getValueSchema();
 
         for (const key in value) {
+          if (!hasOwn(value, key)) continue;
           const itemValue = this.readValue(targetSchema, value[key]);
           newObject[key] = itemValue;
         }
@@ -89,6 +91,7 @@ export class CborShapeDeserializer extends SerdeContext implements ShapeDeserial
         if (isUnion) {
           keys = new Set<string>();
           for (const k in value) {
+            if (!hasOwn(value, k)) continue;
             if (k !== "__type") {
               keys.add(k);
             }
@@ -105,6 +108,7 @@ export class CborShapeDeserializer extends SerdeContext implements ShapeDeserial
         if (isUnion && keys?.size === 1) {
           let newObjectEmpty = true;
           for (const _ in newObject) {
+            if (!hasOwn(newObject, _)) continue;
             newObjectEmpty = false;
             break;
           }
@@ -116,6 +120,7 @@ export class CborShapeDeserializer extends SerdeContext implements ShapeDeserial
           // This if-block is for backwards compatibility support and should not be copied
           // to other implementations.
           for (const k in value) {
+            if (!hasOwn(value, k)) continue;
             if (!(k in newObject)) {
               // we have no type information, so copy as-is from CBOR-derived object.
               newObject[k] = value[k];

--- a/packages/core/src/submodules/cbor/codec-v1/CborShapeSerializer.ts
+++ b/packages/core/src/submodules/cbor/codec-v1/CborShapeSerializer.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { SerdeContext } from "@smithy/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
 import { _parseEpochTimestamp, fromBase64, generateIdempotencyToken } from "@smithy/core/serde";
@@ -66,6 +67,7 @@ export class CborShapeSerializer extends SerdeContext implements ShapeSerializer
       if (ns.isMapSchema()) {
         const sparse = !!ns.getMergedTraits().sparse;
         for (const key in sourceObject) {
+          if (!hasOwn(sourceObject, key)) continue;
           const value = this.serialize(ns.getValueSchema(), sourceObject[key]);
           if (value != null || sparse) {
             newObject[key] = value;
@@ -86,6 +88,7 @@ export class CborShapeSerializer extends SerdeContext implements ShapeSerializer
           // This if-block is for backwards compatibility support and should not be copied
           // to other implementations.
           for (const k in sourceObject) {
+            if (!hasOwn(sourceObject, k)) continue;
             if (!(k in newObject)) {
               // we have no type information, so serialize with Document rules.
               newObject[k] = this.serialize(15 satisfies DocumentSchema, sourceObject[k]);
@@ -102,6 +105,7 @@ export class CborShapeSerializer extends SerdeContext implements ShapeSerializer
           return newArray;
         }
         for (const key in sourceObject) {
+          if (!hasOwn(sourceObject, key)) continue;
           newObject[key] = this.serialize(ns.getValueSchema(), sourceObject[key]);
         }
       } else if (ns.isBigDecimalSchema()) {

--- a/packages/core/src/submodules/cbor/codec-v2/CborShapeDeserializer2.ts
+++ b/packages/core/src/submodules/cbor/codec-v2/CborShapeDeserializer2.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { SerdeContext } from "@smithy/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
 import { NumericValue, _parseEpochTimestamp, nv } from "@smithy/core/serde";
@@ -173,6 +174,7 @@ function readStruct(ns: NormalizedSchema, count: number, startPos: number): any 
   if (isUnion) {
     let resultEmpty = true;
     for (const _ in result) {
+      if (!hasOwn(result, _)) continue;
       resultEmpty = false;
       break;
     }
@@ -348,6 +350,7 @@ function readMapIndefinite(ns: NormalizedSchema): any {
         if (isUnion) {
           let resultEmpty = true;
           for (const _ in result) {
+            if (!hasOwn(result, _)) continue;
             resultEmpty = false;
             break;
           }
@@ -694,6 +697,7 @@ function transformObject(ns: NormalizedSchema, value: any): any {
   if (ns.isMapSchema()) {
     const targetSchema = ns.getValueSchema();
     for (const key in value) {
+      if (!hasOwn(value, key)) continue;
       newObject[key] = transformObject(targetSchema, value[key]);
     }
   } else if (ns.isStructSchema()) {
@@ -702,6 +706,7 @@ function transformObject(ns: NormalizedSchema, value: any): any {
     if (isUnion) {
       keys = new Set<string>();
       for (const k in value) {
+        if (!hasOwn(value, k)) continue;
         if (k !== "__type") {
           keys.add(k);
         }
@@ -718,6 +723,7 @@ function transformObject(ns: NormalizedSchema, value: any): any {
     if (isUnion && keys?.size === 1) {
       let newObjectEmpty = true;
       for (const _ in newObject) {
+        if (!hasOwn(newObject, _)) continue;
         newObjectEmpty = false;
         break;
       }
@@ -727,6 +733,7 @@ function transformObject(ns: NormalizedSchema, value: any): any {
       }
     } else if (typeof value.__type === "string") {
       for (const k in value) {
+        if (!hasOwn(value, k)) continue;
         if (!(k in newObject)) {
           newObject[k] = value[k];
         }

--- a/packages/core/src/submodules/cbor/codec-v2/CborShapeSerializer2.ts
+++ b/packages/core/src/submodules/cbor/codec-v2/CborShapeSerializer2.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { SerdeContext } from "@smithy/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
 import { NumericValue, fromBase64, generateIdempotencyToken } from "@smithy/core/serde";
@@ -353,6 +354,7 @@ function writeStruct(ns: NormalizedSchema, value: Record<string, unknown>, serde
 
   if (typeof value.__type === "string") {
     for (const k in value) {
+      if (!hasOwn(value, k)) continue;
       if (!memberNames.includes(k)) {
         writeString(k);
         writeUntypedValue(value[k]);
@@ -419,6 +421,7 @@ function writeMap(ns: NormalizedSchema, value: Record<string, unknown>, isDocume
 
   const keys: string[] = [];
   for (const k in value) {
+    if (!hasOwn(value, k)) continue;
     const v = value[k];
     if (isDocument ? v !== undefined : v != null || sparse) {
       keys.push(k);

--- a/packages/core/src/submodules/cbor/parseCborBody.ts
+++ b/packages/core/src/submodules/cbor/parseCborBody.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { HttpRequest as __HttpRequest, collectBody } from "@smithy/core/protocols";
 import { calculateBodyLength } from "@smithy/core/serde";
 import type {
@@ -75,6 +76,7 @@ export const loadSmithyRpcV2CborErrorCode = (output: HttpResponse, data: any): s
 
   let codeKey: string | undefined;
   for (const key in data) {
+    if (!hasOwn(data, key)) continue;
     if (key.toLowerCase() === "code") {
       codeKey = key;
       break;
@@ -122,6 +124,7 @@ export const buildHttpRpcRequest = async (
   }
   if (endpoint.headers) {
     for (const name in endpoint.headers) {
+      if (!hasOwn(endpoint.headers, name)) continue;
       contents.headers[name] = endpoint.headers[name];
     }
   }

--- a/packages/core/src/submodules/client/smithy-client/extensions/checksum.ts
+++ b/packages/core/src/submodules/client/smithy-client/extensions/checksum.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import {
   AlgorithmId,
   type ChecksumAlgorithm,
@@ -33,6 +34,7 @@ export const getChecksumConfiguration = (runtimeConfig: PartialChecksumRuntimeCo
   const checksumAlgorithms: ChecksumAlgorithm[] = [];
 
   for (const id in AlgorithmId) {
+    if (!hasOwn(AlgorithmId, id)) continue;
     const algorithmId = AlgorithmId[id as keyof typeof AlgorithmId];
     if (runtimeConfig[algorithmId] === undefined) {
       continue;

--- a/packages/core/src/submodules/client/smithy-client/get-value-from-text-node.ts
+++ b/packages/core/src/submodules/client/smithy-client/get-value-from-text-node.ts
@@ -1,3 +1,5 @@
+import { hasOwn } from "@smithy/core/transport";
+
 /**
  * Recursively parses object and populates value is node from
  * "#text" key if it's available
@@ -8,7 +10,8 @@ export const getValueFromTextNode = (obj: any) => {
   const textNodeName = "#text";
 
   for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key) && obj[key][textNodeName] !== undefined) {
+    if (!hasOwn(obj, key)) continue;
+    if (obj[key][textNodeName] !== undefined) {
       obj[key] = obj[key][textNodeName];
     } else if (typeof obj[key] === "object" && obj[key] !== null) {
       obj[key] = getValueFromTextNode(obj[key]);

--- a/packages/core/src/submodules/client/smithy-client/object-mapping.ts
+++ b/packages/core/src/submodules/client/smithy-client/object-mapping.ts
@@ -1,3 +1,5 @@
+import { hasOwn } from "@smithy/core/transport";
+
 /**
  * A set of instructions for multiple keys.
  * The aim is to provide a concise yet readable way to map and filter values
@@ -188,7 +190,8 @@ export function map(arg0: any, arg1?: any, arg2?: any): any {
     }
   }
 
-  for (const key of Object.keys(instructions)) {
+  for (const key in instructions) {
+    if (!hasOwn(instructions, key)) continue;
     if (!Array.isArray(instructions[key])) {
       target[key] = instructions[key]; // unchecked value.
       continue;
@@ -221,6 +224,7 @@ export const convertMap = (target: any): Record<string, any> => {
 export const take = (source: any, instructions: SourceMappingInstructions): any => {
   const out = {};
   for (const key in instructions) {
+    if (!hasOwn(instructions, key)) continue;
     applyInstruction(out, source, instructions, key);
   }
   return out;

--- a/packages/core/src/submodules/client/smithy-client/serde-json.ts
+++ b/packages/core/src/submodules/client/smithy-client/serde-json.ts
@@ -1,3 +1,5 @@
+import { hasOwn } from "@smithy/core/transport";
+
 /**
  * Maps an object through the default JSON serde behavior.
  * This means removing nullish fields and un-sparsifying lists.
@@ -16,7 +18,8 @@ export const _json = (obj: any): any => {
   }
   if (typeof obj === "object") {
     const target: any = {};
-    for (const key of Object.keys(obj)) {
+    for (const key in obj) {
+      if (!hasOwn(obj, key)) continue;
       if (obj[key] == null) {
         continue;
       }

--- a/packages/core/src/submodules/config/property-provider/memoize.spec.ts
+++ b/packages/core/src/submodules/config/property-provider/memoize.spec.ts
@@ -84,7 +84,8 @@ describe("memoize", () => {
         const memoized = memoize(provider, isExpired, requiresRefresh);
         expect(provider).toHaveBeenCalledTimes(0);
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const index in [...Array(repeatTimes).keys()]) {
+        let n = repeatTimes;
+        while (n-- > 0) {
           expect(await memoized()).toEqual(mockReturn);
         }
 
@@ -108,8 +109,8 @@ describe("memoize", () => {
     describe("should reinvoke the underlying provider when isExpired returns `true`", () => {
       const isExpiredTrueTest = async (requiresRefresh?: any) => {
         const memoized = memoize(provider, isExpired, requiresRefresh);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const index in [...Array(repeatTimes).keys()]) {
+        let n = repeatTimes;
+        while (n-- > 0) {
           expect(await memoized()).toEqual(mockReturn);
         }
 
@@ -155,8 +156,8 @@ describe("memoize", () => {
         const memoized = memoize(provider, isExpired, requiresRefresh);
         const result = memoized();
         expect(await result).toBe(mockReturn);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const index in [...Array(repeatTimes).keys()]) {
+        let n = repeatTimes;
+        while (n-- > 0) {
           expect(memoized()).toStrictEqual(result);
           expect(provider).toHaveBeenCalledTimes(1);
         }

--- a/packages/core/src/submodules/config/shared-ini-file-loader/getConfigFilepath.spec.ts
+++ b/packages/core/src/submodules/config/shared-ini-file-loader/getConfigFilepath.spec.ts
@@ -19,11 +19,15 @@ describe(getConfigFilepath.name, () => {
   });
 
   it("returns configFilePath from default locations", () => {
+    const OLD_ENV = process.env;
+    process.env = { ...OLD_ENV };
+    delete process.env[ENV_CONFIG_PATH];
     vi.mocked(join).mockImplementation((...args) => args.join(mockSeparator));
     vi.mocked(getHomeDir).mockReturnValue(mockHomeDir);
     expect(getConfigFilepath()).toStrictEqual(defaultConfigFilepath);
     expect(getHomeDir).toHaveBeenCalledWith();
     expect(join).toHaveBeenCalledWith(mockHomeDir, ".aws", "config");
+    process.env = OLD_ENV;
   });
 
   it("returns configFile from location defined in environment", () => {

--- a/packages/core/src/submodules/config/shared-ini-file-loader/getCredentialsFilepath.spec.ts
+++ b/packages/core/src/submodules/config/shared-ini-file-loader/getCredentialsFilepath.spec.ts
@@ -19,11 +19,15 @@ describe(getCredentialsFilepath.name, () => {
   });
 
   it("returns configFilePath from default locations", () => {
+    const OLD_ENV = process.env;
+    process.env = { ...OLD_ENV };
+    delete process.env[ENV_CREDENTIALS_PATH];
     vi.mocked(join).mockImplementation((...args) => args.join(mockSeparator));
     vi.mocked(getHomeDir).mockReturnValue(mockHomeDir);
     expect(getCredentialsFilepath()).toStrictEqual(defaultConfigFilepath);
     expect(getHomeDir).toHaveBeenCalledWith();
     expect(join).toHaveBeenCalledWith(mockHomeDir, ".aws", "credentials");
+    process.env = OLD_ENV;
   });
 
   it("returns configFile from location defined in environment", () => {

--- a/packages/core/src/submodules/endpoints/middleware-endpoint/adaptors/getEndpointFromConfig.spec.ts
+++ b/packages/core/src/submodules/endpoints/middleware-endpoint/adaptors/getEndpointFromConfig.spec.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { externalDataInterceptor } from "@smithy/core/config";
 import { afterEach, beforeEach, describe, expect, test as it } from "vitest";
 
@@ -9,14 +10,16 @@ describe(getEndpointFromConfig.name, () => {
 
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
-    for (const key of Object.keys(fileRecord)) {
+    for (const key in fileRecord) {
+      if (!hasOwn(fileRecord, key)) continue;
       delete fileRecord[key];
     }
   });
 
   afterEach(() => {
     process.env = ORIGINAL_ENV;
-    for (const key of Object.keys(fileRecord)) {
+    for (const key in fileRecord) {
+      if (!hasOwn(fileRecord, key)) continue;
       delete fileRecord[key];
     }
   });

--- a/packages/core/src/submodules/endpoints/util-endpoints/resolveEndpoint.ts
+++ b/packages/core/src/submodules/endpoints/util-endpoints/resolveEndpoint.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import type { EndpointV2 } from "@smithy/types";
 
 import { debugId, toDebugString } from "./debug";
@@ -14,6 +15,7 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
   options.logger?.debug?.(`${debugId} Initial EndpointParams: ${toDebugString(endpointParams)}`);
 
   for (const paramKey in parameters) {
+    if (!hasOwn(parameters, paramKey)) continue;
     const parameter = parameters[paramKey];
     const endpointParam = endpointParams[paramKey];
 

--- a/packages/core/src/submodules/event-streams/EventStreamSerde.ts
+++ b/packages/core/src/submodules/event-streams/EventStreamSerde.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { type NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
 import { fromUtf8, toUtf8 } from "@smithy/core/serde";
 import type {
@@ -121,6 +122,7 @@ export class EventStreamSerde {
 
       let unionMember = "";
       for (const key in event) {
+        if (!hasOwn(event, key)) continue;
         if (key !== "__type") {
           unionMember = key;
           break;
@@ -179,6 +181,7 @@ export class EventStreamSerde {
     const asyncIterable = marshaller.deserialize(response.body, async (event) => {
       let unionMember = "";
       for (const key in event) {
+        if (!hasOwn(event, key)) continue;
         if (key !== "__type") {
           unionMember = key;
           break;
@@ -267,6 +270,7 @@ export class EventStreamSerde {
       }
 
       for (const key in firstEvent.value) {
+        if (!hasOwn(firstEvent.value, key)) continue;
         initialResponseContainer[key] = firstEvent.value[key];
       }
     }

--- a/packages/core/src/submodules/event-streams/eventstream-codec/EventStreamCodec.spec.ts
+++ b/packages/core/src/submodules/event-streams/eventstream-codec/EventStreamCodec.spec.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { fromUtf8, toUtf8 } from "@smithy/core/serde";
 import { describe, expect, test as it } from "vitest";
 
@@ -7,7 +8,8 @@ import { vectors } from "./TestVectors.fixture";
 describe("eventstream parsing", () => {
   const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
 
-  for (const vectorName of Object.keys(vectors)) {
+  for (const vectorName in vectors) {
+    if (!hasOwn(vectors, vectorName)) continue;
     const vector = vectors[vectorName];
     it(`should handle the ${vectorName} test case`, () => {
       if (vector.expectation === "failure") {

--- a/packages/core/src/submodules/event-streams/eventstream-codec/HeaderMarshaller.ts
+++ b/packages/core/src/submodules/event-streams/eventstream-codec/HeaderMarshaller.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { fromHex, toHex } from "@smithy/core/serde";
 import type { Decoder, Encoder, MessageHeaderValue, MessageHeaders } from "@smithy/types";
 
@@ -15,7 +16,8 @@ export class HeaderMarshaller {
   format(headers: MessageHeaders): Uint8Array {
     const chunks: Array<Uint8Array> = [];
 
-    for (const headerName of Object.keys(headers)) {
+    for (const headerName in headers) {
+      if (!hasOwn(headers, headerName)) continue;
       const bytes = this.fromUtf8(headerName);
       chunks.push(Uint8Array.from([bytes.byteLength]), bytes, this.formatHeaderValue(headers[headerName]));
     }

--- a/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpBindingProtocol.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { NormalizedSchema, translateTraits, type TypeRegistry } from "@smithy/core/schema";
 import { sdkStreamMixin, splitEvery, splitHeader } from "@smithy/core/serde";
 import { HttpRequest } from "@smithy/core/transport";
@@ -136,6 +137,7 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
         headers[memberTraits.httpHeader.toLowerCase() as string] = String(serializer.flush());
       } else if (typeof memberTraits.httpPrefixHeaders === "string") {
         for (const key in inputMemberValue) {
+          if (!hasOwn(inputMemberValue, key)) continue;
           const val = inputMemberValue[key];
           const amalgam = memberTraits.httpPrefixHeaders + key;
           serializer.write([memberNs.getValueSchema(), { httpHeader: amalgam }], val);
@@ -188,6 +190,7 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
 
     if (traits.httpQueryParams) {
       for (const key in data) {
+        if (!hasOwn(data, key)) continue;
         if (!(key in query)) {
           const val = data[key];
           const valueSchema = ns.getValueSchema();
@@ -243,6 +246,7 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
     }
 
     for (const header in response.headers) {
+      if (!hasOwn(response.headers, header)) continue;
       const value = response.headers[header];
       delete response.headers[header];
       response.headers[header.toLowerCase()] = value;
@@ -361,6 +365,7 @@ export abstract class HttpBindingProtocol extends HttpProtocol {
       } else if (memberTraits.httpPrefixHeaders !== undefined) {
         dataObject[memberName] = {};
         for (const header in response.headers) {
+          if (!hasOwn(response.headers, header)) continue;
           if (header.startsWith(memberTraits.httpPrefixHeaders)) {
             const value = response.headers[header];
             const valueSchema = memberSchema.getValueSchema();

--- a/packages/core/src/submodules/protocols/HttpProtocol.ts
+++ b/packages/core/src/submodules/protocols/HttpProtocol.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import type { EventStreamSerde } from "@smithy/core/event-streams";
 import { NormalizedSchema, TypeRegistry, translateTraits } from "@smithy/core/schema";
 import { HttpRequest, HttpResponse, isValidHostname } from "@smithy/core/transport";
@@ -105,6 +106,7 @@ export abstract class HttpProtocol extends SerdeContext implements ClientProtoco
       // Apply resolved endpoint headers per Endpoints 2.0 spec.
       if (endpoint.headers) {
         for (const name in endpoint.headers) {
+          if (!hasOwn(endpoint.headers, name)) continue;
           request.headers[name] = endpoint.headers[name].join(", ");
         }
       }
@@ -120,6 +122,7 @@ export abstract class HttpProtocol extends SerdeContext implements ClientProtoco
       // Apply endpoint headers for deprecated Endpoint type if present
       if (endpoint.headers) {
         for (const name in endpoint.headers) {
+          if (!hasOwn(endpoint.headers, name)) continue;
           request.headers[name] = endpoint.headers[name];
         }
       }

--- a/packages/core/src/submodules/protocols/RpcProtocol.ts
+++ b/packages/core/src/submodules/protocols/RpcProtocol.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { NormalizedSchema, type TypeRegistry } from "@smithy/core/schema";
 import { HttpRequest } from "@smithy/core/transport";
 import type {
@@ -110,6 +111,7 @@ export abstract class RpcProtocol extends HttpProtocol {
     }
 
     for (const header in response.headers) {
+      if (!hasOwn(response.headers, header)) continue;
       const value = response.headers[header];
       delete response.headers[header];
       response.headers[header.toLowerCase()] = value;

--- a/packages/core/src/submodules/retry/middleware-retry/parseRetryAfterHeader.ts
+++ b/packages/core/src/submodules/retry/middleware-retry/parseRetryAfterHeader.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { HttpResponse } from "@smithy/core/protocols";
 import { parseRfc7231DateTime } from "@smithy/core/serde";
 import type { Logger } from "@smithy/types";
@@ -10,7 +11,8 @@ export function parseRetryAfterHeader(response: unknown, logger?: Logger): Date 
     return;
   }
 
-  for (const header of Object.keys(response.headers)) {
+  for (const header in response.headers) {
+    if (!hasOwn(response.headers, header)) continue;
     const h = header.toLowerCase();
     if (h === "retry-after") {
       const retryAfter = response.headers[header];

--- a/packages/core/src/submodules/serde/index.browser.ts
+++ b/packages/core/src/submodules/serde/index.browser.ts
@@ -108,3 +108,5 @@ export { streamCollector } from "./util-stream/stream-collector.browser";
 const _getRandomValues = (array: Uint8Array): Uint8Array => crypto.getRandomValues(array as Uint8Array<ArrayBuffer>);
 export const v4 = bindV4(_getRandomValues);
 export const generateIdempotencyToken = v4;
+
+export { hasOwn } from "@smithy/core/transport";

--- a/packages/core/src/submodules/serde/index.native.ts
+++ b/packages/core/src/submodules/serde/index.native.ts
@@ -110,3 +110,5 @@ export { streamCollector } from "./util-stream/stream-collector.browser";
 const _getRandomValues = (array: Uint8Array): Uint8Array => crypto.getRandomValues(array as Uint8Array<ArrayBuffer>);
 export const v4 = bindV4(_getRandomValues);
 export const generateIdempotencyToken = v4;
+
+export { hasOwn } from "@smithy/core/transport";

--- a/packages/core/src/submodules/serde/index.ts
+++ b/packages/core/src/submodules/serde/index.ts
@@ -104,3 +104,5 @@ export { streamCollector } from "./util-stream/stream-collector";
 const _getRandomValues = getRandomValues as (array: Uint8Array) => Uint8Array;
 export const v4 = bindV4(_getRandomValues);
 export const generateIdempotencyToken = v4;
+
+export { hasOwn } from "@smithy/core/transport";

--- a/packages/core/src/submodules/serde/parse-utils.ts
+++ b/packages/core/src/submodules/serde/parse-utils.ts
@@ -1,3 +1,5 @@
+import { hasOwn } from "@smithy/core/transport";
+
 /**
  * Give an input string, strictly parses a boolean value.
  *
@@ -295,6 +297,7 @@ export const expectUnion = (value: unknown): Record<string, any> | undefined => 
 
   const setKeys = [];
   for (const k in asObject) {
+    if (!hasOwn(asObject, k)) continue;
     if (asObject[k] != null) {
       setKeys.push(k);
     }

--- a/packages/core/src/submodules/serde/util-utf8/fromUtf8.spec.ts
+++ b/packages/core/src/submodules/serde/util-utf8/fromUtf8.spec.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { describe, expect, test as it } from "vitest";
 
 import { fromUtf8 } from "./fromUtf8";
@@ -21,7 +22,8 @@ const utf8StringsToByteArrays: Record<string, Uint8Array> = {
 };
 
 describe("fromUtf8", () => {
-  for (const string of Object.keys(utf8StringsToByteArrays)) {
+  for (const string in utf8StringsToByteArrays) {
+    if (!hasOwn(utf8StringsToByteArrays, string)) continue;
     it(`should UTF-8 decode "${string}" to the correct value`, () => {
       expect(fromUtf8(string)).toEqual(utf8StringsToByteArrays[string]);
     });

--- a/packages/core/src/submodules/serde/util-utf8/toUtf8.spec.ts
+++ b/packages/core/src/submodules/serde/util-utf8/toUtf8.spec.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import type { Encoder } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
@@ -22,7 +23,8 @@ const utf8StringsToByteArrays: Record<string, Uint8Array> = {
 };
 
 describe("toUtf8", () => {
-  for (const string of Object.keys(utf8StringsToByteArrays)) {
+  for (const string in utf8StringsToByteArrays) {
+    if (!hasOwn(utf8StringsToByteArrays, string)) continue;
     it(`should derive "${string}" from the UTF-8 decoded bytes`, () => {
       expect(toUtf8(utf8StringsToByteArrays[string])).toBe(string);
     });

--- a/packages/core/src/submodules/transport/hasOwn.ts
+++ b/packages/core/src/submodules/transport/hasOwn.ts
@@ -1,0 +1,6 @@
+/**
+ * @internal
+ */
+export function hasOwn(o: object, k: string) {
+  return Object.prototype.hasOwnProperty.call(o, k);
+}

--- a/packages/core/src/submodules/transport/index.ts
+++ b/packages/core/src/submodules/transport/index.ts
@@ -1,8 +1,13 @@
 /*
  * This is a file-cycle-breaking module and shouldn't have its API expanded.
+ * hasOwn is exported here as an exception: transport has zero outgoing
+ * @smithy/core/* dependencies (a true sink node), so it is the only
+ * submodule that can host a widely shared utility without risking a cycle.
+ * Do not add other exports here for convenience.
  */
 
 export { getSmithyContext } from "./getSmithyContext";
+export { hasOwn } from "./hasOwn";
 export { HttpRequest } from "./httpRequest";
 export type { IHttpRequest } from "./httpRequest";
 export { HttpResponse } from "./httpResponse";

--- a/packages/core/src/submodules/transport/toEndpointV1.ts
+++ b/packages/core/src/submodules/transport/toEndpointV1.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "./hasOwn";
 import type { Endpoint, EndpointV2 } from "@smithy/types";
 
 import { parseUrl } from "./parseUrl";
@@ -14,6 +15,7 @@ export const toEndpointV1 = (endpoint: string | Endpoint | EndpointV2): Endpoint
       if (endpoint.headers) {
         v1Endpoint.headers = {};
         for (const name in endpoint.headers) {
+          if (!hasOwn(endpoint.headers, name)) continue;
           v1Endpoint.headers[name.toLowerCase()] = endpoint.headers[name].join(", ");
         }
       }

--- a/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { afterAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import {
@@ -86,7 +87,8 @@ describe("fromContainerMetadata", () => {
     });
 
     it("should retry responses that receive invalid response values", async () => {
-      for (const key of Object.keys(creds)) {
+      for (const key in creds) {
+        if (!hasOwn(creds, key)) continue;
         const invalidCreds: any = { ...creds };
         delete invalidCreds[key];
         mockHttpRequest.mockReturnValueOnce(Promise.resolve(JSON.stringify(invalidCreds)));

--- a/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
+++ b/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import { HttpRequest } from "@smithy/core/protocols";
 import { isArrayBuffer } from "@smithy/core/serde";
 import type {
@@ -59,7 +60,8 @@ export const getApplyMd5BodyChecksumPlugin = (config: Md5BodyChecksumResolvedCon
 
 const hasHeader = (soughtHeader: string, headers: HeaderBag): boolean => {
   soughtHeader = soughtHeader.toLowerCase();
-  for (const headerName of Object.keys(headers)) {
+  for (const headerName in headers) {
+    if (!hasOwn(headers, headerName)) continue;
     if (soughtHeader === headerName.toLowerCase()) {
       return true;
     }

--- a/packages/node-http-handler/src/get-transformed-headers.ts
+++ b/packages/node-http-handler/src/get-transformed-headers.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import type { IncomingHttpHeaders } from "node:http2";
 import type { HeaderBag } from "@smithy/types";
 
@@ -5,6 +6,7 @@ const getTransformedHeaders = (headers: IncomingHttpHeaders) => {
   const transformedHeaders: HeaderBag = {};
 
   for (const name in headers) {
+    if (!hasOwn(headers, name)) continue;
     const headerValues = <string>headers[name];
     transformedHeaders[name] = Array.isArray(headerValues) ? headerValues.join(",") : headerValues;
   }

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import type { Agent as hAgentType, request as hRequestType } from "node:http";
 import type { RequestOptions, Agent as hsAgentType } from "node:https";
 import { HttpResponse, buildQueryString, type HttpHandler, type HttpRequest } from "@smithy/core/protocols";
@@ -88,6 +89,7 @@ export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
 
     if (sockets && requests) {
       for (const origin in sockets) {
+        if (!hasOwn(sockets, origin)) continue;
         const socketsInUse = sockets[origin]?.length ?? 0;
         const requestsEnqueued = requests[origin]?.length ?? 0;
 

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { rejects } from "node:assert";
 import http2, { type ClientHttp2Session, type ClientHttp2Stream, type Http2Server, type Http2Stream } from "node:http2";
 import { Duplex } from "node:stream";
@@ -73,6 +74,7 @@ describe(NodeHttp2Handler.name, () => {
     mockH2Server.removeAllListeners("request");
     vi.clearAllMocks();
     for (const p in mockH2Servers) {
+      if (!hasOwn(mockH2Servers, p)) continue;
       mockH2Servers[p].removeAllListeners("request");
       mockH2Servers[p].close();
     }

--- a/packages/server-common/src/httpbinding/mux.spec.ts
+++ b/packages/server-common/src/httpbinding/mux.spec.ts
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+import { hasOwn } from "@smithy/core/transport";
 import { describe, expect, it } from "vitest";
 import { HttpRequest } from "@smithy/core/protocols";
 
@@ -122,6 +123,7 @@ describe("simple matching", () => {
   ];
 
   for (const key in matches) {
+    if (!hasOwn(matches, key)) continue;
     const reqs = matches[key];
     for (const req of reqs) {
       it(`should match ${JSON.stringify(req)} to ${key}`, () => {

--- a/packages/server-common/src/service-handler/routing.ts
+++ b/packages/server-common/src/service-handler/routing.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { hasOwn } from "@smithy/core/serde";
 import type { HttpRequest, HttpResponse } from "@smithy/core/protocols";
 import type { Logger, StaticOperationSchema } from "@smithy/types";
 
@@ -262,6 +263,7 @@ export function createCombinedRouter(protocols: Record<string, ServerProtocol<Ht
  */
 function getHeaderValue(request: HttpRequest, name: string): string | undefined {
   for (const key in request.headers) {
+    if (!hasOwn(request.headers, key)) continue;
     if (key.toLowerCase() === name) {
       return request.headers[key];
     }

--- a/packages/signature-v4/src/HeaderFormatter.ts
+++ b/packages/signature-v4/src/HeaderFormatter.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import { fromHex, fromUtf8, toHex } from "@smithy/core/serde";
 import type { Int64 as IInt64, MessageHeaderValue, MessageHeaders } from "@smithy/types";
 
@@ -11,7 +12,8 @@ export class HeaderFormatter {
   public format(headers: MessageHeaders): Uint8Array {
     const chunks: Array<Uint8Array> = [];
 
-    for (const headerName of Object.keys(headers)) {
+    for (const headerName in headers) {
+      if (!hasOwn(headers, headerName)) continue;
       const bytes = fromUtf8(headerName);
       chunks.push(Uint8Array.from([bytes.byteLength]), bytes, this.formatHeaderValue(headers[headerName]));
     }

--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import { HttpRequest } from "@smithy/core/protocols";
 import type { HeaderBag } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
@@ -40,7 +41,8 @@ describe("getCanonicalHeaders", () => {
       },
       hostname: "foo.us-east-1.amazonaws.com",
     });
-    for (const headerName of Object.keys(ALWAYS_UNSIGNABLE_HEADERS)) {
+    for (const headerName in ALWAYS_UNSIGNABLE_HEADERS) {
+      if (!hasOwn(ALWAYS_UNSIGNABLE_HEADERS, headerName)) continue;
       request.headers[headerName] = "baz";
     }
 

--- a/packages/signature-v4/src/getCanonicalQuery.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import { escapeUri } from "@smithy/core/protocols";
 import type { HttpRequest } from "@smithy/types";
 
@@ -9,7 +10,8 @@ import { SIGNATURE_HEADER } from "./constants";
 export const getCanonicalQuery = ({ query = {} }: HttpRequest): string => {
   const keys: Array<string> = [];
   const serialized: Record<string, string> = {};
-  for (const key of Object.keys(query)) {
+  for (const key in query) {
+    if (!hasOwn(query, key)) continue;
     if (key.toLowerCase() === SIGNATURE_HEADER) {
       continue;
     }

--- a/packages/signature-v4/src/getPayloadHash.ts
+++ b/packages/signature-v4/src/getPayloadHash.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import { isArrayBuffer, toHex, toUint8Array } from "@smithy/core/serde";
 import type { ChecksumConstructor, HashConstructor, HttpRequest } from "@smithy/types";
 
@@ -10,7 +11,8 @@ export const getPayloadHash = async (
   { headers, body }: HttpRequest,
   hashConstructor: ChecksumConstructor | HashConstructor
 ): Promise<string> => {
-  for (const headerName of Object.keys(headers)) {
+  for (const headerName in headers) {
+    if (!hasOwn(headers, headerName)) continue;
     if (headerName.toLowerCase() === SHA256_HEADER) {
       return headers[headerName];
     }

--- a/packages/signature-v4/src/headerUtil.ts
+++ b/packages/signature-v4/src/headerUtil.ts
@@ -1,8 +1,10 @@
+import { hasOwn } from "@smithy/core/serde";
 import type { HeaderBag } from "@smithy/types";
 
 export const hasHeader = (soughtHeader: string, headers: HeaderBag): boolean => {
   soughtHeader = soughtHeader.toLowerCase();
-  for (const headerName of Object.keys(headers)) {
+  for (const headerName in headers) {
+    if (!hasOwn(headers, headerName)) continue;
     if (soughtHeader === headerName.toLowerCase()) {
       return true;
     }
@@ -14,7 +16,8 @@ export const hasHeader = (soughtHeader: string, headers: HeaderBag): boolean => 
 /* Get the value of one request header, ignore the case. Return string if header is in the headers, else return undefined */
 export const getHeaderValue = (soughtHeader: string, headers: HeaderBag): string | undefined => {
   soughtHeader = soughtHeader.toLowerCase();
-  for (const headerName of Object.keys(headers)) {
+  for (const headerName in headers) {
+    if (!hasOwn(headers, headerName)) continue;
     if (soughtHeader === headerName.toLowerCase()) {
       return headers[headerName];
     }
@@ -26,7 +29,8 @@ export const getHeaderValue = (soughtHeader: string, headers: HeaderBag): string
 /* Delete the one request header, ignore the case. Do nothing if it's not there */
 export const deleteHeader = (soughtHeader: string, headers: HeaderBag) => {
   soughtHeader = soughtHeader.toLowerCase();
-  for (const headerName of Object.keys(headers)) {
+  for (const headerName in headers) {
+    if (!hasOwn(headers, headerName)) continue;
     if (soughtHeader === headerName.toLowerCase()) {
       delete headers[headerName];
     }

--- a/packages/signature-v4/src/moveHeadersToQuery.ts
+++ b/packages/signature-v4/src/moveHeadersToQuery.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import { HttpRequest } from "@smithy/core/protocols";
 import type { HttpRequest as IHttpRequest, QueryParameterBag } from "@smithy/types";
 
@@ -9,7 +10,8 @@ export const moveHeadersToQuery = (
   options: { unhoistableHeaders?: Set<string>; hoistableHeaders?: Set<string> } = {}
 ): IHttpRequest & { query: QueryParameterBag } => {
   const { headers, query = {} as QueryParameterBag } = HttpRequest.clone(request);
-  for (const name of Object.keys(headers)) {
+  for (const name in headers) {
+    if (!hasOwn(headers, name)) continue;
     const lname = name.toLowerCase();
     if (
       (lname.slice(0, 6) === "x-amz-" && !options.unhoistableHeaders?.has(lname)) ||

--- a/packages/signature-v4/src/prepareRequest.ts
+++ b/packages/signature-v4/src/prepareRequest.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import { HttpRequest } from "@smithy/core/protocols";
 import type { HttpRequest as IHttpRequest } from "@smithy/types";
 
@@ -10,7 +11,8 @@ export const prepareRequest = (request: IHttpRequest): IHttpRequest => {
   // Create a clone of the request object that does not clone the body
   request = HttpRequest.clone(request);
 
-  for (const headerName of Object.keys(request.headers)) {
+  for (const headerName in request.headers) {
+    if (!hasOwn(request.headers, headerName)) continue;
     if (GENERATED_HEADERS.indexOf(headerName.toLowerCase()) > -1) {
       delete request.headers[headerName];
     }

--- a/packages/undici-http-handler/src/undici-http-handler.ts
+++ b/packages/undici-http-handler/src/undici-http-handler.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/serde";
 import type { Readable } from "node:stream";
 import { HttpResponse, buildQueryString, type HttpHandler, type HttpRequest } from "@smithy/core/protocols";
 import type { HttpHandlerOptions, Logger } from "@smithy/types";
@@ -156,12 +157,14 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
       // Only allocate a new object if multi-value headers are present.
       let transformedHeaders: Record<string, string> | undefined;
       for (const key in responseHeaders) {
+        if (!hasOwn(responseHeaders, key)) continue;
         const value = responseHeaders[key];
         if (Array.isArray(value)) {
           if (!transformedHeaders) {
             // Lazily copy all headers seen so far.
             transformedHeaders = {};
             for (const k in responseHeaders) {
+              if (!hasOwn(responseHeaders, k)) continue;
               if (k === key) break;
               transformedHeaders[k] = responseHeaders[k] as string;
             }

--- a/private/my-local-model/package.json
+++ b/private/my-local-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xyz",
   "description": "xyz client",
-  "version": "3.32.0",
+  "version": "3.33.0",
   "scripts": {
     "build": "concurrently 'npm:build:cjs' 'npm:build:es' 'npm:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/private/util-test/src/test-http-handler.ts
+++ b/private/util-test/src/test-http-handler.ts
@@ -1,3 +1,4 @@
+import { hasOwn } from "@smithy/core/transport";
 import type { HttpHandler, HttpRequest, HttpResponse } from "@smithy/core/protocols";
 import type { Client, HttpHandlerOptions, RequestHandler, RequestHandlerOutput } from "@smithy/types";
 import { expect } from "vitest";
@@ -63,6 +64,7 @@ export class TestHttpHandler implements HttpHandler {
       AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE: 1,
     };
     for (const key in RESERVED_ENVIRONMENT_VARIABLES) {
+      if (!hasOwn(RESERVED_ENVIRONMENT_VARIABLES, key)) continue;
       delete process.env[key];
     }
     process.env.AWS_ACCESS_KEY_ID = "INTEGRATION_TEST_MOCK";

--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -140,6 +140,10 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
       if (linkedPackageDirs.has(localPackageDir)) {
         continue;
       }
+      // Ensure the destination directory exists up front. Without this, the parallel
+      // `cp -r` calls below race to create the same target directory, and `cp` on some
+      // platforms fails with EEXIST when more than one of them tries to create it first.
+      await spawnProcess("mkdir", ["-p", path.join(node_modules, "@smithy", smithyPkg)]);
       await Promise.all(
         ["dist-cjs", "dist-types", "dist-es", "package.json"].map((folder) =>
           spawnProcess("cp", [

--- a/scripts/compilation/esm-to-cjs.js
+++ b/scripts/compilation/esm-to-cjs.js
@@ -306,7 +306,7 @@ function collectAwaitImports(ast, edits, src) {
     if (node.type === ImportExpression) {
       throw new Error(ERR_NON_AWAITED_IMPORT);
     }
-    for (const key in node) {
+    for (const key of Object.keys(node)) {
       if (SKIP_KEYS.has(key)) {
         continue;
       }

--- a/scripts/post-protocol-test-codegen.js
+++ b/scripts/post-protocol-test-codegen.js
@@ -59,7 +59,7 @@ for (const dir of privatePackages) {
   if (fs.existsSync(pkgJsonPath)) {
     const pkgJson = require(pkgJsonPath);
     const imported = collectImportedPackages(packageDir);
-    for (const dep in pkgJson.dependencies ?? {}) {
+    for (const dep of Object.keys(pkgJson.dependencies ?? {})) {
       if (!IMPLICIT_DEPS.has(dep) && !imported.has(dep)) {
         delete pkgJson.dependencies[dep];
         continue;
@@ -68,7 +68,7 @@ for (const dir of privatePackages) {
         pkgJson.dependencies[dep] = "workspace:^";
       }
     }
-    for (const dep in pkgJson.devDependencies ?? {}) {
+    for (const dep of Object.keys(pkgJson.devDependencies ?? {})) {
       if (isWorkspaceDep(dep)) {
         pkgJson.devDependencies[dep] = "workspace:^";
       }


### PR DESCRIPTION
iterate keys with hasOwn guard, add oxlint rule

- hasOwn is the standard safe and performant way to iterate object keys