### PR TITLE
feat(core/pagination): add item-level paginators

### DIFF
--- a/.changeset/ready-mirrors-knock.md
+++ b/.changeset/ready-mirrors-knock.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": minor
+---
+
+Adds item-level pagination

--- a/api-snapshot/api.json
+++ b/api-snapshot/api.json
@@ -45,6 +45,7 @@
   },
   "@smithy/core": {
     "createIsIdentityExpiredFunction": "function",
+    "createItemsPaginator": "function",
     "createPaginator": "function",
     "DefaultIdentityProviderConfig": "function",
     "doesIdentityRequireRefresh": "function",

--- a/packages/core/src/core.integ.spec.ts
+++ b/packages/core/src/core.integ.spec.ts
@@ -9,7 +9,13 @@ import {
 } from "@smithy/smithy-rpcv2-cbor-schema";
 import { requireRequestsFrom } from "@smithy/util-test/src";
 import { describe, expect, test as it } from "vitest";
-import { GetNumbersCommand, XYZService, type GetNumbersCommandOutput } from "xyz-schema";
+import {
+  GetNumbersCommand,
+  type GetNumbersCommandOutput,
+  paginateGetNumbers,
+  paginateGetNumbersItems,
+  XYZService,
+} from "xyz-schema";
 
 import { NumericValue } from "./submodules/serde";
 
@@ -200,5 +206,64 @@ describe("types", () => {
   it("empty input may be instantiated without parameters", () => {
     new EmptyInputOutputCommand();
     new SimpleScalarPropertiesCommand();
+  });
+});
+
+describe("item paginators", () => {
+  const cborPage = (body: object) =>
+    new HttpResponse({
+      headers: { "smithy-protocol": "rpc-v2-cbor" },
+      statusCode: 200,
+      body: cbor.serialize(body),
+    });
+
+  it("should flatten list items across pages via paginateGetNumbersItems", async () => {
+    const xyz = new XYZService({ endpoint: "https://localhost", apiKey: async () => ({ apiKey: "test-key" }) });
+    const testHandler = requireRequestsFrom(xyz).toMatch({ hostname: /^localhost$/ });
+
+    testHandler.respondWith(
+      cborPage({ numbers: [1, 2], nextToken: "t1" } as GetNumbersCommandOutput),
+      cborPage({ numbers: [3], nextToken: "t2" } as GetNumbersCommandOutput),
+      cborPage({ numbers: [4, 5] } as GetNumbersCommandOutput)
+    );
+
+    const items: number[] = [];
+    for await (const n of paginateGetNumbersItems({ client: xyz }, {})) {
+      items.push(n);
+    }
+    expect(items).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("should skip pages whose items member is absent", async () => {
+    const xyz = new XYZService({ endpoint: "https://localhost", apiKey: async () => ({ apiKey: "test-key" }) });
+    const testHandler = requireRequestsFrom(xyz).toMatch({ hostname: /^localhost$/ });
+
+    testHandler.respondWith(
+      cborPage({ numbers: [10], nextToken: "t1" } as GetNumbersCommandOutput),
+      cborPage({ nextToken: "t2" } as GetNumbersCommandOutput),
+      cborPage({ numbers: [20] } as GetNumbersCommandOutput)
+    );
+
+    const items: number[] = [];
+    for await (const n of paginateGetNumbersItems({ client: xyz }, {})) {
+      items.push(n);
+    }
+    expect(items).toEqual([10, 20]);
+  });
+
+  it("page and item paginators yield consistent data", async () => {
+    const xyz = new XYZService({ endpoint: "https://localhost", apiKey: async () => ({ apiKey: "test-key" }) });
+    const testHandler = requireRequestsFrom(xyz).toMatch({ hostname: /^localhost$/ });
+
+    testHandler.respondWith(
+      cborPage({ numbers: [1, 2], nextToken: "t1" } as GetNumbersCommandOutput),
+      cborPage({ numbers: [3] } as GetNumbersCommandOutput)
+    );
+
+    const flatFromPages: number[] = [];
+    for await (const page of paginateGetNumbers({ client: xyz }, {})) {
+      flatFromPages.push(...(page.numbers ?? []));
+    }
+    expect(flatFromPages).toEqual([1, 2, 3]);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@ export {
   httpSigningMiddlewareOptions,
 } from "./legacy-root-exports/middleware-http-signing";
 export { normalizeProvider } from "./normalizeProvider";
-export { createPaginator } from "./legacy-root-exports/pagination/createPaginator";
+export { createItemsPaginator, createPaginator } from "./legacy-root-exports/pagination/createPaginator";
 /**
  * Backwards compatibility re-export.
  * @internal

--- a/packages/core/src/legacy-root-exports/pagination/createPaginator.spec.ts
+++ b/packages/core/src/legacy-root-exports/pagination/createPaginator.spec.ts
@@ -1,7 +1,7 @@
 import type { PaginationConfiguration } from "@smithy/types";
 import { afterEach, describe, expect, test as it, vi } from "vitest";
 
-import { createPaginator } from "./createPaginator";
+import { createItemsPaginator, createPaginator } from "./createPaginator";
 
 describe(createPaginator.name, () => {
   class Client {
@@ -338,5 +338,89 @@ describe(createPaginator.name, () => {
     expect(client.send).toHaveBeenCalledTimes(5);
     expect(config.withCommand).toHaveBeenCalledTimes(5);
     expect(config.withCommand).toHaveBeenCalledWith(expect.any(CommandObjectToken));
+  });
+});
+
+describe(createItemsPaginator.name, () => {
+  // A fake page paginator yielding the given pages, so item extraction is tested in isolation.
+  const pagesOf =
+    (...pages: any[]) =>
+    async function* () {
+      yield* pages;
+      return undefined;
+    };
+
+  const collect = async <T>(gen: AsyncGenerator<T>): Promise<T[]> => {
+    const out: T[] = [];
+    for await (const item of gen) {
+      out.push(item);
+    }
+    return out;
+  };
+
+  it("should yield each element of a list items member across pages", async () => {
+    const paginate = createItemsPaginator(pagesOf({ items: [1, 2] }, { items: [3] }, { items: [4, 5] }), "items");
+    expect(await collect(paginate({} as any, {}))).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("should resolve a nested (dotted) items path", async () => {
+    const paginate = createItemsPaginator(
+      pagesOf({ result: { items: ["a", "b"] } }, { result: { items: ["c"] } }),
+      "result.items"
+    );
+    expect(await collect(paginate({} as any, {}))).toEqual(["a", "b", "c"]);
+  });
+
+  it("should skip pages where the items member is absent or null", async () => {
+    const paginate = createItemsPaginator(pagesOf({ items: [1] }, {}, { items: null }, { items: [2] }), "items");
+    expect(await collect(paginate({} as any, {}))).toEqual([1, 2]);
+  });
+
+  it("should yield nothing for empty item lists", async () => {
+    const paginate = createItemsPaginator(pagesOf({ items: [] }, { items: [] }), "items");
+    expect(await collect(paginate({} as any, {}))).toEqual([]);
+  });
+
+  it("should yield [key, value] entries for a map items member (matches Java SDK Map.Entry)", async () => {
+    const paginate = createItemsPaginator(pagesOf({ items: { a: 1, b: 2 } }, { items: { c: 3 } }), "items");
+    expect(await collect(paginate({} as any, {}))).toEqual([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]);
+  });
+
+  it("should yield a scalar items member as a single value", async () => {
+    const paginate = createItemsPaginator(pagesOf({ items: "only" }, { items: "next" }), "items");
+    expect(await collect(paginate({} as any, {}))).toEqual(["only", "next"]);
+  });
+
+  it("should work when composed with a real createPaginator (end-to-end)", async () => {
+    class ItemsClient {
+      private pages = 3;
+      async send() {
+        if (--this.pages > 0) {
+          return { items: [this.pages, this.pages], outToken: "T" };
+        }
+        return { items: [0] };
+      }
+    }
+    class ItemsCommand {
+      public constructor(public input: any) {}
+    }
+
+    const paginatePages = createPaginator<PaginationConfiguration, { inToken?: string }, { items: number[] }>(
+      ItemsClient,
+      ItemsCommand,
+      "inToken",
+      "outToken"
+    );
+    const paginateItems = createItemsPaginator<PaginationConfiguration, { inToken?: string }, number>(
+      paginatePages,
+      "items"
+    );
+
+    const items = await collect(paginateItems({ client: new ItemsClient() as any }, {}));
+    expect(items).toEqual([2, 2, 1, 1, 0]);
   });
 });

--- a/packages/core/src/legacy-root-exports/pagination/createPaginator.spec.ts
+++ b/packages/core/src/legacy-root-exports/pagination/createPaginator.spec.ts
@@ -343,8 +343,7 @@ describe(createPaginator.name, () => {
 
 describe(createItemsPaginator.name, () => {
   // A fake page paginator yielding the given pages, so item extraction is tested in isolation.
-  const pagesOf =
-    (...pages: any[]) =>
+  const pagesOf = (...pages: any[]) =>
     async function* () {
       yield* pages;
       return undefined;

--- a/packages/core/src/legacy-root-exports/pagination/createPaginator.ts
+++ b/packages/core/src/legacy-root-exports/pagination/createPaginator.ts
@@ -68,9 +68,49 @@ export function createPaginator<
 }
 
 /**
+ * Creates an item-level paginator by wrapping a page-level paginator and
+ * yielding the elements of each page's items member instead of the pages.
+ *
+ * Delegating to the page paginator preserves token handling, pageSize,
+ * withCommand, and stopOnSameToken behavior.
+ *
  * @internal
  */
-const get = (fromObject: any, path: string): any => {
+export function createItemsPaginator<
+  PaginationConfigType extends PaginationConfiguration,
+  InputType extends object,
+  ItemType,
+>(
+  paginator: (config: PaginationConfigType, input: InputType, ...additionalArguments: any[]) => Paginator<any>,
+  itemsPath: string
+): (config: PaginationConfigType, input: InputType, ...additionalArguments: any[]) => Paginator<ItemType> {
+  return async function* paginateItems(
+    config: PaginationConfigType,
+    input: InputType,
+    ...additionalArguments: any[]
+  ): Paginator<ItemType> {
+    for await (const page of paginator(config, input, ...additionalArguments)) {
+      const items = get(page, itemsPath);
+      if (items == null) {
+        continue;
+      }
+      if (Array.isArray(items)) {
+        yield* items;
+      } else if (typeof items === "object") {
+        // Map-typed items member: yield each [key, value] entry.
+        yield* Object.entries(items) as ItemType[];
+      } else {
+        yield items;
+      }
+    }
+    return undefined;
+  };
+}
+
+/**
+ * @internal
+ */
+export const get = (fromObject: any, path: string): any => {
   let cursor = fromObject;
   const pathComponents = path.split(".");
   for (const step of pathComponents) {

--- a/private/my-local-model-schema/src/pagination/GetNumbersPaginator.ts
+++ b/private/my-local-model-schema/src/pagination/GetNumbersPaginator.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { createPaginator } from "@smithy/core";
+import { createItemsPaginator, createPaginator } from "@smithy/core";
 import type { Paginator } from "@smithy/types";
 
 import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
@@ -18,3 +18,16 @@ export const paginateGetNumbers: (
   GetNumbersCommandInput,
   GetNumbersCommandOutput
 >(XYZServiceClient, GetNumbersCommand, "startToken", "nextToken", "maxResults");
+
+/**
+ * @public
+ */
+export const paginateGetNumbersItems: (
+  config: XYZServicePaginationConfiguration,
+  input: GetNumbersCommandInput,
+  ...rest: any[]
+) => Paginator<number> = createItemsPaginator<
+  XYZServicePaginationConfiguration,
+  GetNumbersCommandInput,
+  number
+>(paginateGetNumbers, "numbers");

--- a/private/my-local-model-schema/src/pagination/camelCaseOperationPaginator.ts
+++ b/private/my-local-model-schema/src/pagination/camelCaseOperationPaginator.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { createPaginator } from "@smithy/core";
+import { createItemsPaginator, createPaginator } from "@smithy/core";
 import type { Paginator } from "@smithy/types";
 
 import {
@@ -22,3 +22,16 @@ export const paginatecamelCaseOperation: (
   CamelCaseOperationCommandInput,
   CamelCaseOperationCommandOutput
 >(XYZServiceClient, CamelCaseOperationCommand, "token", "token", "");
+
+/**
+ * @public
+ */
+export const paginatecamelCaseOperationItems: (
+  config: XYZServicePaginationConfiguration,
+  input: CamelCaseOperationCommandInput,
+  ...rest: any[]
+) => Paginator<Uint8Array> = createItemsPaginator<
+  XYZServicePaginationConfiguration,
+  CamelCaseOperationCommandInput,
+  Uint8Array
+>(paginatecamelCaseOperation, "results");

--- a/private/my-local-model/src/pagination/GetNumbersPaginator.ts
+++ b/private/my-local-model/src/pagination/GetNumbersPaginator.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { createPaginator } from "@smithy/core";
+import { createItemsPaginator, createPaginator } from "@smithy/core";
 import type { Paginator } from "@smithy/types";
 
 import { GetNumbersCommand, GetNumbersCommandInput, GetNumbersCommandOutput } from "../commands/GetNumbersCommand";
@@ -18,3 +18,16 @@ export const paginateGetNumbers: (
   GetNumbersCommandInput,
   GetNumbersCommandOutput
 >(XYZServiceClient, GetNumbersCommand, "startToken", "nextToken", "maxResults");
+
+/**
+ * @public
+ */
+export const paginateGetNumbersItems: (
+  config: XYZServicePaginationConfiguration,
+  input: GetNumbersCommandInput,
+  ...rest: any[]
+) => Paginator<number> = createItemsPaginator<
+  XYZServicePaginationConfiguration,
+  GetNumbersCommandInput,
+  number
+>(paginateGetNumbers, "numbers");

--- a/private/my-local-model/src/pagination/camelCaseOperationPaginator.ts
+++ b/private/my-local-model/src/pagination/camelCaseOperationPaginator.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { createPaginator } from "@smithy/core";
+import { createItemsPaginator, createPaginator } from "@smithy/core";
 import type { Paginator } from "@smithy/types";
 
 import {
@@ -22,3 +22,16 @@ export const paginatecamelCaseOperation: (
   CamelCaseOperationCommandInput,
   CamelCaseOperationCommandOutput
 >(XYZServiceClient, CamelCaseOperationCommand, "token", "token", "");
+
+/**
+ * @public
+ */
+export const paginatecamelCaseOperationItems: (
+  config: XYZServicePaginationConfiguration,
+  input: CamelCaseOperationCommandInput,
+  ...rest: any[]
+) => Paginator<Uint8Array> = createItemsPaginator<
+  XYZServicePaginationConfiguration,
+  CamelCaseOperationCommandInput,
+  Uint8Array
+>(paginatecamelCaseOperation, "results");

--- a/scripts/validation/export-names.js
+++ b/scripts/validation/export-names.js
@@ -27,6 +27,7 @@ const EXCEPTIONS = new Set([
 // Function names that are reused across many exports (e.g. all paginators share one factory name).
 const NAMING_EXCEPTIONS = new Set([
   "paginateOperation",
+  "paginateItems", // item paginators share the createItemsPaginator factory's inner function name
   "readableStreamToIterable", // readableStreamtoIterable (typo alias)
   "fromValue", // fromStatic is aliased from fromValue
   "Md5Node", // exported as Md5 from @smithy/md5-js, internal class name

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.typescript.codegen;
 
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -16,9 +17,12 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.PaginatedIndex;
 import software.amazon.smithy.model.knowledge.PaginationInfo;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -32,6 +36,8 @@ final class PaginationGenerator implements Runnable {
         "Interfaces.ts"
     ).toString();
 
+    private final Model model;
+    private final SymbolProvider symbolProvider;
     private final TypeScriptWriter writer;
     private final String aggregatedClientName;
     private final PaginationInfo paginatedInfo;
@@ -52,6 +58,8 @@ final class PaginationGenerator implements Runnable {
         TypeScriptWriter writer,
         String aggregatedClientName
     ) {
+        this.model = model;
+        this.symbolProvider = symbolProvider;
         this.writer = writer;
         this.aggregatedClientName = aggregatedClientName;
 
@@ -104,6 +112,7 @@ final class PaginationGenerator implements Runnable {
         );
 
         writePager();
+        writeItemsPager();
     }
 
     static String getOutputFileLocation(OperationShape operation) {
@@ -198,5 +207,73 @@ final class PaginationGenerator implements Runnable {
                 """
             )
             .popState();
+    }
+
+    /**
+     * Emits an item-level paginator (paginate{Operation}Items) when the @paginated
+     * trait declares an items member. It wraps the page paginator and yields items.
+     */
+    private void writeItemsPager() {
+        List<MemberShape> itemsPath = paginatedInfo.getItemsMemberPath();
+        if (itemsPath.isEmpty()) {
+            return;
+        }
+
+        String itemsPathString = paginatedInfo.getPaginatedTrait().getItems().get();
+        String itemType = resolveItemType(itemsPath.get(itemsPath.size() - 1));
+
+        writer.addImport("createItemsPaginator", null, TypeScriptDependency.SMITHY_CORE);
+
+        writer.writeDocs("@public");
+        writer
+            .pushState()
+            .putContext("operation", operationName)
+            .putContext("aggClient", aggregatedClientName)
+            .putContext("inputType", inputSymbol.getName())
+            .putContext("paginationType", paginationType)
+            .putContext("itemType", itemType)
+            .putContext("pagePaginator", "paginate" + operationName)
+            .putContext("itemsPath", itemsPathString)
+            .write(
+                """
+                export const paginate${operation:L}Items: (
+                  config: ${aggClient:L}PaginationConfiguration,
+                  input: ${inputType:L},
+                  ...rest: any[]
+                ) => Paginator<${itemType:L}> = createItemsPaginator<
+                  ${paginationType:L},
+                  ${inputType:L},
+                  ${itemType:L}
+                >(${pagePaginator:L}, ${itemsPath:S});
+                """
+            )
+            .popState();
+    }
+
+    /**
+     * Resolves the TypeScript item type for the paginated items member.
+     * List/set -> element type; map -> [keyType, valueType] tuple. Any other target should be a modeling error.
+     */
+    private String resolveItemType(MemberShape itemsMember) {
+        Shape target = model.expectShape(itemsMember.getTarget());
+        if (target instanceof CollectionShape) {
+            MemberShape element = ((CollectionShape) target).getMember();
+            return writer.format("$T", symbolProvider.toSymbol(element));
+        }
+        if (target instanceof MapShape) {
+            MapShape map = (MapShape) target;
+            return writer.format(
+                "[$T, $T]",
+                symbolProvider.toSymbol(map.getKey()),
+                symbolProvider.toSymbol(map.getValue())
+            );
+        }
+        throw new CodegenException(
+            String.format(
+                "Paginated items member %s of operation %s must target a list or map shape.",
+                itemsMember.getId(),
+                operationName
+            )
+        );
     }
 }


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws/aws-sdk-js-v3/issues/2328 / Internal JS-7029

_Description of changes:_
Adds item-level paginators that expose a `@paginated` operation's items member as an async iterator, so callers can iterate results directly.

_Testing_
new test cases added



If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
