### PR TITLE
fix(node-http-handler): clear the http2 session timeout

### DIFF
--- a/.changeset/quiet-timers-rest.md
+++ b/.changeset/quiet-timers-rest.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Clear the HTTP/2 session timeout before destroying a session. Node keeps a destroyed `Http2Session` reachable until its pending `setTimeout` fires, so with the default 300 s timer on isolated sessions every completed request was retained for 5 minutes.

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
@@ -10,6 +10,7 @@ const createMockSession = (destroyed = false) => {
     destroy: vi.fn(() => {
       (session as any).destroyed = true;
     }),
+    setTimeout: vi.fn(),
     destroyed,
   } as unknown as ClientHttp2Session;
   return session;
@@ -91,5 +92,17 @@ describe(ClientHttp2SessionRef.name, () => {
     const ref = new ClientHttp2SessionRef(session);
     ref.destroy();
     expect(session.destroy).not.toHaveBeenCalled();
+    expect(session.setTimeout).not.toHaveBeenCalled();
+  });
+
+  it("destroy() clears the session timeout before destroying the session", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    ref.destroy();
+    expect(session.setTimeout).toHaveBeenCalledTimes(1);
+    expect(session.setTimeout).toHaveBeenCalledWith(0);
+    expect((session.setTimeout as any).mock.invocationCallOrder[0]).toBeLessThan(
+      (session.destroy as any).mock.invocationCallOrder[0]
+    );
   });
 });

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
@@ -83,6 +83,7 @@ export class ClientHttp2SessionRef {
   public destroy(): void {
     this.refs = 0;
     if (!this.session.destroyed) {
+      this.session.setTimeout(0);
       this.session.destroy();
     }
   }

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -526,6 +526,58 @@ describe(NodeHttp2Handler.name, () => {
         expect(session?.destroyed).toBe(true);
       });
     });
+
+    describe("clears the session timer when a session is destroyed", () => {
+      // Node keeps a destroyed Http2Session reachable until a pending setTimeout fires, and
+      // Http2Session.setTimeout(0) is a no-op once the session is destroyed. Isolated sessions
+      // get a 300s default timer, so without clearing it every completed request is retained
+      // for 5 minutes. `session.timeout` is the last value set while the session was alive.
+      it.each([
+        ["object provider", async () => ({ disableConcurrentStreams: true })],
+        ["static object", { disableConcurrentStreams: true }],
+      ])(
+        "isolated session with the default timer, disableConcurrentStreams: true in constructor parameter of %s",
+        async (_, options) => {
+          let session: any;
+
+          nodeH2Handler = new NodeHttp2Handler(options);
+
+          const connectReal = http2.connect;
+          vi.spyOn(http2, "connect").mockImplementation((...args: any[]) => {
+            session = connectReal(args[0], args[1]);
+            return session;
+          });
+
+          mockH2Server.removeAllListeners("request");
+          mockH2Server.on("request", (request: any, response: any) => {
+            createResponseFunction(mockResponse)(request, response);
+          });
+          const { response } = await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+          expect(session.timeout).toBe(300_000);
+
+          const closed = new Promise((resolve) => session.once("close", resolve));
+          (response.body as ClientHttp2Stream).resume();
+          await closed;
+
+          expect(session.destroyed).toBe(true);
+          expect(session.timeout).toBe(0);
+        }
+      );
+
+      it("pooled session with a configured sessionTimeout, on handler destroy", async () => {
+        nodeH2Handler = new NodeHttp2Handler({ sessionTimeout });
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+        const session: any = getFirstSession(nodeH2Handler, authority).deref();
+        expect(session.timeout).toBe(sessionTimeout);
+
+        nodeH2Handler.destroy();
+
+        expect(session.destroyed).toBe(true);
+        expect(session.timeout).toBe(0);
+      });
+    });
   });
 
   describe("maxConcurrency", () => {


### PR DESCRIPTION
_Issue #, if available:_ #2258

_Description of changes:_

A destroyed Http2Session with a timeout attached stays in memory until the pending setTimeout fires. Since #2223 every isolated session gets a 300 s timer by default, which retained each completed request for 5 minutes. Clients that force isolated sessions, such as Kinesis, grew their heap linearly at request rate and hit the heap limit under load.

Clears the timer in ClientHttp2SessionRef.destroy() before destroying the session. Covers both the isolated-session reaper and pooled-session teardown.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
