### PR TITLE
fix(node-http-handler): clear h2 session timeout on destroy

### DIFF
--- a/.changeset/great-cobras-walk.md
+++ b/.changeset/great-cobras-walk.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+clear timeout for h2/session before destroy

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
@@ -87,7 +87,7 @@ describe(ClientHttp2SessionRef.name, () => {
     expect(session.destroy).toHaveBeenCalledTimes(1);
   });
 
-  it("destroy() clears the session timeout before destroying (prevents #2258 retention)", () => {
+  it("destroy() clears the session timeout before destroying", () => {
     const session = createMockSession();
     const ref = new ClientHttp2SessionRef(session);
     ref.destroy();

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.spec.ts
@@ -7,6 +7,7 @@ const createMockSession = (destroyed = false) => {
   const session = {
     ref: vi.fn(),
     unref: vi.fn(),
+    setTimeout: vi.fn(),
     destroy: vi.fn(() => {
       (session as any).destroyed = true;
     }),
@@ -86,10 +87,23 @@ describe(ClientHttp2SessionRef.name, () => {
     expect(session.destroy).toHaveBeenCalledTimes(1);
   });
 
+  it("destroy() clears the session timeout before destroying (prevents #2258 retention)", () => {
+    const session = createMockSession();
+    const ref = new ClientHttp2SessionRef(session);
+    ref.destroy();
+    // Node retains a session with an armed timeout until it fires, even after
+    // destroy(). Clearing the timer with setTimeout(0) lets it be collected.
+    expect(session.setTimeout).toHaveBeenCalledWith(0);
+    const clearOrder = vi.mocked(session.setTimeout).mock.invocationCallOrder[0];
+    const destroyOrder = vi.mocked(session.destroy).mock.invocationCallOrder[0];
+    expect(clearOrder).toBeLessThan(destroyOrder);
+  });
+
   it("destroy() is safe to call on already-destroyed session", () => {
     const session = createMockSession(true);
     const ref = new ClientHttp2SessionRef(session);
     ref.destroy();
     expect(session.destroy).not.toHaveBeenCalled();
+    expect(session.setTimeout).not.toHaveBeenCalled();
   });
 });

--- a/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
+++ b/packages/node-http-handler/src/http2/ClientHttp2SessionRef.ts
@@ -83,6 +83,10 @@ export class ClientHttp2SessionRef {
   public destroy(): void {
     this.refs = 0;
     if (!this.session.destroyed) {
+      // Clear any armed session timeout before destroying. In Node, a Http2Session
+      // with an active timeout is retained until that timer fires, even after
+      // destroy()
+      this.session.setTimeout(0);
       this.session.destroy();
     }
   }

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -526,6 +526,58 @@ describe(NodeHttp2Handler.name, () => {
         expect(session?.destroyed).toBe(true);
       });
     });
+
+    describe("clears the session timer when a session is destroyed", () => {
+      // Node keeps a destroyed Http2Session reachable until a pending setTimeout fires, and
+      // Http2Session.setTimeout(0) is a no-op once the session is destroyed. Isolated sessions
+      // get a 300s default timer, so without clearing it every completed request is retained
+      // for 5 minutes. `session.timeout` is the last value set while the session was alive.
+      it.each([
+        ["object provider", async () => ({ disableConcurrentStreams: true })],
+        ["static object", { disableConcurrentStreams: true }],
+      ])(
+        "isolated session with the default timer, disableConcurrentStreams: true in constructor parameter of %s",
+        async (_, options) => {
+          let session: any;
+
+          nodeH2Handler = new NodeHttp2Handler(options);
+
+          const connectReal = http2.connect;
+          vi.spyOn(http2, "connect").mockImplementation((...args: any[]) => {
+            session = connectReal(args[0], args[1]);
+            return session;
+          });
+
+          mockH2Server.removeAllListeners("request");
+          mockH2Server.on("request", (request: any, response: any) => {
+            createResponseFunction(mockResponse)(request, response);
+          });
+          const { response } = await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+          expect(session.timeout).toBe(300_000);
+
+          const closed = new Promise((resolve) => session.once("close", resolve));
+          (response.body as ClientHttp2Stream).resume();
+          await closed;
+
+          expect(session.destroyed).toBe(true);
+          expect(session.timeout).toBe(0);
+        }
+      );
+
+      it("pooled session with a configured sessionTimeout, on handler destroy", async () => {
+        nodeH2Handler = new NodeHttp2Handler({ sessionTimeout });
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+        const session: any = getFirstSession(nodeH2Handler, authority).deref();
+        expect(session.timeout).toBe(sessionTimeout);
+
+        nodeH2Handler.destroy();
+
+        expect(session.destroyed).toBe(true);
+        expect(session.timeout).toBe(0);
+      });
+    });
   });
 
   describe("maxConcurrency", () => {


### PR DESCRIPTION
_Issue #, if available:_
#2258 

_Description of changes:_
clear timeout before destroy

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
