### PR TITLE
feat(fetch-http-handler): add option to pass custom fetch function

### DIFF
--- a/.changeset/nine-buttons-sniff.md
+++ b/.changeset/nine-buttons-sniff.md
@@ -1,0 +1,6 @@
+---
+"@smithy/fetch-http-handler": minor
+"@smithy/types": minor
+---
+
+Allow passing custom fetch function to fetch-http-handler

--- a/packages/fetch-http-handler/src/fetch-http-handler.browser.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.browser.spec.ts
@@ -90,6 +90,26 @@ vi.spyOn(global, "fetch").mockImplementation((async () => {
       expect(requestArgs[1]!.keepalive).toEqual(true);
     });
 
+    it("uses customFetch instead of global fetch when provided", async () => {
+      const customFetch = vi.fn(async () => ({
+        headers: {
+          entries() {
+            return [];
+          },
+        },
+        async blob() {
+          return undefined;
+        },
+      })) as unknown as typeof fetch;
+      const fetchHttpHandler = new FetchHttpHandler({ customFetch });
+
+      const mockHttpRequest = getMockHttpRequest({});
+      await fetchHttpHandler.handle(mockHttpRequest);
+
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it(`builds querystring if provided`, async () => {
       const fetchHttpHandler = new FetchHttpHandler();
 

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -82,6 +82,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerOptions> {
     const requestTimeoutInMs = requestTimeout ?? this.config!.requestTimeout;
     const keepAlive = this.config!.keepAlive === true;
     const credentials = this.config!.credentials as RequestInit["credentials"];
+    const fetchFn = this.config!.customFetch ?? fetch;
 
     // if the request was already aborted, prevent doing extra work
     if (abortSignal?.aborted) {
@@ -144,7 +145,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerOptions> {
 
     const fetchRequest = createRequest(url, requestOptions);
     const raceOfPromises = [
-      fetch(fetchRequest).then((response) => {
+      fetchFn(fetchRequest).then((response) => {
         const fetchHeaders: any = response.headers;
         const transformedHeaders: HeaderBag = {};
 

--- a/packages/types/src/http/httpHandlerInitialization.ts
+++ b/packages/types/src/http/httpHandlerInitialization.ts
@@ -133,6 +133,21 @@ export interface FetchHttpHandlerOptions {
    * ```
    */
   requestInit?: (httpRequest: IHttpRequest) => RequestInit;
+
+  /**
+   * An optional custom fetch implementation to use in place of the
+   * global fetch function.
+   *
+   * @example
+   * ```js
+   * new Client({
+   *   requestHandler: {
+   *     customFetch: (request) => myFetchImplementation(request)
+   *   }
+   * });
+   * ```
+   */
+  customFetch?: typeof fetch;
 }
 
 declare global {


### PR DESCRIPTION
_Issue #1340_

_Description of changes:_

Allows passing a custom fetch function to the `FetchHttpHandler` thats used instead of the global fetch (Without needing to reimplement how the class forms the request)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
