### PR TITLE
ci: dry-run publishing on the release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -64,11 +64,11 @@ jobs:
       pull-requests: read
     env:
       RELEASE_BRANCH: changeset-release/main
-      # Workflows that must leave the approval queue before this job is done. Both
-      # trigger on `pull_request` to main with no path filters, so both always run
-      # on the release PR; keep this list in step with them. Other pending runs are
-      # still approved, just not waited for.
-      EXPECTED_WORKFLOWS: ci npm-package-existence
+      # Workflows that must leave the approval queue before this job is done. They
+      # all trigger on `pull_request` to main with no path filters, so they always
+      # run on the release PR; keep this list in step with them. Other pending runs
+      # are still approved, just not waited for.
+      EXPECTED_WORKFLOWS: ci npm-package-existence release-dry-run
     steps:
       - name: Approve workflow runs awaiting approval
         env:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,91 @@
+name: release-dry-run
+
+on:
+  # Verify the changesets release PR by doing everything release-npm-packages.yml
+  # does except the publish itself, so that a packaging problem fails a check on
+  # the PR instead of surfacing part-way through a release, with some packages
+  # already on the registry and the rest not. Changesets has no `publish
+  # --dry-run` (changesets/changesets#614 is still open); what stands in for it is
+  # `changeset publish-plan` plus `changeset pack`, which between them resolve the
+  # same plan against the registry and run the same per-package pack that
+  # `changeset publish` would, and stop short of uploading anything.
+  #
+  # Fires on every pull request to main and skips the ones that are not the
+  # release PR, the same way npm-package-existence.yml does. Keep it listed in
+  # EXPECTED_WORKFLOWS in create-release-pr.yml: runs on the release PR need
+  # approving, and that job is what approves them.
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dry-run-release:
+    name: Dry-run the release
+    runs-on: ubuntu-latest
+    # Only the changesets release PR is worth this: it is the only PR whose merge
+    # triggers a publish, and the only one carrying the versions that publish would
+    # use. Every other PR still has its packages built and validated by ci.
+    if: github.head_ref == 'changeset-release/main'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # The PR head, which is the commit that would be published, rather than
+        # the merge ref the default checkout resolves to.
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      # Node version, install and build below all match release-npm-packages.yml.
+      # The point of this job is that it packs what that workflow would publish,
+      # so any difference in how the artifacts are produced weakens it.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install
+      # The plan and the tarballs go under $RUNNER_TEMP, not the workspace, so that
+      # nothing packed here can be mistaken for a change to the tree under test.
+      # Set in a step rather than in the job's `env`, where the runner context is
+      # not available.
+      - name: Set up dry-run paths
+        run: |
+          set -euo pipefail
+          dir="$RUNNER_TEMP/release-dry-run"
+          echo "PUBLISH_PLAN=$dir/publish-plan.json" >> "$GITHUB_ENV"
+          echo "PACK_DIR=$dir/pack" >> "$GITHUB_ENV"
+      # Resolved before the build because it needs no artifacts and is the step
+      # that reaches the registry: a plan that cannot be resolved - a bad
+      # .changeset/config.json, an unreachable registry - fails here in seconds
+      # rather than after a full build. The plan is written out so the pack below
+      # uses exactly this one and the two steps cannot disagree about what is
+      # being released.
+      #
+      # --output is marked experimental by the CLI. If it is ever dropped, pack
+      # resolves its own plan when given no --from-publish-plan, so the fallback is
+      # to drop this step's flag and pack's.
+      - name: Resolve the publish plan
+        run: yarn changeset publish-plan --output "$PUBLISH_PLAN"
+      # dist-cjs/dist-es/dist-types plus downleveled ts3.4 types, which is all a
+      # published tarball contains.
+      - name: Build Release Artifacts
+        run: yarn build:release
+      # The dry run proper. `changeset pack` walks the plan and runs the pack tool
+      # the workspace's package manager implies - `yarn pack` here - once per
+      # package, which is where a package.json that publishes under Yarn only in
+      # theory gives way: the publishConfig.directory incompatibility that broke a
+      # release in #2235 fails this step.
+      - name: Pack every package the release would publish
+        run: yarn changeset pack --from-publish-plan "$PUBLISH_PLAN" --out-dir "$PACK_DIR"
+      # Packing an unbuilt tree is not an error to yarn - it just matches no files
+      # and produces a manifest-only tarball - so passing the step above is not by
+      # itself evidence that the release would ship anything usable.
+      - name: Verify the packed tarballs
+        run: node ./scripts/npm-packages/verify-packed-tarballs.mts "$PACK_DIR"
+      # What this job cannot cover, so that it is not mistaken for a full
+      # rehearsal: npm provenance and the trusted publishing (OIDC) exchange only
+      # happen when a tarball is actually uploaded, by a workflow holding
+      # id-token: write on a push to main. A dry run on a pull request has neither,
+      # so a release that would publish without provenance - which is what #2235
+      # was - still looks clean here. Whether the versions being published exist on
+      # npm at all is checked separately, by npm-package-existence.yml.

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,19 +1,15 @@
 name: release-dry-run
 
 on:
-  # Verify the changesets release PR by doing everything release-npm-packages.yml
-  # does except the publish itself, so that a packaging problem fails a check on
-  # the PR instead of surfacing part-way through a release, with some packages
-  # already on the registry and the rest not. Changesets has no `publish
-  # --dry-run` (changesets/changesets#614 is still open); what stands in for it is
-  # `changeset publish-plan` plus `changeset pack`, which between them resolve the
-  # same plan against the registry and run the same per-package pack that
-  # `changeset publish` would, and stop short of uploading anything.
+  # Run everything release-npm-packages.yml does except the publish itself, for
+  # verification: a packaging problem then fails a check on the release PR instead
+  # of surfacing part-way through a release. Changesets has no built-in `publish
+  # --dry-run` (changesets/changesets#614), so `changeset publish-plan` and
+  # `changeset pack` stand in for it. Provenance and trusted publishing are not
+  # covered, since both need an actual upload from a push to main.
   #
-  # Fires on every pull request to main and skips the ones that are not the
-  # release PR, the same way npm-package-existence.yml does. Keep it listed in
-  # EXPECTED_WORKFLOWS in create-release-pr.yml: runs on the release PR need
-  # approving, and that job is what approves them.
+  # Keep this workflow listed in EXPECTED_WORKFLOWS in create-release-pr.yml,
+  # which is what approves the runs awaiting approval on the release PR.
   pull_request:
     branches:
       - main
@@ -25,67 +21,40 @@ jobs:
   dry-run-release:
     name: Dry-run the release
     runs-on: ubuntu-latest
-    # Only the changesets release PR is worth this: it is the only PR whose merge
-    # triggers a publish, and the only one carrying the versions that publish would
-    # use. Every other PR still has its packages built and validated by ci.
     if: github.head_ref == 'changeset-release/main'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        # The PR head, which is the commit that would be published, rather than
-        # the merge ref the default checkout resolves to.
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      # Node version, install and build below all match release-npm-packages.yml.
-      # The point of this job is that it packs what that workflow would publish,
-      # so any difference in how the artifacts are produced weakens it.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "yarn"
       - name: Install dependencies
         run: yarn install
-      # The plan and the tarballs go under $RUNNER_TEMP, not the workspace, so that
-      # nothing packed here can be mistaken for a change to the tree under test.
-      # Set in a step rather than in the job's `env`, where the runner context is
-      # not available.
+      # Written under $RUNNER_TEMP rather than the workspace, so nothing packed here
+      # can be mistaken for a change to the tree under test. Set in a step because
+      # the runner context is not available in the job's `env`.
       - name: Set up dry-run paths
         run: |
           set -euo pipefail
           dir="$RUNNER_TEMP/release-dry-run"
           echo "PUBLISH_PLAN=$dir/publish-plan.json" >> "$GITHUB_ENV"
           echo "PACK_DIR=$dir/pack" >> "$GITHUB_ENV"
-      # Resolved before the build because it needs no artifacts and is the step
-      # that reaches the registry: a plan that cannot be resolved - a bad
-      # .changeset/config.json, an unreachable registry - fails here in seconds
-      # rather than after a full build. The plan is written out so the pack below
-      # uses exactly this one and the two steps cannot disagree about what is
-      # being released.
-      #
-      # --output is marked experimental by the CLI. If it is ever dropped, pack
-      # resolves its own plan when given no --from-publish-plan, so the fallback is
-      # to drop this step's flag and pack's.
+      # Before the build, since it needs no artifacts: an unresolvable plan then
+      # fails in seconds rather than after a full build. Written out so the pack
+      # below releases exactly this plan.
       - name: Resolve the publish plan
         run: yarn changeset publish-plan --output "$PUBLISH_PLAN"
-      # dist-cjs/dist-es/dist-types plus downleveled ts3.4 types, which is all a
-      # published tarball contains.
       - name: Build Release Artifacts
         run: yarn build:release
-      # The dry run proper. `changeset pack` walks the plan and runs the pack tool
-      # the workspace's package manager implies - `yarn pack` here - once per
-      # package, which is where a package.json that publishes under Yarn only in
-      # theory gives way: the publishConfig.directory incompatibility that broke a
-      # release in #2235 fails this step.
+      # Runs the same per-package pack that `changeset publish` would, which is
+      # where a package.json that publishes only in theory gives way: the
+      # publishConfig.directory incompatibility that broke a release in #2235 fails
+      # this step.
       - name: Pack every package the release would publish
         run: yarn changeset pack --from-publish-plan "$PUBLISH_PLAN" --out-dir "$PACK_DIR"
-      # Packing an unbuilt tree is not an error to yarn - it just matches no files
-      # and produces a manifest-only tarball - so passing the step above is not by
-      # itself evidence that the release would ship anything usable.
+      # Packing an unbuilt tree matches no files and still succeeds, so the step
+      # above passing is not by itself evidence that the tarballs are usable.
       - name: Verify the packed tarballs
         run: node ./scripts/npm-packages/verify-packed-tarballs.mts "$PACK_DIR"
-      # What this job cannot cover, so that it is not mistaken for a full
-      # rehearsal: npm provenance and the trusted publishing (OIDC) exchange only
-      # happen when a tarball is actually uploaded, by a workflow holding
-      # id-token: write on a push to main. A dry run on a pull request has neither,
-      # so a release that would publish without provenance - which is what #2235
-      # was - still looks clean here. Whether the versions being published exist on
-      # npm at all is checked separately, by npm-package-existence.yml.

--- a/scripts/npm-packages/verify-packed-tarballs.mts
+++ b/scripts/npm-packages/verify-packed-tarballs.mts
@@ -1,36 +1,19 @@
 #!/usr/bin/env node
 
 /**
- * Verifies that the tarballs `changeset pack` produced are the tarballs we would
- * want published.
+ * Checks that the tarballs `changeset pack` produced contain the files their
+ * entry points target, and declare no `workspace:` dependency ranges.
  *
- * `changeset pack` runs the workspace's pack tool - `yarn pack` here - once per
- * package the publish plan covers, so it fails on anything that would stop
- * `changeset publish` from getting a tarball onto the registry. What it does not
- * check is whether the tarball it produced has anything useful in it: `files` in
- * every package.json selects only the dist directories, and packing a tree that
- * was never built matches none of them, which yarn reports as success. The result
- * is a tarball holding only the manifest, LICENSE and README - a publish that
- * "succeeds" and ships a package that cannot be imported.
+ * Packing a tree that was never built matches none of the dist directories that
+ * `files` selects, which yarn reports as success, so a passing `changeset pack`
+ * is not by itself evidence that a release would ship anything importable.
+ * Everything is read back out of the tarball, so what is checked is what a
+ * consumer would install.
  *
- * So each tarball is checked to contain the entry points its own packed manifest
- * declares. main, module and types cover dist-cjs, dist-es and dist-types
- * respectively, which is every build output a release produces, so a tarball that
- * has all three is not an unbuilt one. The manifest is read back out of the
- * tarball rather than from the workspace, so what is verified is what a consumer
- * would install.
- *
- * The packed dependency ranges are checked for the same reason. Internal
- * dependencies are declared as `workspace:^`, a protocol only the pack tool
- * resolves; one that reached the registry unresolved would be unresolvable to
- * everyone installing the package.
- *
- * The `browser`, `react-native` and `exports` maps are deliberately left alone.
- * They are condition tables over the same three directories, some of their paths
- * are extensionless, and their contents are already validated at build time by
- * scripts/validation (submodules-linter, esm-compat); re-resolving them here would
- * add Node resolution semantics to this script for no coverage it does not
- * already have.
+ * The `browser`, `react-native` and `exports` maps are left alone: they are
+ * condition tables over the same directories main, module and types cover, and
+ * are already validated at build time by scripts/validation (submodules-linter,
+ * esm-compat).
  *
  * Runs directly via Node type stripping (Node >= 24, no build step).
  *
@@ -63,8 +46,7 @@ interface PackedPlan {
 /**
  * Manifest fields pointing at a single built file, paired with the directory each
  * one proves made it into the tarball. Every publishable package declares all
- * three; a manifest missing one is reported rather than skipped, since that is
- * itself a packaging problem.
+ * three, so a manifest missing one is reported rather than skipped.
  */
 const REQUIRED_ENTRY_POINTS = [
   { field: "main", proves: "dist-cjs" },
@@ -91,7 +73,7 @@ const releases = plan.flat().filter((release) => release.kind === "publish");
 
 if (releases.length === 0) {
   // A release PR always has packages to publish, so an empty plan means the pack
-  // ran against the wrong tree - not that there is nothing to verify.
+  // ran against the wrong tree.
   fail(`${planPath} covers no packages to publish.`);
 }
 
@@ -143,16 +125,14 @@ for (const release of releases) {
     continue;
   }
 
-  // The version is what the tag and the registry entry are keyed on, so a
-  // mismatch here means the plan and the tarball disagree about what is released.
+  // A mismatch means the plan and the tarball disagree about what is released.
   if (manifest.version !== release.version) {
     errors.push(`${label}: the packed manifest declares version ${String(manifest.version)}.`);
   }
 
-  // Every internal dependency in this repository is declared as `workspace:^`,
-  // which only the pack tool resolves to a real range. One left unresolved in a
-  // published manifest is unresolvable to anyone installing it, so it is worth
-  // confirming the rewrite happened rather than assuming it.
+  // Internal dependencies are declared as `workspace:^`, which only the pack tool
+  // resolves to a real range. One left unresolved is unresolvable to anyone
+  // installing the package.
   for (const field of DEPENDENCY_FIELDS) {
     const deps = manifest[field];
     if (typeof deps !== "object" || deps === null) {

--- a/scripts/npm-packages/verify-packed-tarballs.mts
+++ b/scripts/npm-packages/verify-packed-tarballs.mts
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that the tarballs `changeset pack` produced are the tarballs we would
+ * want published.
+ *
+ * `changeset pack` runs the workspace's pack tool - `yarn pack` here - once per
+ * package the publish plan covers, so it fails on anything that would stop
+ * `changeset publish` from getting a tarball onto the registry. What it does not
+ * check is whether the tarball it produced has anything useful in it: `files` in
+ * every package.json selects only the dist directories, and packing a tree that
+ * was never built matches none of them, which yarn reports as success. The result
+ * is a tarball holding only the manifest, LICENSE and README - a publish that
+ * "succeeds" and ships a package that cannot be imported.
+ *
+ * So each tarball is checked to contain the entry points its own packed manifest
+ * declares. main, module and types cover dist-cjs, dist-es and dist-types
+ * respectively, which is every build output a release produces, so a tarball that
+ * has all three is not an unbuilt one. The manifest is read back out of the
+ * tarball rather than from the workspace, so what is verified is what a consumer
+ * would install.
+ *
+ * The packed dependency ranges are checked for the same reason. Internal
+ * dependencies are declared as `workspace:^`, a protocol only the pack tool
+ * resolves; one that reached the registry unresolved would be unresolvable to
+ * everyone installing the package.
+ *
+ * The `browser`, `react-native` and `exports` maps are deliberately left alone.
+ * They are condition tables over the same three directories, some of their paths
+ * are extensionless, and their contents are already validated at build time by
+ * scripts/validation (submodules-linter, esm-compat); re-resolving them here would
+ * add Node resolution semantics to this script for no coverage it does not
+ * already have.
+ *
+ * Runs directly via Node type stripping (Node >= 24, no build step).
+ *
+ * Usage:
+ *   node verify-packed-tarballs.mts <packDir>
+ *
+ * where <packDir> is the --out-dir given to `changeset pack`.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { fail } from "./shared.mts";
+
+/** The shape `changeset pack` writes; only the fields used here are described. */
+interface PackedRelease {
+  kind: "publish" | "tag-only";
+  name: string;
+  version: string;
+  /** Present on publish releases once packed, relative to the pack directory. */
+  tarball?: { path: string; integrity: string };
+}
+
+interface PackedPlan {
+  version: number;
+  plan: PackedRelease[][];
+}
+
+/**
+ * Manifest fields pointing at a single built file, paired with the directory each
+ * one proves made it into the tarball. Every publishable package declares all
+ * three; a manifest missing one is reported rather than skipped, since that is
+ * itself a packaging problem.
+ */
+const REQUIRED_ENTRY_POINTS = [
+  { field: "main", proves: "dist-cjs" },
+  { field: "module", proves: "dist-es" },
+  { field: "types", proves: "dist-types" },
+] as const;
+
+/** Manifest fields whose ranges an installing consumer has to be able to resolve. */
+const DEPENDENCY_FIELDS = ["dependencies", "peerDependencies", "optionalDependencies"] as const;
+
+const packDirArg = process.argv[2];
+if (!packDirArg || process.argv.length > 3) {
+  fail("Usage: node verify-packed-tarballs.mts <packDir>");
+}
+
+const packDir = path.resolve(packDirArg);
+const planPath = path.join(packDir, "publish-plan.json");
+if (!fs.existsSync(planPath)) {
+  fail(`No publish plan at ${planPath}. Run \`changeset pack --out-dir ${packDirArg}\` first.`);
+}
+
+const { plan } = JSON.parse(fs.readFileSync(planPath, "utf-8")) as PackedPlan;
+const releases = plan.flat().filter((release) => release.kind === "publish");
+
+if (releases.length === 0) {
+  // A release PR always has packages to publish, so an empty plan means the pack
+  // ran against the wrong tree - not that there is nothing to verify.
+  fail(`${planPath} covers no packages to publish.`);
+}
+
+/** Paths inside a tarball, with npm's leading "package/" component removed. */
+function listTarballContents(tarballPath: string): Set<string> {
+  const stdout = execFileSync("tar", ["-tzf", tarballPath], { encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 });
+  return new Set(
+    stdout
+      .split("\n")
+      .filter(Boolean)
+      .map((entry) => entry.replace(/^\.?\/?package\//, "").replace(/\/$/, ""))
+  );
+}
+
+/** The packed manifest, which is what an installing consumer actually reads. */
+function readPackedManifest(tarballPath: string): Record<string, unknown> {
+  const stdout = execFileSync("tar", ["-xzOf", tarballPath, "package/package.json"], {
+    encoding: "utf-8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+const errors: string[] = [];
+const verified: string[] = [];
+
+for (const release of releases) {
+  const label = `${release.name}@${release.version}`;
+  const errorsBefore = errors.length;
+
+  if (!release.tarball) {
+    errors.push(`${label}: the publish plan has no tarball for it, so \`changeset pack\` did not pack it.`);
+    continue;
+  }
+
+  const tarballPath = path.join(packDir, release.tarball.path);
+  if (!fs.existsSync(tarballPath)) {
+    errors.push(`${label}: the publish plan points at ${release.tarball.path}, which does not exist.`);
+    continue;
+  }
+
+  let contents: Set<string>;
+  let manifest: Record<string, unknown>;
+  try {
+    contents = listTarballContents(tarballPath);
+    manifest = readPackedManifest(tarballPath);
+  } catch (error) {
+    errors.push(`${label}: could not read ${release.tarball.path}: ${(error as Error).message}`);
+    continue;
+  }
+
+  // The version is what the tag and the registry entry are keyed on, so a
+  // mismatch here means the plan and the tarball disagree about what is released.
+  if (manifest.version !== release.version) {
+    errors.push(`${label}: the packed manifest declares version ${String(manifest.version)}.`);
+  }
+
+  // Every internal dependency in this repository is declared as `workspace:^`,
+  // which only the pack tool resolves to a real range. One left unresolved in a
+  // published manifest is unresolvable to anyone installing it, so it is worth
+  // confirming the rewrite happened rather than assuming it.
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = manifest[field];
+    if (typeof deps !== "object" || deps === null) {
+      continue;
+    }
+    for (const [dependency, range] of Object.entries(deps as Record<string, unknown>)) {
+      if (typeof range === "string" && range.startsWith("workspace:")) {
+        errors.push(`${label}: "${field}"."${dependency}" is still ${range} in the packed manifest.`);
+      }
+    }
+  }
+
+  for (const { field, proves } of REQUIRED_ENTRY_POINTS) {
+    const declared = manifest[field];
+    if (typeof declared !== "string") {
+      errors.push(`${label}: the packed manifest declares no "${field}", so its ${proves} output is unverifiable.`);
+      continue;
+    }
+    const entry = declared.replace(/^\.\//, "");
+    if (!contents.has(entry)) {
+      errors.push(`${label}: "${field}" is ${declared} but ${entry} is not in ${release.tarball.path}.`);
+    }
+  }
+
+  if (errors.length === errorsBefore) {
+    verified.push(label);
+  }
+}
+
+if (errors.length) {
+  fail(
+    `${errors.length} problem(s) with the packed tarballs in ${packDir}. A release from this commit would publish ` +
+      `packages that consumers cannot use:\n  ${errors.join("\n  ")}`
+  );
+}
+
+console.log(
+  `✅ All ${verified.length} packed tarball(s) carry the entry points their manifests declare, at the version the ` +
+    `plan releases, with every dependency range resolved:\n  ` +
+    verified.join("\n  ")
+);


### PR DESCRIPTION
_Issue #, if available:_

Refs: https://github.com/smithy-lang/smithy-typescript/issues/2235#issuecomment-5303676664

_Description of changes:_

A release publishes 60+ packages from one merge, so a packaging problem that only surfaces at publish time leaves some on the registry and the rest not, as in #2222. Changesets has no `publish --dry-run` (changesets/changesets#614), so use v3's `publish-plan` and `pack`, which resolve the same plan and run the same per-package pack without uploading, plus a check that each tarball is not a manifest-only one.

Provenance and trusted publishing are not covered: both need an actual upload from a workflow holding id-token: write on a push to main.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
