### PR TITLE
fix(core/cbor): handle exponent notation when serializing NumericValue containers

### DIFF
--- a/.changeset/fuzzy-dragons-fix.md
+++ b/.changeset/fuzzy-dragons-fix.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+fix: handle exponent notation when serializing NumericValue wrappers

--- a/packages/core/src/submodules/cbor/cbor-decode.ts
+++ b/packages/core/src/submodules/cbor/cbor-decode.ts
@@ -377,25 +377,41 @@ function decodeTagValue(
     return minor === 3 ? -b - BigInt(1) : b;
   } else if (minor === 4) {
     const decimalFraction = decode(at + offset, to);
-    const [exponent, mantissa] = decimalFraction;
+    const [rawExponent, mantissa] = decimalFraction;
     const normalizer = mantissa < 0 ? -1 : 1;
-    const mantissaStr = "0".repeat(Math.abs(exponent) + 1) + String(BigInt(normalizer) * BigInt(mantissa));
-
-    let numericString: string;
+    const absMantissa = BigInt(normalizer) * BigInt(mantissa);
+    const mantissaDigits = String(absMantissa);
     const sign = mantissa < 0 ? "-" : "";
 
-    numericString =
-      exponent === 0
-        ? mantissaStr
-        : mantissaStr.slice(0, mantissaStr.length + exponent) + "." + mantissaStr.slice(exponent);
-    numericString = numericString.replace(/^0+/g, "");
-    if (numericString === "") {
-      numericString = "0";
+    let numericString: string;
+
+    const isSmallExponent = typeof rawExponent === "number" && Math.abs(rawExponent) <= 2 ** 28;
+    if (isSmallExponent) {
+      const exponent = rawExponent as number;
+      const mantissaStr = "0".repeat(Math.abs(exponent) + 1) + mantissaDigits;
+
+      numericString =
+        exponent === 0
+          ? mantissaStr
+          : mantissaStr.slice(0, mantissaStr.length + exponent) + "." + mantissaStr.slice(exponent);
+      numericString = numericString.replace(/^0+/g, "");
+      if (numericString === "") {
+        numericString = "0";
+      }
+      if (numericString[0] === ".") {
+        numericString = "0" + numericString;
+      }
+      numericString = sign + numericString;
+    } else {
+      // Exponent too large to expand into a decimal string; emit scientific notation.
+      const bigExponent = BigInt(rawExponent);
+      if (mantissaDigits.length === 1) {
+        numericString = sign + mantissaDigits + "e" + String(bigExponent);
+      } else {
+        const adjustedExp = bigExponent + BigInt(mantissaDigits.length - 1);
+        numericString = sign + mantissaDigits[0] + "." + mantissaDigits.slice(1) + "e" + String(adjustedExp);
+      }
     }
-    if (numericString[0] === ".") {
-      numericString = "0" + numericString;
-    }
-    numericString = sign + numericString;
 
     // the new offset is the sum of:
     // 1. the local major offset (1)

--- a/packages/core/src/submodules/cbor/cbor-encode.ts
+++ b/packages/core/src/submodules/cbor/cbor-encode.ts
@@ -179,14 +179,24 @@ export function encode(_input: any): void {
       continue;
     } else if (typeof input === "object") {
       if (input instanceof NumericValue) {
-        const decimalIndex = input.string.indexOf(".");
-        const exponent = decimalIndex === -1 ? 0 : decimalIndex - input.string.length + 1;
-        const mantissa = BigInt(input.string.replace(".", ""));
+        let str = input.string;
+        let expOffset = BigInt(0);
+
+        const eIndex = str.search(/[eE]/);
+        if (eIndex !== -1) {
+          expOffset = BigInt(str.slice(eIndex + 1));
+          str = str.slice(0, eIndex);
+        }
+
+        const decimalIndex = str.indexOf(".");
+        const fractionDigits = decimalIndex === -1 ? 0 : str.length - decimalIndex - 1;
+        const exponent = expOffset - BigInt(fractionDigits);
+        const mantissa = BigInt(str.replace(".", ""));
 
         data[cursor++] = 0b110_00100; // major 6, tag 4.
         encodeInteger(majorList, 2);
         encodeStack.push(mantissa);
-        encodeStack.push(exponent);
+        encodeStack.push(exponent >= -0x20000000000000n && exponent <= 0x1fffffffffffffn ? Number(exponent) : exponent);
         continue;
       }
       if (input[tagSymbol]) {

--- a/packages/core/src/submodules/cbor/cbor.spec.ts
+++ b/packages/core/src/submodules/cbor/cbor.spec.ts
@@ -322,6 +322,52 @@ describe("cbor", () => {
       ]);
     });
 
+    it("should round-trip NumericValue with exponent notation", () => {
+      for (const bigDecimal of ["1.5e10", "3E-20", "-2.0e+5", "100E3", "1e2", ".5e3"]) {
+        const numericValue = new NumericValue(bigDecimal, "bigDecimal");
+        const serialized = cbor.serialize(numericValue);
+
+        const major = serialized[0] >> 5;
+        expect(major).toEqual(0b110); // 6
+
+        const tag = serialized[0] & 0b11111;
+        expect(tag).toEqual(0b0100); // 4
+
+        const deserialized = cbor.deserialize(serialized);
+        expect(deserialized).toBeInstanceOf(NumericValue);
+      }
+    });
+
+    it("should round-trip NumericValue with exponent exceeding safe integer range", () => {
+      for (const bigDecimal of ["1e99999999999999999999", "-1e99999999999999999999"]) {
+        const numericValue = new NumericValue(bigDecimal, "bigDecimal");
+        const serialized = cbor.serialize(numericValue);
+
+        const major = serialized[0] >> 5;
+        expect(major).toEqual(0b110); // 6
+
+        const tag = serialized[0] & 0b11111;
+        expect(tag).toEqual(0b0100); // 4
+
+        const deserialized = cbor.deserialize(serialized);
+        expect(deserialized).toBeInstanceOf(NumericValue);
+        // Verify the exponent is preserved exactly (not lossy via Number coercion)
+        expect(deserialized.string).toContain("99999999999999999999");
+      }
+    });
+
+    it("should round-trip NumericValue with exponent exceeding string expansion limit", () => {
+      // Exponents larger than 2^28 cannot be expanded via "0".repeat() without
+      // throwing a RangeError. Verify they fall through to scientific notation.
+      for (const bigDecimal of ["1e300000000", "-5e300000000"]) {
+        const numericValue = new NumericValue(bigDecimal, "bigDecimal");
+        const serialized = cbor.serialize(numericValue);
+        const deserialized = cbor.deserialize(serialized);
+        expect(deserialized).toBeInstanceOf(NumericValue);
+        expect(deserialized.string).toContain("300000000");
+      }
+    });
+
     it("should round-trip sequences of big numbers", () => {
       const sequence = {
         map: {

--- a/packages/core/src/submodules/cbor/codec-v2/CborShapeDeserializer2.ts
+++ b/packages/core/src/submodules/cbor/codec-v2/CborShapeDeserializer2.ts
@@ -220,26 +220,42 @@ function readTag(ns: NormalizedSchema): any {
 
   if (tagNumber === 4) {
     const docSchema = NormalizedSchema.of(15 satisfies DocumentSchema);
-    const pair = readValue(docSchema) as [number, number | bigint];
-    const [exponent, mantissa] = pair;
+    const pair = readValue(docSchema) as [number | bigint, number | bigint];
+    const [rawExponent, mantissa] = pair;
     const normalizer = mantissa < 0 ? -1 : 1;
-    const mantissaStr = "0".repeat(Math.abs(exponent) + 1) + String(BigInt(normalizer) * BigInt(mantissa));
-
-    let numericString: string;
+    const absMantissa = BigInt(normalizer) * BigInt(mantissa);
+    const mantissaDigits = String(absMantissa);
     const sign = mantissa < 0 ? "-" : "";
 
-    numericString =
-      exponent === 0
-        ? mantissaStr
-        : mantissaStr.slice(0, mantissaStr.length + exponent) + "." + mantissaStr.slice(exponent);
-    numericString = numericString.replace(/^0+/g, "");
-    if (numericString === "") {
-      numericString = "0";
+    let numericString: string;
+
+    const isSmallExponent = typeof rawExponent === "number" && Math.abs(rawExponent) <= 2 ** 28;
+    if (isSmallExponent) {
+      const exponent = rawExponent as number;
+      const mantissaStr = "0".repeat(Math.abs(exponent) + 1) + mantissaDigits;
+
+      numericString =
+        exponent === 0
+          ? mantissaStr
+          : mantissaStr.slice(0, mantissaStr.length + exponent) + "." + mantissaStr.slice(exponent);
+      numericString = numericString.replace(/^0+/g, "");
+      if (numericString === "") {
+        numericString = "0";
+      }
+      if (numericString[0] === ".") {
+        numericString = "0" + numericString;
+      }
+      numericString = sign + numericString;
+    } else {
+      // Exponent too large to expand into a decimal string; emit scientific notation.
+      const bigExponent = BigInt(rawExponent);
+      if (mantissaDigits.length === 1) {
+        numericString = sign + mantissaDigits + "e" + String(bigExponent);
+      } else {
+        const adjustedExp = bigExponent + BigInt(mantissaDigits.length - 1);
+        numericString = sign + mantissaDigits[0] + "." + mantissaDigits.slice(1) + "e" + String(adjustedExp);
+      }
     }
-    if (numericString[0] === ".") {
-      numericString = "0" + numericString;
-    }
-    numericString = sign + numericString;
 
     return nv(numericString);
   }

--- a/packages/core/src/submodules/cbor/codec-v2/CborShapeSerializer2.ts
+++ b/packages/core/src/submodules/cbor/codec-v2/CborShapeSerializer2.ts
@@ -701,16 +701,30 @@ function writeTag(tagValue: number | bigint, innerValue: unknown): void {
 }
 
 function writeNumericValue(nv: NumericValue): void {
-  const decimalIndex = nv.string.indexOf(".");
-  const exponent = decimalIndex === -1 ? 0 : decimalIndex - nv.string.length + 1;
-  const mantissa = BigInt(nv.string.replace(".", ""));
+  let str = nv.string;
+  let expOffset = BigInt(0);
+
+  const eIndex = str.search(/[eE]/);
+  if (eIndex !== -1) {
+    expOffset = BigInt(str.slice(eIndex + 1));
+    str = str.slice(0, eIndex);
+  }
+
+  const decimalIndex = str.indexOf(".");
+  const fractionDigits = decimalIndex === -1 ? 0 : str.length - decimalIndex - 1;
+  const exponent = expOffset - BigInt(fractionDigits);
+  const mantissa = BigInt(str.replace(".", ""));
 
   ensure(9);
   buf[cursor++] = 0b110_00100; // major 6, tag 4
   encodeHeader(majorList, 2);
 
   ensure(9);
-  writeInteger(exponent);
+  if (exponent >= -0x20000000000000n && exponent <= 0x1fffffffffffffn) {
+    writeInteger(Number(exponent));
+  } else {
+    writeBigInt(exponent);
+  }
   writeBigInt(mantissa);
 }
 

--- a/packages/core/src/submodules/cbor/codec-v2/SinglePassCbor.spec.ts
+++ b/packages/core/src/submodules/cbor/codec-v2/SinglePassCbor.spec.ts
@@ -188,6 +188,90 @@ describe("CborShapeSerializer2", () => {
       expect(cbor.deserialize(singleBytes)).toEqual(cbor.deserialize(multiBytes));
     });
 
+    it("serializes NumericValue with exponent notation", () => {
+      const schema = [
+        3,
+        "ns",
+        "Measurement",
+        0,
+        ["value"],
+        [19 satisfies BigDecimalSchema],
+      ] satisfies StaticStructureSchema;
+
+      const cases = ["1.5e10", "3E-20", "-2.0e+5", "100E3", "1e2", ".5e3"];
+      for (const str of cases) {
+        const data = { value: nv(str) };
+
+        multiPass.write(schema, data);
+        const multiBytes = multiPass.flush();
+
+        singlePass.write(schema, data);
+        const singleBytes = singlePass.flush();
+
+        const multiResult = cbor.deserialize(multiBytes);
+        const singleResult = cbor.deserialize(singleBytes);
+        expect(singleResult).toEqual(multiResult);
+        expect(singleResult.value.string).toEqual(multiResult.value.string);
+      }
+    });
+
+    it("serializes NumericValue with exponent exceeding safe integer range", () => {
+      const schema = [
+        3,
+        "ns",
+        "Measurement",
+        0,
+        ["value"],
+        [19 satisfies BigDecimalSchema],
+      ] satisfies StaticStructureSchema;
+
+      const cases = ["1e99999999999999999999", "-1e99999999999999999999"];
+      for (const str of cases) {
+        const data = { value: nv(str) };
+
+        multiPass.write(schema, data);
+        const multiBytes = multiPass.flush();
+
+        singlePass.write(schema, data);
+        const singleBytes = singlePass.flush();
+
+        const multiResult = cbor.deserialize(multiBytes);
+        const singleResult = cbor.deserialize(singleBytes);
+        expect(singleResult).toEqual(multiResult);
+        // Verify the exponent is preserved exactly (not lossy via Number coercion)
+        expect(singleResult.value.string).toContain("99999999999999999999");
+      }
+    });
+
+    it("serializes NumericValue with exponent exceeding string expansion limit", () => {
+      const schema = [
+        3,
+        "ns",
+        "Measurement",
+        0,
+        ["value"],
+        [19 satisfies BigDecimalSchema],
+      ] satisfies StaticStructureSchema;
+
+      // Exponents larger than 2^28 cannot be expanded via "0".repeat() without
+      // throwing a RangeError. Verify they fall through to scientific notation.
+      const cases = ["1e300000000", "-5e300000000"];
+      for (const str of cases) {
+        const data = { value: nv(str) };
+
+        multiPass.write(schema, data);
+        const multiBytes = multiPass.flush();
+
+        singlePass.write(schema, data);
+        const singleBytes = singlePass.flush();
+
+        const multiResult = cbor.deserialize(multiBytes);
+        const singleResult = cbor.deserialize(singleBytes);
+        expect(singleResult).toEqual(multiResult);
+        expect(singleResult.value.string).toContain("300000000");
+      }
+    });
+
     it("serializes unions with $unknown", () => {
       const unionSchema = [4, "ns", "Union", 0, ["a", "b"], [0, 0]] satisfies StaticUnionSchema;
       const data = { $unknown: ["c", "hello"] };
@@ -389,6 +473,65 @@ describe("CborShapeDeserializer2", () => {
       const data = { price: nv("0.99") };
       const result = assertEquivalentDeserialization(schema, data);
       expect(result).toEqual(data);
+    });
+
+    it("deserializes NumericValue with exponent notation", () => {
+      const schema = [
+        3,
+        "ns",
+        "Measurement",
+        0,
+        ["value"],
+        [19 satisfies BigDecimalSchema],
+      ] satisfies StaticStructureSchema;
+
+      const cases = ["1.5e10", "3E-20", "-2.0e+5", "100E3", "1e2", ".5e3"];
+      for (const str of cases) {
+        const data = { value: nv(str) };
+        const result = assertEquivalentDeserialization(schema, data);
+        expect(result.value).toBeInstanceOf(Object);
+        expect(result.value.string).toBeDefined();
+      }
+    });
+
+    it("deserializes NumericValue with exponent exceeding safe integer range", () => {
+      const schema = [
+        3,
+        "ns",
+        "Measurement",
+        0,
+        ["value"],
+        [19 satisfies BigDecimalSchema],
+      ] satisfies StaticStructureSchema;
+
+      const cases = ["1e99999999999999999999", "-1e99999999999999999999", "1e-99999999999999999999"];
+      for (const str of cases) {
+        const data = { value: nv(str) };
+        const result = assertEquivalentDeserialization(schema, data);
+        expect(result.value).toBeInstanceOf(Object);
+        expect(result.value.string).toContain("99999999999999999999");
+      }
+    });
+
+    it("deserializes NumericValue with exponent exceeding string expansion limit", () => {
+      const schema = [
+        3,
+        "ns",
+        "Measurement",
+        0,
+        ["value"],
+        [19 satisfies BigDecimalSchema],
+      ] satisfies StaticStructureSchema;
+
+      // Exponents larger than 2^28 cannot be expanded via "0".repeat() without
+      // throwing a RangeError. Verify they fall through to scientific notation.
+      const cases = ["1e300000000", "-5e300000000", "1e-300000000"];
+      for (const str of cases) {
+        const data = { value: nv(str) };
+        const result = assertEquivalentDeserialization(schema, data);
+        expect(result.value).toBeInstanceOf(Object);
+        expect(result.value.string).toContain("300000000");
+      }
     });
 
     it("deserializes unknown union members to $unknown", () => {


### PR DESCRIPTION
fixes CBOR serialization to handle when the NumericValue string container has a value like `1.23E100` (exponential). 

It also fixes precision handling when the exponent is itself a bigInteger (for excessively large numbers).