### PR TITLE
ci: skip the ci workflow on the release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,15 @@ on:
 permissions:
   contents: read
 
+# Every job is guarded with `if: github.head_ref != 'changeset-release/main'` so
+# that none of them run on the release PR, which only bumps versions and writes
+# changelogs; release-dry-run.yml installs, builds and packs that tree already.
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     name: Java ${{ matrix.java }} ${{ matrix.os }}
+    if: github.head_ref != 'changeset-release/main'
     strategy:
       matrix:
         java: [17]
@@ -41,6 +46,7 @@ jobs:
   protocol-tests:
     runs-on: ${{ matrix.os }}
     name: Protocol Tests
+    if: github.head_ref != 'changeset-release/main'
     strategy:
       matrix:
         java: [17]
@@ -78,6 +84,7 @@ jobs:
   lint-typescript:
     runs-on: ubuntu-latest
     name: TypeScript Lint
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -93,6 +100,7 @@ jobs:
     runs-on: smithy-typescript_ubuntu-latest_8-core
     name: TypeScript Test ${{ matrix.node }}
     needs: ["ensure-typescript-packages-have-changesets", "lint-typescript", "ensure-typescript-formatted"]
+    if: github.head_ref != 'changeset-release/main'
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +137,7 @@ jobs:
   extract-docs:
     runs-on: smithy-typescript_ubuntu-latest_8-core
     name: Extract Docs
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -147,6 +156,7 @@ jobs:
   ensure-typescript-formatted:
     runs-on: ubuntu-latest
     name: Ensure TypeScript is formatted
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -167,6 +177,7 @@ jobs:
   ensure-typescript-packages-have-changesets:
     runs-on: ubuntu-latest
     name: Ensure TypeScript packages have changesets
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # Include full git history needed for `yarn changeset status`
@@ -180,7 +191,4 @@ jobs:
       - name: Install
         run: yarn
       - name: Ensure changesets exist for each changed package
-        # Skip on the release PR opened by the changesets action, where
-        # changesets have already been consumed by `changeset version`.
-        if: github.head_ref != 'changeset-release/main'
         run: yarn changeset status --since=origin/main

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -65,9 +65,13 @@ jobs:
     env:
       RELEASE_BRANCH: changeset-release/main
       # Workflows that must leave the approval queue before this job is done. They
-      # all trigger on `pull_request` to main with no path filters, so they always
-      # run on the release PR; keep this list in step with them. Other pending runs
-      # are still approved, just not waited for.
+      # all trigger on `pull_request` to main with no path filters, so a run is
+      # always created for the release PR; keep this list in step with them. Other
+      # pending runs are still approved, just not waited for.
+      #
+      # ci is listed even though all its jobs skip on the release PR: the run is
+      # queued for approval before those conditions are evaluated, so it would
+      # otherwise sit pending forever. Waiting is what guarantees it was approved.
       EXPECTED_WORKFLOWS: ci npm-package-existence release-dry-run
     steps:
       - name: Approve workflow runs awaiting approval


### PR DESCRIPTION
_Issue #, if available:_

N/A

_Description of changes:_

The changesets release PR only bumps versions, rewrites the inter-package dependency ranges to match, writes changelogs and deletes the consumed changesets. It touches no Java or TypeScript source, and `release-dry-run.yml` already installs, builds and packs that exact tree.

Guard every job rather than the trigger, since a pull_request event's branch filters match the base branch and there is no workflow-level if. This makes the step-level guard on the changeset status check redundant, so it moves up to the job.

The run is still created and still queued for approval before any of these conditions are evaluated, so ci stays in EXPECTED_WORKFLOWS in create-release-pr.yml, which is what approves it. It now completes as skipped rather than running the Java matrix, five Node test legs, protocol tests and docs extraction.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
