### PR TITLE
chore: bump smithyVersion to 1.73.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-smithyVersion=1.72.1
+smithyVersion=1.73.0
 smithyGradleVersion=1.3.0
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=build/jreleaser/marker.txt


### PR DESCRIPTION
Bumps smithyCli version to [1.73.0](https://github.com/smithy-lang/smithy/releases/tag/1.73.0)
