### PR TITLE
feat(core/errors): add SDK base error classes

### DIFF
--- a/.changeset/lucky-carpets-hide.md
+++ b/.changeset/lucky-carpets-hide.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+Add custom error classes to identify and differentiate Smithy runtime errors from other errors.

--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -296,6 +296,12 @@
     "toEndpointV1": "function",
     "TreeRuleObject": "type(object)"
   },
+  "@smithy/core/errors": {
+    "errors": "object",
+    "SmithyError": "type(class)",
+    "SmithyRangeError": "type(class)",
+    "SmithyTypeError": "type(class)"
+  },
   "@smithy/core/event-streams": {
     "BinaryHeaderValue": "type(object)",
     "BooleanHeaderValue": "type(object)",

--- a/packages/core/errors.d.ts
+++ b/packages/core/errors.d.ts
@@ -1,0 +1,5 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+export * from "./dist-types/submodules/errors/index";

--- a/packages/core/errors.js
+++ b/packages/core/errors.js
@@ -1,0 +1,5 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+module.exports = require("./dist-cjs/submodules/errors/index.js");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,8 @@
     "./config.js",
     "./endpoints.d.ts",
     "./endpoints.js",
+    "./errors.d.ts",
+    "./errors.js",
     "./event-streams.d.ts",
     "./event-streams.js",
     "./protocols.d.ts",
@@ -212,6 +214,13 @@
       "node": "./dist-cjs/submodules/transport/index.js",
       "import": "./dist-es/submodules/transport/index.js",
       "require": "./dist-cjs/submodules/transport/index.js"
+    },
+    "./errors": {
+      "types": "./dist-types/submodules/errors/index.d.ts",
+      "module": "./dist-es/submodules/errors/index.js",
+      "node": "./dist-cjs/submodules/errors/index.js",
+      "import": "./dist-es/submodules/errors/index.js",
+      "require": "./dist-cjs/submodules/errors/index.js"
     }
   },
   "scripts": {

--- a/packages/core/src/submodules/errors/errors.spec.ts
+++ b/packages/core/src/submodules/errors/errors.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test as it } from "vitest";
+
+import { errors, SmithyError, SmithyRangeError, SmithyTypeError } from "./errors";
+
+// [container key, class, name, extended built-in]
+const cases = [
+  ["Error", SmithyError, "SmithyError", Error],
+  ["TypeError", SmithyTypeError, "SmithyTypeError", TypeError],
+  ["RangeError", SmithyRangeError, "SmithyRangeError", RangeError],
+] as const;
+
+describe("errors", () => {
+  describe.each(cases)("%s", (key, Class, name, builtIn) => {
+    it("has the expected name, $source, message, and prototype chain", () => {
+      const error = new Class("PANIC");
+      expect(error.name).toBe(name);
+      expect(error.$source).toBe("smithy");
+      expect(error.message).toBe("PANIC");
+      expect(error.stack).toBeDefined();
+      expect(error).toBeInstanceOf(Class);
+      expect(error).toBeInstanceOf(builtIn);
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it("is the default container entry and constructs a real instance", () => {
+      expect(errors[key]).toBe(Class);
+      expect(new errors[key]("PANIC")).toBeInstanceOf(Class);
+    });
+  });
+
+  describe("$source brand", () => {
+    // A view of the container with `readonly` stripped. `$source` is read-only
+    // in its public contract; the owning runtime sets it once, modeled here via
+    // this transform.
+    type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+    const mutableErrors = errors as Mutable<typeof errors>;
+
+    afterEach(() => {
+      // Reset to avoid cross-test leakage of the module-singleton brand.
+      mutableErrors.$source = "smithy";
+    });
+
+    it('defaults to "smithy"', () => {
+      expect(errors.$source).toBe("smithy");
+    });
+
+    it("stamps the current brand onto errors constructed after it changes", () => {
+      mutableErrors.$source = "aws-sdk";
+
+      expect(errors.$source).toBe("aws-sdk");
+      expect(new errors.Error("PANIC").$source).toBe("aws-sdk");
+      expect(new errors.TypeError("PANIC").$source).toBe("aws-sdk");
+      expect(new errors.RangeError("PANIC").$source).toBe("aws-sdk");
+    });
+  });
+
+  describe("override / injection", () => {
+    type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+    const mutableErrors = errors as Mutable<typeof errors>;
+
+    const original = errors.Error;
+
+    afterEach(() => {
+      // Reset to avoid cross-test leakage of the module-singleton container.
+      mutableErrors.Error = original;
+    });
+
+    it("emits the injected subclass while preserving the Smithy base instanceof", () => {
+      class AwsSdkError extends SmithyError {
+        public name = "AwsSdkError";
+      }
+
+      mutableErrors.Error = AwsSdkError;
+
+      const error = new errors.Error("PANIC");
+
+      // Real instance (issue #2169), not a plain object.
+      expect(error).toBeInstanceOf(AwsSdkError);
+      // instanceof of the Smithy base still holds after override.
+      expect(error).toBeInstanceOf(SmithyError);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe("AwsSdkError");
+    });
+  });
+});

--- a/packages/core/src/submodules/errors/errors.ts
+++ b/packages/core/src/submodules/errors/errors.ts
@@ -1,0 +1,54 @@
+/**
+ * A general SDK error that does not fall into a more specific category.
+ *
+ * @public
+ */
+export class SmithyError extends Error {
+  public name = "SmithyError";
+  public readonly $source: string = errors.$source;
+}
+
+/**
+ * A value had the wrong type or could not be interpreted as the expected type.
+ *
+ * @public
+ */
+export class SmithyTypeError extends TypeError {
+  public name = "SmithyTypeError";
+  public readonly $source: string = errors.$source;
+}
+
+/**
+ * A value was the correct type but fell outside its allowed range or bounds.
+ *
+ * @public
+ */
+export class SmithyRangeError extends RangeError {
+  public name = "SmithyRangeError";
+  public readonly $source: string = errors.$source;
+}
+
+/**
+ * @public
+ */
+export type ErrorConstructor<E extends Error = Error> = new (message?: string) => E;
+
+/**
+ * @public
+ */
+export interface ErrorContainer {
+  readonly $source: string;
+  readonly Error: ErrorConstructor<SmithyError>;
+  readonly TypeError: ErrorConstructor<SmithyTypeError>;
+  readonly RangeError: ErrorConstructor<SmithyRangeError>;
+}
+
+/**
+ * @public
+ */
+export const errors: ErrorContainer = {
+  $source: "smithy",
+  Error: SmithyError,
+  TypeError: SmithyTypeError,
+  RangeError: SmithyRangeError,
+};

--- a/packages/core/src/submodules/errors/index.ts
+++ b/packages/core/src/submodules/errors/index.ts
@@ -1,0 +1,1 @@
+export { errors, type SmithyError, type SmithyRangeError, type SmithyTypeError } from "./errors";

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -13,7 +13,8 @@
       "@smithy/core/retry": ["./src/submodules/retry/index.ts"],
       "@smithy/core/protocols": ["./src/submodules/protocols/index.ts"],
       "@smithy/core/schema": ["./src/submodules/schema/index.ts"],
-      "@smithy/core/serde": ["./src/submodules/serde/index.ts"]
+      "@smithy/core/serde": ["./src/submodules/serde/index.ts"],
+      "@smithy/core/errors": ["./src/submodules/errors/index.ts"]
     }
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/core/tsconfig.es.json
+++ b/packages/core/tsconfig.es.json
@@ -14,7 +14,8 @@
       "@smithy/core/schema": ["./src/submodules/schema/index.ts"],
       "@smithy/core/event-streams": ["./src/submodules/event-streams/index.ts"],
       "@smithy/core/endpoints": ["./src/submodules/endpoints/index.ts"],
-      "@smithy/core/transport": ["./src/submodules/transport/index.ts"]
+      "@smithy/core/transport": ["./src/submodules/transport/index.ts"],
+      "@smithy/core/errors": ["./src/submodules/errors/index.ts"]
     }
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/core/tsconfig.types.json
+++ b/packages/core/tsconfig.types.json
@@ -13,7 +13,8 @@
       "@smithy/core/schema": ["./src/submodules/schema/index.ts"],
       "@smithy/core/event-streams": ["./src/submodules/event-streams/index.ts"],
       "@smithy/core/endpoints": ["./src/submodules/endpoints/index.ts"],
-      "@smithy/core/transport": ["./src/submodules/transport/index.ts"]
+      "@smithy/core/transport": ["./src/submodules/transport/index.ts"],
+      "@smithy/core/errors": ["./src/submodules/errors/index.ts"]
     }
   },
   "extends": "../../tsconfig.types.json",

--- a/scripts/validation/api-snapshot.js
+++ b/scripts/validation/api-snapshot.js
@@ -73,6 +73,35 @@ const program = ts.createProgram(allDtsPaths, {
 const checker = program.getTypeChecker();
 
 /**
+ * Determine whether an export symbol is exposed as a type only because of a
+ * `type` modifier on its export/import specifier, e.g. `export { type Foo }`,
+ * `import type { Foo }`, or a fully `type`-only export/import declaration.
+ *
+ * This is distinct from the resolved symbol's flags: a `type`-only re-export of
+ * a *class* still resolves (after getAliasedSymbol) to a class symbol, whose
+ * flags carry no Interface/TypeAlias bit. Such an export contributes only a
+ * type to the public surface (the value side is erased), so it must be tracked
+ * as a type export even though the target is a class.
+ */
+function isTypeOnlyAliasExport(sym) {
+  if (!(sym.flags & ts.SymbolFlags.Alias)) return false;
+  for (const decl of sym.getDeclarations() || []) {
+    // `export { type Foo }` / `import { type Foo }` -> specifier isTypeOnly
+    if ((ts.isExportSpecifier(decl) || ts.isImportSpecifier(decl)) && decl.isTypeOnly) {
+      return true;
+    }
+    // `export type { Foo }` / `import type { Foo }` -> declaration isTypeOnly
+    if (ts.isExportSpecifier(decl) && decl.parent?.parent?.isTypeOnly) {
+      return true;
+    }
+    if (ts.isImportSpecifier(decl) && decl.parent?.parent?.parent?.isTypeOnly) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Extract type-only exports from a .d.ts entry point using the shared program.
  */
 function getTypeExports(dtsPath) {
@@ -85,12 +114,15 @@ function getTypeExports(dtsPath) {
 
   const exports = checker.getExportsOfModule(moduleSymbol);
   for (const sym of exports) {
+    const typeOnlyAlias = isTypeOnlyAliasExport(sym);
+
     let resolved = sym;
     if (resolved.flags & ts.SymbolFlags.Alias) {
       resolved = checker.getAliasedSymbol(resolved);
     }
     const flags = resolved.flags;
     const isTypeOnly =
+      typeOnlyAlias ||
       !!(flags & ts.SymbolFlags.Interface) ||
       !!(flags & ts.SymbolFlags.TypeAlias) ||
       (!!(flags & ts.SymbolFlags.Enum) && !(flags & ts.SymbolFlags.RegularEnum));
@@ -107,6 +139,11 @@ function getTypeExports(dtsPath) {
         else if (type.flags & ts.TypeFlags.Boolean) kind = "type(boolean)";
         else if (type.flags & ts.TypeFlags.Object) kind = "type(object)";
         else kind = "type(alias)";
+      } else if (flags & ts.SymbolFlags.Class) {
+        // A `type`-only re-export of a class: only the instance type is public.
+        kind = "type(class)";
+      } else if (typeOnlyAlias) {
+        kind = "type(alias)";
       } else {
         kind = "type(?)";
       }


### PR DESCRIPTION
Related to https://github.com/aws/aws-sdk-js-v3/issues/8061.

This PR adds error classes that identify themselves as being from the Smithy core, with a `$source` value of `"smithy"`. When used by the AWS SDK, the `$source` will be overridden to `"aws-sdk'`.

They are intended to replace call sites of `throw new Error()`, including TypeError and RangeError.