### PR TITLE
chore(codegen): smithy-typescript-codegen 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 [Commit logs](https://github.com/smithy-lang/smithy-typescript/commits/main/smithy-typescript-codegen)
 
+## 0.53.0 (2026-08-24)
+
+### Features
+
+- Added event stream support to server-common ([#2226](https://github.com/smithy-lang/smithy-typescript/pull/2226))
+
+### Bug Fixes
+
+- Generated operation-level defaults for endpointParams ([#2218](https://github.com/smithy-lang/smithy-typescript/pull/2218))
+- Omitted staticContextParams on ClientInputEndpointParameters ([#2216](https://github.com/smithy-lang/smithy-typescript/pull/2216))
+
+### Chores
+
+- Updated smithyVersion to 1.73.0 ([#2244](https://github.com/smithy-lang/smithy-typescript/pull/2244))
+- Upgraded to TypeScript 7 ([#2220](https://github.com/smithy-lang/smithy-typescript/pull/2220))
+- Upgraded to TypeScript 6 ([#2217](https://github.com/smithy-lang/smithy-typescript/pull/2217))
+
 ## 0.52.0 (2026-08-07)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
   "sources": ["models"],
   // Add the Smithy TypeScript code generator dependency
   "maven": {
-    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.52.0"]
+    "dependencies": ["software.amazon.smithy.typescript:smithy-typescript-codegen:0.53.0"]
   },
   "plugins": {
     // Add the Smithy TypeScript client plugin
@@ -159,7 +159,7 @@ dependencies {
     smithyCli("software.amazon.smithy:smithy-cli:$smithyVersion")
 
     // Add the Smithy TypeScript code generator dependency
-    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.52.0")
+    implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.53.0")
 
     // Uncomment below to add various smithy dependencies (see full list of smithy dependencies in https://github.com/awslabs/smithy)
     // implementation("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy.typescript"
-    version = "0.52.0"
+    version = "0.53.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
Bumps the Maven version of smithy-typescript-codegen to 0.53.0.